### PR TITLE
CI: add -race test job, coverage reporting, and local coverage targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Go Tests
+  test-race:
+    name: Go Tests (race)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,6 +37,49 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: Test
-        run: go test ./... -v
+      - name: Test with -race
+        run: go test -race ./... -v
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    env:
+      COVERAGE_THRESHOLD: ${{ vars.COVERAGE_THRESHOLD || '0' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run tests with coverage
+        run: |
+          set -euo pipefail
+          go test ./... -covermode=atomic -coverprofile=coverage.out -v
+          go tool cover -func=coverage.out | tee coverage.txt
+          go tool cover -html=coverage.out -o coverage.html
+          total=$(go tool cover -func=coverage.out | grep total: | awk '{print substr($3, 1, length($3)-1)}')
+          echo "total=$total" >> $GITHUB_OUTPUT
+          thr=${COVERAGE_THRESHOLD:-0}
+          awk -v t="$total" -v thr="$thr" 'BEGIN{ if (t+0 < thr+0) { printf("coverage %.2f%% is below threshold %.2f%%\n", t, thr); exit 1 } else { printf("coverage %.2f%% meets threshold %.2f%%\n", t, thr); } }'
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            coverage.out
+            coverage.txt
+            coverage.html

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ dist/
 ._*
 Icon?
 
-
+# Coverage files
+coverage*

--- a/Justfile
+++ b/Justfile
@@ -35,5 +35,21 @@ lint:
 test:
     go test ./...
 
+test-race:
+    go test -race ./...
+
+cover:
+    set -euo pipefail
+    go test ./... -covermode=atomic -coverprofile=coverage.out -v
+    go tool cover -func=coverage.out | tee coverage.txt
+    go tool cover -html=coverage.out -o coverage.html
+    @echo "wrote coverage.out and coverage.html"
+
+cover-threshold thr="0":
+    set -euo pipefail
+    go test ./... -covermode=atomic -coverprofile=coverage.out -v
+    total=$(go tool cover -func=coverage.out | grep total: | awk '{print substr($3, 1, length($3)-1)}')
+    awk -v t="$total" -v thr="{{thr}}" 'BEGIN{ if (t+0 < thr+0) { printf("coverage %.2f%% is below threshold %.2f%%\n", t, thr); exit 1 } else { printf("coverage %.2f%% meets threshold %.2f%%\n", t, thr); } }'
+
 tidy:
     go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # If `just` is installed, Make will delegate targets to it.
 # Otherwise, Make runs the fallback recipes defined below.
 
-FALLBACK_TARGETS := dev build sqlite-build sqlite-run fmt lint test tidy
+FALLBACK_TARGETS := dev build sqlite-build sqlite-run fmt lint test test-race cover tidy
 
 .PHONY: help $(FALLBACK_TARGETS)
 
@@ -45,6 +45,16 @@ help:
 
 .fallback-test:
 	go test ./...
+
+.fallback-test-race:
+	go test -race ./...
+
+.fallback-cover:
+	set -euo pipefail; \
+	go test ./... -covermode=atomic -coverprofile=coverage.out; \
+	go tool cover -func=coverage.out | tee coverage.txt; \
+	go tool cover -html=coverage.out -o coverage.html; \
+	echo "wrote coverage.out and coverage.html"
 
 .fallback-tidy:
 	go mod tidy

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -23,28 +23,28 @@ type CreatePool struct {
 // Account represents a cloud account or project to which pools can be assigned.
 // It uses a generic shape to support AWS accounts, GCP projects, etc.
 type Account struct {
-    ID          int64     `json:"id"`
-    Key         string    `json:"key"` // unique key like "aws:123456789012" or "gcp:my-project"
-    Name        string    `json:"name"`
-    Provider    string    `json:"provider,omitempty"`
-    ExternalID  string    `json:"external_id,omitempty"`
-    Description string    `json:"description,omitempty"`
-    Platform    string    `json:"platform,omitempty"`
-    Tier        string    `json:"tier,omitempty"`
-    Environment string    `json:"environment,omitempty"`
-    Regions     []string  `json:"regions,omitempty"`
-    CreatedAt   time.Time `json:"created_at"`
+	ID          int64     `json:"id"`
+	Key         string    `json:"key"` // unique key like "aws:123456789012" or "gcp:my-project"
+	Name        string    `json:"name"`
+	Provider    string    `json:"provider,omitempty"`
+	ExternalID  string    `json:"external_id,omitempty"`
+	Description string    `json:"description,omitempty"`
+	Platform    string    `json:"platform,omitempty"`
+	Tier        string    `json:"tier,omitempty"`
+	Environment string    `json:"environment,omitempty"`
+	Regions     []string  `json:"regions,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 // CreateAccount is the input for creating an account.
 type CreateAccount struct {
-    Key         string `json:"key"`
-    Name        string `json:"name"`
-    Provider    string `json:"provider,omitempty"`
-    ExternalID  string `json:"external_id,omitempty"`
-    Description string `json:"description,omitempty"`
-    Platform    string `json:"platform,omitempty"`
-    Tier        string `json:"tier,omitempty"`
-    Environment string `json:"environment,omitempty"`
-    Regions     []string `json:"regions,omitempty"`
+	Key         string   `json:"key"`
+	Name        string   `json:"name"`
+	Provider    string   `json:"provider,omitempty"`
+	ExternalID  string   `json:"external_id,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Platform    string   `json:"platform,omitempty"`
+	Tier        string   `json:"tier,omitempty"`
+	Environment string   `json:"environment,omitempty"`
+	Regions     []string `json:"regions,omitempty"`
 }

--- a/internal/http/handlers_test.go
+++ b/internal/http/handlers_test.go
@@ -179,161 +179,269 @@ func TestAccountsHandlers_Negative(t *testing.T) {
 }
 
 func TestAccounts_Subroutes_CRUD(t *testing.T) {
-    srv, _ := setupTestServer()
-    // Create account
-    rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:999999999999","name":"Sandbox"}`, stdhttp.StatusCreated)
-    var acc struct{ ID int64 `json:"id"` }
-    if err := json.Unmarshal(rr.Body.Bytes(), &acc); err != nil { t.Fatalf("unmarshal: %v", err) }
+	srv, _ := setupTestServer()
+	// Create account
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:999999999999","name":"Sandbox"}`, stdhttp.StatusCreated)
+	var acc struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &acc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
 
-    // GET /api/v1/accounts/{id}
-    doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10), "", stdhttp.StatusOK)
+	// GET /api/v1/accounts/{id}
+	doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10), "", stdhttp.StatusOK)
 
-    // PATCH /api/v1/accounts/{id}
-    doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10), `{"name":"Sandbox2"}`, stdhttp.StatusOK)
+	// PATCH /api/v1/accounts/{id}
+	doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10), `{"name":"Sandbox2"}`, stdhttp.StatusOK)
 
-    // Create pool referencing the account, to induce delete conflict
-    doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.200.0.0/16","account_id":`+strconv.FormatInt(acc.ID, 10)+`}`, stdhttp.StatusCreated)
+	// Create pool referencing the account, to induce delete conflict
+	doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.200.0.0/16","account_id":`+strconv.FormatInt(acc.ID, 10)+`}`, stdhttp.StatusCreated)
 
-    // DELETE /api/v1/accounts/{id} without force -> expect 409
-    req := httptest.NewRequest(stdhttp.MethodDelete, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10), nil)
-    res := httptest.NewRecorder()
-    srv.mux.ServeHTTP(res, req)
-    if res.Code != stdhttp.StatusConflict { t.Fatalf("expected 409, got %d", res.Code) }
+	// DELETE /api/v1/accounts/{id} without force -> expect 409
+	req := httptest.NewRequest(stdhttp.MethodDelete, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10), nil)
+	res := httptest.NewRecorder()
+	srv.mux.ServeHTTP(res, req)
+	if res.Code != stdhttp.StatusConflict {
+		t.Fatalf("expected 409, got %d", res.Code)
+	}
 
-    // DELETE with force -> 204
-    doJSON(t, srv.mux, stdhttp.MethodDelete, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10)+"?force=1", "", stdhttp.StatusNoContent)
+	// DELETE with force -> 204
+	doJSON(t, srv.mux, stdhttp.MethodDelete, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10)+"?force=1", "", stdhttp.StatusNoContent)
 }
 
 func TestAccounts_UpdateMetadata_Tier(t *testing.T) {
-    srv, _ := setupTestServer()
-    // Create account
-    rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:222222222222","name":"Staging"}`, stdhttp.StatusCreated)
-    var acc struct{ ID int64 `json:"id"` }
-    if err := json.Unmarshal(rr.Body.Bytes(), &acc); err != nil { t.Fatalf("unmarshal: %v", err) }
-    // PATCH tier + platform + environment
-    body := `{"platform":"aws","tier":"sbx","environment":"stg","regions":["us-west-2"]}`
-    doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/accounts/"+strconv.FormatInt(acc.ID,10), body, stdhttp.StatusOK)
-    // GET and verify
-    rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/accounts/"+strconv.FormatInt(acc.ID,10), "", stdhttp.StatusOK)
-    var out struct{ Platform, Tier, Environment string; Regions []string }
-    if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil { t.Fatalf("unmarshal: %v", err) }
-    if out.Platform != "aws" || out.Tier != "sbx" || out.Environment != "stg" || len(out.Regions) != 1 || out.Regions[0] != "us-west-2" {
-        t.Fatalf("metadata mismatch: %+v", out)
-    }
+	srv, _ := setupTestServer()
+	// Create account
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:222222222222","name":"Staging"}`, stdhttp.StatusCreated)
+	var acc struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &acc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// PATCH tier + platform + environment
+	body := `{"platform":"aws","tier":"sbx","environment":"stg","regions":["us-west-2"]}`
+	doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10), body, stdhttp.StatusOK)
+	// GET and verify
+	rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10), "", stdhttp.StatusOK)
+	var out struct {
+		Platform, Tier, Environment string
+		Regions                     []string
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Platform != "aws" || out.Tier != "sbx" || out.Environment != "stg" || len(out.Regions) != 1 || out.Regions[0] != "us-west-2" {
+		t.Fatalf("metadata mismatch: %+v", out)
+	}
 }
 
 func TestPools_Overlap_SiblingsAndBlocksAnnotation(t *testing.T) {
-    srv, _ := setupTestServer()
-    // create parent
-    rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.10.0.0/16"}`, stdhttp.StatusCreated)
-    var root poolDTO
-    if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil { t.Fatalf("unmarshal root: %v", err) }
-    // create child /24
-    doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"c24","cidr":"10.10.1.0/24","parent_id":`+strconv.FormatInt(root.ID, 10)+`}`, stdhttp.StatusCreated)
-    // attempt overlapping sibling /29 -> 400
-    bad := httptest.NewRequest(stdhttp.MethodPost, "/api/v1/pools", strings.NewReader(`{"name":"c29","cidr":"10.10.1.0/29","parent_id":`+strconv.FormatInt(root.ID, 10)+`}`))
-    bad.Header.Set("Content-Type", "application/json")
-    res := httptest.NewRecorder()
-    srv.mux.ServeHTTP(res, bad)
-    if res.Code != stdhttp.StatusBadRequest { t.Fatalf("expected 400, got %d: %s", res.Code, res.Body.String()) }
+	srv, _ := setupTestServer()
+	// create parent
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.10.0.0/16"}`, stdhttp.StatusCreated)
+	var root poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil {
+		t.Fatalf("unmarshal root: %v", err)
+	}
+	// create child /24
+	doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"c24","cidr":"10.10.1.0/24","parent_id":`+strconv.FormatInt(root.ID, 10)+`}`, stdhttp.StatusCreated)
+	// attempt overlapping sibling /29 -> 400
+	bad := httptest.NewRequest(stdhttp.MethodPost, "/api/v1/pools", strings.NewReader(`{"name":"c29","cidr":"10.10.1.0/29","parent_id":`+strconv.FormatInt(root.ID, 10)+`}`))
+	bad.Header.Set("Content-Type", "application/json")
+	res := httptest.NewRecorder()
+	srv.mux.ServeHTTP(res, bad)
+	if res.Code != stdhttp.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", res.Code, res.Body.String())
+	}
 
-    // Blocks annotation: /26 blocks that intersect 10.10.1.0/24 should be marked ExistsElsewhere
-    path := "/api/v1/pools/"+strconv.FormatInt(root.ID,10)+"/blocks?new_prefix_len=26&page_size=all"
-    rr2 := doJSON(t, srv.mux, stdhttp.MethodGet, path, "", stdhttp.StatusOK)
-    var env struct{ Items []struct{ CIDR string `json:"cidr"`; ExistsElsewhere bool `json:"exists_elsewhere"` } }
-    if err := json.Unmarshal(rr2.Body.Bytes(), &env); err != nil { t.Fatalf("unmarshal: %v", err) }
-    if len(env.Items) == 0 { t.Fatalf("expected items") }
-    // Find a /26 inside 10.10.1.0/24
-    var found bool
-    for _, it := range env.Items {
-        if strings.HasPrefix(it.CIDR, "10.10.1.") && it.ExistsElsewhere { found = true; break }
-    }
-    if !found { t.Fatalf("expected an ExistsElsewhere block within 10.10.1.0/24") }
+	// Blocks annotation: /26 blocks that intersect 10.10.1.0/24 should be marked ExistsElsewhere
+	path := "/api/v1/pools/" + strconv.FormatInt(root.ID, 10) + "/blocks?new_prefix_len=26&page_size=all"
+	rr2 := doJSON(t, srv.mux, stdhttp.MethodGet, path, "", stdhttp.StatusOK)
+	var env struct {
+		Items []struct {
+			CIDR            string `json:"cidr"`
+			ExistsElsewhere bool   `json:"exists_elsewhere"`
+		}
+	}
+	if err := json.Unmarshal(rr2.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(env.Items) == 0 {
+		t.Fatalf("expected items")
+	}
+	// Find a /26 inside 10.10.1.0/24
+	var found bool
+	for _, it := range env.Items {
+		if strings.HasPrefix(it.CIDR, "10.10.1.") && it.ExistsElsewhere {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected an ExistsElsewhere block within 10.10.1.0/24")
+	}
 }
 
 func TestBlocks_PaginationWindow(t *testing.T) {
-    srv, _ := setupTestServer()
-    // parent /16
-    rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.0.0.0/16"}`, stdhttp.StatusCreated)
-    var root poolDTO
-    if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil { t.Fatalf("unmarshal root: %v", err) }
-    // page_size=3, page=2 over /24s
-    path := "/api/v1/pools/"+strconv.FormatInt(root.ID,10)+"/blocks?new_prefix_len=24&page_size=3&page=2"
-    rr2 := doJSON(t, srv.mux, stdhttp.MethodGet, path, "", stdhttp.StatusOK)
-    var env struct{
-        Items []struct{ CIDR string `json:"cidr"` }
-        Total int `json:"total"`
-        Page int `json:"page"`
-        PageSize int `json:"page_size"`
-    }
-    if err := json.Unmarshal(rr2.Body.Bytes(), &env); err != nil { t.Fatalf("unmarshal: %v", err) }
-    if env.Total != 256 { t.Fatalf("expected total 256, got %d", env.Total) }
-    if len(env.Items) != 3 { t.Fatalf("expected 3 items, got %d", len(env.Items)) }
-    if env.Items[0].CIDR != "10.0.3.0/24" || env.Items[2].CIDR != "10.0.5.0/24" {
-        t.Fatalf("unexpected window: %+v", env.Items)
-    }
+	srv, _ := setupTestServer()
+	// parent /16
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.0.0.0/16"}`, stdhttp.StatusCreated)
+	var root poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil {
+		t.Fatalf("unmarshal root: %v", err)
+	}
+	// page_size=3, page=2 over /24s
+	path := "/api/v1/pools/" + strconv.FormatInt(root.ID, 10) + "/blocks?new_prefix_len=24&page_size=3&page=2"
+	rr2 := doJSON(t, srv.mux, stdhttp.MethodGet, path, "", stdhttp.StatusOK)
+	var env struct {
+		Items []struct {
+			CIDR string `json:"cidr"`
+		}
+		Total    int `json:"total"`
+		Page     int `json:"page"`
+		PageSize int `json:"page_size"`
+	}
+	if err := json.Unmarshal(rr2.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.Total != 256 {
+		t.Fatalf("expected total 256, got %d", env.Total)
+	}
+	if len(env.Items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(env.Items))
+	}
+	if env.Items[0].CIDR != "10.0.3.0/24" || env.Items[2].CIDR != "10.0.5.0/24" {
+		t.Fatalf("unexpected window: %+v", env.Items)
+	}
 }
 
 func TestAnalytics_MetadataInBlocks(t *testing.T) {
-    srv, _ := setupTestServer()
-    // create two accounts with different metadata
-    rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:111","name":"Prod"}`, stdhttp.StatusCreated)
-    var a1 struct{ ID int64 `json:"id"` }
-    _ = json.Unmarshal(rr.Body.Bytes(), &a1)
-    rr = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"gcp:proj","name":"Dev"}`, stdhttp.StatusCreated)
-    var a2 struct{ ID int64 `json:"id"` }
-    _ = json.Unmarshal(rr.Body.Bytes(), &a2)
-    // patch metadata and verify persistence
-    doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/accounts/"+strconv.FormatInt(a1.ID,10), `{"platform":"aws","environment":"prd","regions":["us-east-1","us-west-2"]}`, stdhttp.StatusOK)
-    ar := doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/accounts/"+strconv.FormatInt(a1.ID,10), "", stdhttp.StatusOK)
-    var acc1 struct{ Platform, Environment string; Regions []string }
-    if err := json.Unmarshal(ar.Body.Bytes(), &acc1); err != nil { t.Fatalf("unmarshal acc1: %v", err) }
-    if acc1.Platform != "aws" || acc1.Environment != "prd" || len(acc1.Regions)==0 { t.Fatalf("account1 metadata not set: %+v", acc1) }
-    doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/accounts/"+strconv.FormatInt(a2.ID,10), `{"platform":"gcp","environment":"dev","regions":["us-east1"]}`, stdhttp.StatusOK)
-    ar = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/accounts/"+strconv.FormatInt(a2.ID,10), "", stdhttp.StatusOK)
-    var acc2 struct{ Platform, Environment string; Regions []string }
-    if err := json.Unmarshal(ar.Body.Bytes(), &acc2); err != nil { t.Fatalf("unmarshal acc2: %v", err) }
-    if acc2.Platform != "gcp" || acc2.Environment != "dev" || len(acc2.Regions)==0 { t.Fatalf("account2 metadata not set: %+v", acc2) }
-    // parent and children
-    rr = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.50.0.0/16"}`, stdhttp.StatusCreated)
-    var root poolDTO
-    if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil { t.Fatalf("unmarshal root: %v", err) }
-    doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"prodnet","cidr":"10.50.1.0/24","parent_id":`+strconv.FormatInt(root.ID,10)+`,"account_id":`+strconv.FormatInt(a1.ID,10)+`}`, stdhttp.StatusCreated)
-    doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"devnet","cidr":"10.50.2.0/24","parent_id":`+strconv.FormatInt(root.ID,10)+`,"account_id":`+strconv.FormatInt(a2.ID,10)+`}`, stdhttp.StatusCreated)
+	srv, _ := setupTestServer()
+	// create two accounts with different metadata
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:111","name":"Prod"}`, stdhttp.StatusCreated)
+	var a1 struct {
+		ID int64 `json:"id"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &a1)
+	rr = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"gcp:proj","name":"Dev"}`, stdhttp.StatusCreated)
+	var a2 struct {
+		ID int64 `json:"id"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &a2)
+	// patch metadata and verify persistence
+	doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/accounts/"+strconv.FormatInt(a1.ID, 10), `{"platform":"aws","environment":"prd","regions":["us-east-1","us-west-2"]}`, stdhttp.StatusOK)
+	ar := doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/accounts/"+strconv.FormatInt(a1.ID, 10), "", stdhttp.StatusOK)
+	var acc1 struct {
+		Platform, Environment string
+		Regions               []string
+	}
+	if err := json.Unmarshal(ar.Body.Bytes(), &acc1); err != nil {
+		t.Fatalf("unmarshal acc1: %v", err)
+	}
+	if acc1.Platform != "aws" || acc1.Environment != "prd" || len(acc1.Regions) == 0 {
+		t.Fatalf("account1 metadata not set: %+v", acc1)
+	}
+	doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/accounts/"+strconv.FormatInt(a2.ID, 10), `{"platform":"gcp","environment":"dev","regions":["us-east1"]}`, stdhttp.StatusOK)
+	ar = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/accounts/"+strconv.FormatInt(a2.ID, 10), "", stdhttp.StatusOK)
+	var acc2 struct {
+		Platform, Environment string
+		Regions               []string
+	}
+	if err := json.Unmarshal(ar.Body.Bytes(), &acc2); err != nil {
+		t.Fatalf("unmarshal acc2: %v", err)
+	}
+	if acc2.Platform != "gcp" || acc2.Environment != "dev" || len(acc2.Regions) == 0 {
+		t.Fatalf("account2 metadata not set: %+v", acc2)
+	}
+	// parent and children
+	rr = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.50.0.0/16"}`, stdhttp.StatusCreated)
+	var root poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil {
+		t.Fatalf("unmarshal root: %v", err)
+	}
+	doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"prodnet","cidr":"10.50.1.0/24","parent_id":`+strconv.FormatInt(root.ID, 10)+`,"account_id":`+strconv.FormatInt(a1.ID, 10)+`}`, stdhttp.StatusCreated)
+	doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"devnet","cidr":"10.50.2.0/24","parent_id":`+strconv.FormatInt(root.ID, 10)+`,"account_id":`+strconv.FormatInt(a2.ID, 10)+`}`, stdhttp.StatusCreated)
 
-    // fetch analytics rows
-    rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/blocks?page_size=all", "", stdhttp.StatusOK)
-    var env struct{ Items []struct{ AccountID *int64 `json:"account_id"`; AccountName, AccountPlatform, AccountEnvironment string; AccountRegions []string } }
-    if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil { t.Fatalf("unmarshal: %v", err) }
-    if len(env.Items) < 2 { t.Fatalf("expected at least 2 items") }
-    var seenProd, seenDev bool
-    for _, it := range env.Items {
-        if it.AccountID == nil { continue }
-        if *it.AccountID == a1.ID { seenProd = true }
-        if *it.AccountID == a2.ID { seenDev = true }
-    }
-    if !seenProd || !seenDev { t.Fatalf("did not see both account rows") }
+	// fetch analytics rows
+	rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/blocks?page_size=all", "", stdhttp.StatusOK)
+	var env struct {
+		Items []struct {
+			AccountID                                        *int64 `json:"account_id"`
+			AccountName, AccountPlatform, AccountEnvironment string
+			AccountRegions                                   []string
+		}
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(env.Items) < 2 {
+		t.Fatalf("expected at least 2 items")
+	}
+	var seenProd, seenDev bool
+	for _, it := range env.Items {
+		if it.AccountID == nil {
+			continue
+		}
+		if *it.AccountID == a1.ID {
+			seenProd = true
+		}
+		if *it.AccountID == a2.ID {
+			seenDev = true
+		}
+	}
+	if !seenProd || !seenDev {
+		t.Fatalf("did not see both account rows")
+	}
 
-    // apply accounts and pools filters combination
-    rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/blocks?accounts="+strconv.FormatInt(a1.ID,10)+"&pools="+strconv.FormatInt(root.ID,10)+"&page_size=all", "", stdhttp.StatusOK)
-    var env2 struct{ Items []struct{ AccountID *int64 `json:"account_id"` } }
-    if err := json.Unmarshal(rr.Body.Bytes(), &env2); err != nil { t.Fatalf("unmarshal: %v", err) }
-    for _, it := range env2.Items { if it.AccountID == nil || *it.AccountID != a1.ID { t.Fatalf("filter mismatch: %+v", it) } }
+	// apply accounts and pools filters combination
+	rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/blocks?accounts="+strconv.FormatInt(a1.ID, 10)+"&pools="+strconv.FormatInt(root.ID, 10)+"&page_size=all", "", stdhttp.StatusOK)
+	var env2 struct {
+		Items []struct {
+			AccountID *int64 `json:"account_id"`
+		}
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, it := range env2.Items {
+		if it.AccountID == nil || *it.AccountID != a1.ID {
+			t.Fatalf("filter mismatch: %+v", it)
+		}
+	}
 }
 
 func TestBlocks_HostsAndNoExistsElsewhere(t *testing.T) {
-    srv, _ := setupTestServer()
-    rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.60.0.0/16"}`, stdhttp.StatusCreated)
-    var root poolDTO
-    if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil { t.Fatalf("unmarshal: %v", err) }
-    // request /26 blocks
-    rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/pools/"+strconv.FormatInt(root.ID,10)+"/blocks?new_prefix_len=26&page_size=3&page=1", "", stdhttp.StatusOK)
-    var env struct{ Items []struct{ Hosts uint64 `json:"hosts"`; ExistsElsewhere bool `json:"exists_elsewhere"` } }
-    if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil { t.Fatalf("unmarshal: %v", err) }
-    if len(env.Items) == 0 { t.Fatalf("expected some items") }
-    // /26 has 64 addresses; usableHostsIPv4 returns total-2 for <=30
-    if env.Items[0].Hosts != 62 { t.Fatalf("expected 62 hosts for /26, got %d", env.Items[0].Hosts) }
-    for _, it := range env.Items { if it.ExistsElsewhere { t.Fatalf("should not be marked exists elsewhere in empty subtree") } }
+	srv, _ := setupTestServer()
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.60.0.0/16"}`, stdhttp.StatusCreated)
+	var root poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// request /26 blocks
+	rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/pools/"+strconv.FormatInt(root.ID, 10)+"/blocks?new_prefix_len=26&page_size=3&page=1", "", stdhttp.StatusOK)
+	var env struct {
+		Items []struct {
+			Hosts           uint64 `json:"hosts"`
+			ExistsElsewhere bool   `json:"exists_elsewhere"`
+		}
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(env.Items) == 0 {
+		t.Fatalf("expected some items")
+	}
+	// /26 has 64 addresses; usableHostsIPv4 returns total-2 for <=30
+	if env.Items[0].Hosts != 62 {
+		t.Fatalf("expected 62 hosts for /26, got %d", env.Items[0].Hosts)
+	}
+	for _, it := range env.Items {
+		if it.ExistsElsewhere {
+			t.Fatalf("should not be marked exists elsewhere in empty subtree")
+		}
+	}
 }
 func TestAccountsHandlers_AndBlocks(t *testing.T) {
 	srv, _ := setupTestServer()
@@ -384,18 +492,20 @@ func TestAccountsHandlers_AndBlocks(t *testing.T) {
 		t.Fatalf("expected to find assigned child block")
 	}
 
-    // global blocks filter by account (request all for simple assertion)
-    rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/blocks?accounts="+strconv.FormatInt(acc.ID, 10)+"&page_size=all", "", stdhttp.StatusOK)
-    var env struct {
-        Items []struct{ AccountID *int64 `json:"account_id"` }
-        Total int `json:"total"`
-    }
-    if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
-        t.Fatalf("unmarshal rows: %v", err)
-    }
-    if env.Total == 0 || len(env.Items) == 0 || env.Items[0].AccountID == nil || *env.Items[0].AccountID != acc.ID {
-        t.Fatalf("expected rows for account %d", acc.ID)
-    }
+	// global blocks filter by account (request all for simple assertion)
+	rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/blocks?accounts="+strconv.FormatInt(acc.ID, 10)+"&page_size=all", "", stdhttp.StatusOK)
+	var env struct {
+		Items []struct {
+			AccountID *int64 `json:"account_id"`
+		}
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal rows: %v", err)
+	}
+	if env.Total == 0 || len(env.Items) == 0 || env.Items[0].AccountID == nil || *env.Items[0].AccountID != acc.ID {
+		t.Fatalf("expected rows for account %d", acc.ID)
+	}
 
 	// delete account without force should fail due to referencing pools
 	rr = doJSON(t, srv.mux, stdhttp.MethodDelete, "/api/v1/accounts/"+strconv.FormatInt(acc.ID, 10), "", stdhttp.StatusConflict)
@@ -405,62 +515,66 @@ func TestAccountsHandlers_AndBlocks(t *testing.T) {
 }
 
 func TestErrorEnvelope_JSON(t *testing.T) {
-    srv, _ := setupTestServer()
-    // create a valid parent
-    rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.0.0.0/16"}`, stdhttp.StatusCreated)
-    var root poolDTO
-    if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil {
-        t.Fatalf("unmarshal: %v", err)
-    }
-    // missing new_prefix_len -> should be JSON error envelope
-    req := httptest.NewRequest(stdhttp.MethodGet, "/api/v1/pools/"+strconv.FormatInt(root.ID, 10)+"/blocks", nil)
-    res := httptest.NewRecorder()
-    srv.mux.ServeHTTP(res, req)
-    if res.Code != stdhttp.StatusBadRequest {
-        t.Fatalf("expected 400, got %d", res.Code)
-    }
-    if ct := res.Header().Get("Content-Type"); ct == "" || ct[:16] != "application/json" {
-        t.Fatalf("expected json content-type, got %q", ct)
-    }
-    var e struct{ Error string `json:"error"` }
-    if err := json.Unmarshal(res.Body.Bytes(), &e); err != nil {
-        t.Fatalf("not json: %v: %s", err, res.Body.String())
-    }
-    if e.Error == "" {
-        t.Fatalf("expected error message")
-    }
+	srv, _ := setupTestServer()
+	// create a valid parent
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.0.0.0/16"}`, stdhttp.StatusCreated)
+	var root poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// missing new_prefix_len -> should be JSON error envelope
+	req := httptest.NewRequest(stdhttp.MethodGet, "/api/v1/pools/"+strconv.FormatInt(root.ID, 10)+"/blocks", nil)
+	res := httptest.NewRecorder()
+	srv.mux.ServeHTTP(res, req)
+	if res.Code != stdhttp.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.Code)
+	}
+	if ct := res.Header().Get("Content-Type"); ct == "" || ct[:16] != "application/json" {
+		t.Fatalf("expected json content-type, got %q", ct)
+	}
+	var e struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &e); err != nil {
+		t.Fatalf("not json: %v: %s", err, res.Body.String())
+	}
+	if e.Error == "" {
+		t.Fatalf("expected error message")
+	}
 }
 
 func TestPoolsHandlers_OverlapProtection(t *testing.T) {
-    srv, _ := setupTestServer()
+	srv, _ := setupTestServer()
 
-    // Create a large top-level pool
-    rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.0.0.0/8"}`, stdhttp.StatusCreated)
-    var root poolDTO
-    if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil { t.Fatalf("unmarshal root: %v", err) }
+	// Create a large top-level pool
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.0.0.0/8"}`, stdhttp.StatusCreated)
+	var root poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil {
+		t.Fatalf("unmarshal root: %v", err)
+	}
 
-    // Create a child /24 inside it (in a region we won't reuse later)
-    body := `{"name":"c24","cidr":"10.1.0.0/24","parent_id":` + strconv.FormatInt(root.ID, 10) + `}`
-    _ = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", body, stdhttp.StatusCreated)
+	// Create a child /24 inside it (in a region we won't reuse later)
+	body := `{"name":"c24","cidr":"10.1.0.0/24","parent_id":` + strconv.FormatInt(root.ID, 10) + `}`
+	_ = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", body, stdhttp.StatusCreated)
 
-    // Attempt overlapping /29 under the same parent -> should fail
-    body = `{"name":"c29","cidr":"10.1.0.0/29","parent_id":` + strconv.FormatInt(root.ID, 10) + `}`
-    bad := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", body, stdhttp.StatusBadRequest)
-    if !strings.Contains(bad.Body.String(), "overlap") {
-        t.Fatalf("expected overlap error, got: %s", bad.Body.String())
-    }
+	// Attempt overlapping /29 under the same parent -> should fail
+	body = `{"name":"c29","cidr":"10.1.0.0/29","parent_id":` + strconv.FormatInt(root.ID, 10) + `}`
+	bad := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", body, stdhttp.StatusBadRequest)
+	if !strings.Contains(bad.Body.String(), "overlap") {
+		t.Fatalf("expected overlap error, got: %s", bad.Body.String())
+	}
 
-    // Attempt child equal to parent prefix -> should fail (must be stricter than parent)
-    eq := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"eq","cidr":"10.0.0.0/8","parent_id":`+strconv.FormatInt(root.ID,10)+`}`, stdhttp.StatusBadRequest)
-    if !strings.Contains(eq.Body.String(), "greater") && !strings.Contains(eq.Body.String(), "invalid sub-pool") {
-        t.Fatalf("expected strict subset error, got: %s", eq.Body.String())
-    }
+	// Attempt child equal to parent prefix -> should fail (must be stricter than parent)
+	eq := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"eq","cidr":"10.0.0.0/8","parent_id":`+strconv.FormatInt(root.ID, 10)+`}`, stdhttp.StatusBadRequest)
+	if !strings.Contains(eq.Body.String(), "greater") && !strings.Contains(eq.Body.String(), "invalid sub-pool") {
+		t.Fatalf("expected strict subset error, got: %s", eq.Body.String())
+	}
 
-    // Attempt another overlapping top-level root -> should fail
-    bad2 := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root2","cidr":"10.0.0.0/16"}`, stdhttp.StatusBadRequest)
-    if !strings.Contains(bad2.Body.String(), "overlap") {
-        t.Fatalf("expected overlap error for top-level, got: %s", bad2.Body.String())
-    }
+	// Attempt another overlapping top-level root -> should fail
+	bad2 := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root2","cidr":"10.0.0.0/16"}`, stdhttp.StatusBadRequest)
+	if !strings.Contains(bad2.Body.String(), "overlap") {
+		t.Fatalf("expected overlap error for top-level, got: %s", bad2.Body.String())
+	}
 
-    // Additional cross-tree global tests are constrained by strict subset rules.
+	// Additional cross-tree global tests are constrained by strict subset rules.
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -11,7 +11,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
-    "sort"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -21,23 +21,23 @@ import (
 )
 
 type apiError struct {
-    Error  string `json:"error"`
-    Detail string `json:"detail,omitempty"`
+	Error  string `json:"error"`
+	Detail string `json:"detail,omitempty"`
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {
-    w.Header().Set("Content-Type", "application/json")
-    w.WriteHeader(code)
-    _ = json.NewEncoder(w).Encode(v)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
 }
 
 func writeErr(w http.ResponseWriter, code int, msg string, detail string) {
-    if detail != "" {
-        log.Printf("http %d error: %s detail=%s", code, msg, detail)
-    } else {
-        log.Printf("http %d error: %s", code, msg)
-    }
-    writeJSON(w, code, apiError{Error: msg, Detail: detail})
+	if detail != "" {
+		log.Printf("http %d error: %s detail=%s", code, msg, detail)
+	} else {
+		log.Printf("http %d error: %s", code, msg)
+	}
+	writeJSON(w, code, apiError{Error: msg, Detail: detail})
 }
 
 type Server struct {
@@ -50,91 +50,94 @@ func NewServer(mux *http.ServeMux, store storage.Store) *Server {
 }
 
 func (s *Server) RegisterRoutes() {
-    s.mux.HandleFunc("/healthz", s.handleHealth)
-    s.mux.HandleFunc("/api/v1/pools", s.handlePools)
-    s.mux.HandleFunc("/api/v1/pools/", s.handlePoolsSubroutes)
-    s.mux.HandleFunc("/api/v1/accounts", s.handleAccounts)
-    s.mux.HandleFunc("/api/v1/accounts/", s.handleAccountsSubroutes)
-    s.mux.HandleFunc("/api/v1/blocks", s.handleBlocksList)
-    // Static index
-    s.mux.HandleFunc("/", s.handleIndex)
+	s.mux.HandleFunc("/healthz", s.handleHealth)
+	s.mux.HandleFunc("/api/v1/pools", s.handlePools)
+	s.mux.HandleFunc("/api/v1/pools/", s.handlePoolsSubroutes)
+	s.mux.HandleFunc("/api/v1/accounts", s.handleAccounts)
+	s.mux.HandleFunc("/api/v1/accounts/", s.handleAccountsSubroutes)
+	s.mux.HandleFunc("/api/v1/blocks", s.handleBlocksList)
+	// Static index
+	s.mux.HandleFunc("/", s.handleIndex)
 }
 
 // /api/v1/accounts/{id}
 func (s *Server) handleAccountsSubroutes(w http.ResponseWriter, r *http.Request) {
-    path := strings.TrimPrefix(r.URL.Path, "/api/v1/accounts/")
-    idStr := strings.Trim(path, "/")
-    if idStr == "" {
-        writeErr(w, http.StatusNotFound, "not found", "")
-        return
-    }
-    id, err := strconv.ParseInt(idStr, 10, 64)
-    if err != nil {
-        writeErr(w, http.StatusBadRequest, "invalid id", "")
-        return
-    }
-    switch r.Method {
-    case http.MethodGet:
-        a, ok, err := s.store.GetAccount(r.Context(), id)
-        if err != nil {
-            writeErr(w, http.StatusBadRequest, err.Error(), "")
-            return
-        }
-        if !ok {
-            writeErr(w, http.StatusNotFound, "not found", "")
-            return
-        }
-        writeJSON(w, http.StatusOK, a)
-    case http.MethodPatch:
-        var in domain.Account
-        if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-            writeErr(w, http.StatusBadRequest, "invalid json", "")
-            return
-        }
-        a, ok, err := s.store.UpdateAccount(r.Context(), id, in)
-        if err != nil {
-            writeErr(w, http.StatusBadRequest, err.Error(), "")
-            return
-        }
-        if !ok {
-            writeErr(w, http.StatusNotFound, "not found", "")
-            return
-        }
-        writeJSON(w, http.StatusOK, a)
-    case http.MethodDelete:
-        var ok bool
-        force := strings.ToLower(r.URL.Query().Get("force"))
-        if force == "1" || force == "true" || force == "yes" {
-            ok, err = s.store.DeleteAccountCascade(r.Context(), id)
-        } else {
-            ok, err = s.store.DeleteAccount(r.Context(), id)
-        }
-        if err != nil {
-            writeErr(w, http.StatusConflict, err.Error(), "")
-            return
-        }
-        if !ok {
-            writeErr(w, http.StatusNotFound, "not found", "")
-            return
-        }
-        w.WriteHeader(http.StatusNoContent)
-    default:
-        writeErr(w, http.StatusMethodNotAllowed, "method not allowed", "")
-    }
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/accounts/")
+	idStr := strings.Trim(path, "/")
+	if idStr == "" {
+		writeErr(w, http.StatusNotFound, "not found", "")
+		return
+	}
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid id", "")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		a, ok, err := s.store.GetAccount(r.Context(), id)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, err.Error(), "")
+			return
+		}
+		if !ok {
+			writeErr(w, http.StatusNotFound, "not found", "")
+			return
+		}
+		writeJSON(w, http.StatusOK, a)
+	case http.MethodPatch:
+		var in domain.Account
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid json", "")
+			return
+		}
+		a, ok, err := s.store.UpdateAccount(r.Context(), id, in)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, err.Error(), "")
+			return
+		}
+		if !ok {
+			writeErr(w, http.StatusNotFound, "not found", "")
+			return
+		}
+		writeJSON(w, http.StatusOK, a)
+	case http.MethodDelete:
+		var ok bool
+		force := strings.ToLower(r.URL.Query().Get("force"))
+		if force == "1" || force == "true" || force == "yes" {
+			ok, err = s.store.DeleteAccountCascade(r.Context(), id)
+		} else {
+			ok, err = s.store.DeleteAccount(r.Context(), id)
+		}
+		if err != nil {
+			writeErr(w, http.StatusConflict, err.Error(), "")
+			return
+		}
+		if !ok {
+			writeErr(w, http.StatusNotFound, "not found", "")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "method not allowed", "")
+	}
 }
-
 
 // LoggingMiddleware wraps an http.Handler to log basic request info.
 func LoggingMiddleware(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        start := time.Now()
-        sr := &statusRecorder{ResponseWriter: w, status: 200}
-        next.ServeHTTP(sr, r)
-        log.Printf("%s %s -> %d in %s", r.Method, r.URL.Path, sr.status, time.Since(start))
-    })
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		sr := &statusRecorder{ResponseWriter: w, status: 200}
+		next.ServeHTTP(sr, r)
+		log.Printf("%s %s -> %d in %s", r.Method, r.URL.Path, sr.status, time.Since(start))
+	})
 }
 
-type statusRecorder struct { http.ResponseWriter; status int }
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
 func (s *statusRecorder) WriteHeader(code int) { s.status = code; s.ResponseWriter.WriteHeader(code) }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -189,14 +192,14 @@ func (s *Server) handleAccounts(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listAccounts(w http.ResponseWriter, r *http.Request) {
-    ctx := r.Context()
-    accs, err := s.store.ListAccounts(ctx)
-    if err != nil {
-        writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
-        return
-    }
-    w.Header().Set("Content-Type", "application/json")
-    _ = json.NewEncoder(w).Encode(accs)
+	ctx := r.Context()
+	accs, err := s.store.ListAccounts(ctx)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(accs)
 }
 
 func (s *Server) createAccount(w http.ResponseWriter, r *http.Request) {
@@ -222,156 +225,169 @@ func (s *Server) createAccount(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(a)
 }
 
-
 // Legacy account query-param endpoints are not supported; use /api/v1/accounts/{id}.
-
 
 // GET /api/v1/blocks?accounts=1,2&pools=10,11
 // Returns all assigned blocks (sub-pools), optionally filtered by account IDs and parent pool IDs.
 func (s *Server) handleBlocksList(w http.ResponseWriter, r *http.Request) {
-    ctx := r.Context()
-    ps, err := s.store.ListPools(ctx)
-    if err != nil {
-        writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
-        return
-    }
-    accs, err := s.store.ListAccounts(ctx)
-    if err != nil {
-        writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
-        return
-    }
-    // Build lookups
-    accName := map[int64]string{}
-    accMeta := map[int64]struct{ Platform, Tier, Environment string; Regions []string }{}
-    for _, a := range accs {
-        accName[a.ID] = a.Name
-        accMeta[a.ID] = struct{ Platform, Tier, Environment string; Regions []string }{Platform:a.Platform, Tier:a.Tier, Environment:a.Environment, Regions:a.Regions}
-    }
-    poolName := map[int64]string{}
-    for _, p := range ps {
-        poolName[p.ID] = p.Name
-    }
-    // Parse filters
-    parseIDs := func(s string) map[int64]struct{} {
-        set := map[int64]struct{}{}
-        if s == "" {
-            return set
-        }
-        for _, part := range strings.Split(s, ",") {
-            part = strings.TrimSpace(part)
-            if part == "" {
-                continue
-            }
-            if id, err := strconv.ParseInt(part, 10, 64); err == nil {
-                set[id] = struct{}{}
-            }
-        }
-        return set
-    }
-    accFilter := parseIDs(r.URL.Query().Get("accounts"))
-    poolFilter := parseIDs(r.URL.Query().Get("pools"))
-    // Pagination params
-    pageSizeStr := r.URL.Query().Get("page_size")
-    pageStr := r.URL.Query().Get("page")
-    // Defaults
-    pageSize := 50
-    if strings.ToLower(pageSizeStr) == "all" {
-        pageSize = 0
-    } else if pageSizeStr != "" {
-        psn, err := strconv.Atoi(pageSizeStr)
-        if err != nil || psn < 0 {
-            writeErr(w, http.StatusBadRequest, "invalid page_size", "")
-            return
-        }
-        pageSize = psn
-    }
-    // Cap page size
-    if pageSize > 0 && pageSize > 500 {
-        pageSize = 500
-    }
-    page := 1
-    if pageStr != "" {
-        p, err := strconv.Atoi(pageStr)
-        if err != nil || p <= 0 {
-            writeErr(w, http.StatusBadRequest, "invalid page", "")
-            return
-        }
-        page = p
-    }
-    // Collect assigned blocks (sub-pools)
-    type row struct {
-        ID          int64     `json:"id"`
-        Name        string    `json:"name"`
-        CIDR        string    `json:"cidr"`
-        ParentID    int64     `json:"parent_id"`
-        ParentName  string    `json:"parent_name"`
-        AccountID   *int64    `json:"account_id,omitempty"`
-        AccountName string    `json:"account_name,omitempty"`
-        AccountPlatform string `json:"account_platform,omitempty"`
-        AccountTier      string `json:"account_tier,omitempty"`
-        AccountEnvironment string `json:"account_environment,omitempty"`
-        AccountRegions   []string `json:"account_regions,omitempty"`
-        CreatedAt   time.Time `json:"created_at"`
-    }
-    var items []row
-    for _, p := range ps {
-        if p.ParentID == nil {
-            continue
-        }
-        // Filters
-        if len(accFilter) > 0 {
-            if p.AccountID == nil {
-                continue
-            }
-            if _, ok := accFilter[*p.AccountID]; !ok {
-                continue
-            }
-        }
-        if len(poolFilter) > 0 {
-            if _, ok := poolFilter[*p.ParentID]; !ok {
-                continue
-            }
-        }
-        r := row{
-            ID:         p.ID,
-            Name:       p.Name,
-            CIDR:       p.CIDR,
-            ParentID:   *p.ParentID,
-            ParentName: poolName[*p.ParentID],
-            AccountID:  p.AccountID,
-            CreatedAt:  p.CreatedAt,
-        }
-        if p.AccountID != nil {
-            if n, ok := accName[*p.AccountID]; ok { r.AccountName = n }
-            if m, ok := accMeta[*p.AccountID]; ok { r.AccountPlatform = m.Platform; r.AccountTier = m.Tier; r.AccountEnvironment = m.Environment; r.AccountRegions = m.Regions }
-        }
-        items = append(items, r)
-    }
-    // Sort by CreatedAt then ID for deterministic order
-    sort.Slice(items, func(i, j int) bool {
-        if items[i].CreatedAt.Equal(items[j].CreatedAt) {
-            return items[i].ID < items[j].ID
-        }
-        return items[i].CreatedAt.Before(items[j].CreatedAt)
-    })
-    total := len(items)
-    // Paginate
-    if pageSize > 0 {
-        start := (page - 1) * pageSize
-        if start > total {
-            start = total
-        }
-        end := start + pageSize
-        if end > total { end = total }
-        items = items[start:end]
-    }
-    type resp struct {
-        Items    []row `json:"items"`
-        Total    int   `json:"total"`
-        Page     int   `json:"page"`
-        PageSize int   `json:"page_size"`
-    }
-    writeJSON(w, http.StatusOK, resp{Items: items, Total: total, Page: page, PageSize: pageSize})
+	ctx := r.Context()
+	ps, err := s.store.ListPools(ctx)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
+		return
+	}
+	accs, err := s.store.ListAccounts(ctx)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
+		return
+	}
+	// Build lookups
+	accName := map[int64]string{}
+	accMeta := map[int64]struct {
+		Platform, Tier, Environment string
+		Regions                     []string
+	}{}
+	for _, a := range accs {
+		accName[a.ID] = a.Name
+		accMeta[a.ID] = struct {
+			Platform, Tier, Environment string
+			Regions                     []string
+		}{Platform: a.Platform, Tier: a.Tier, Environment: a.Environment, Regions: a.Regions}
+	}
+	poolName := map[int64]string{}
+	for _, p := range ps {
+		poolName[p.ID] = p.Name
+	}
+	// Parse filters
+	parseIDs := func(s string) map[int64]struct{} {
+		set := map[int64]struct{}{}
+		if s == "" {
+			return set
+		}
+		for _, part := range strings.Split(s, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if id, err := strconv.ParseInt(part, 10, 64); err == nil {
+				set[id] = struct{}{}
+			}
+		}
+		return set
+	}
+	accFilter := parseIDs(r.URL.Query().Get("accounts"))
+	poolFilter := parseIDs(r.URL.Query().Get("pools"))
+	// Pagination params
+	pageSizeStr := r.URL.Query().Get("page_size")
+	pageStr := r.URL.Query().Get("page")
+	// Defaults
+	pageSize := 50
+	if strings.ToLower(pageSizeStr) == "all" {
+		pageSize = 0
+	} else if pageSizeStr != "" {
+		psn, err := strconv.Atoi(pageSizeStr)
+		if err != nil || psn < 0 {
+			writeErr(w, http.StatusBadRequest, "invalid page_size", "")
+			return
+		}
+		pageSize = psn
+	}
+	// Cap page size
+	if pageSize > 0 && pageSize > 500 {
+		pageSize = 500
+	}
+	page := 1
+	if pageStr != "" {
+		p, err := strconv.Atoi(pageStr)
+		if err != nil || p <= 0 {
+			writeErr(w, http.StatusBadRequest, "invalid page", "")
+			return
+		}
+		page = p
+	}
+	// Collect assigned blocks (sub-pools)
+	type row struct {
+		ID                 int64     `json:"id"`
+		Name               string    `json:"name"`
+		CIDR               string    `json:"cidr"`
+		ParentID           int64     `json:"parent_id"`
+		ParentName         string    `json:"parent_name"`
+		AccountID          *int64    `json:"account_id,omitempty"`
+		AccountName        string    `json:"account_name,omitempty"`
+		AccountPlatform    string    `json:"account_platform,omitempty"`
+		AccountTier        string    `json:"account_tier,omitempty"`
+		AccountEnvironment string    `json:"account_environment,omitempty"`
+		AccountRegions     []string  `json:"account_regions,omitempty"`
+		CreatedAt          time.Time `json:"created_at"`
+	}
+	var items []row
+	for _, p := range ps {
+		if p.ParentID == nil {
+			continue
+		}
+		// Filters
+		if len(accFilter) > 0 {
+			if p.AccountID == nil {
+				continue
+			}
+			if _, ok := accFilter[*p.AccountID]; !ok {
+				continue
+			}
+		}
+		if len(poolFilter) > 0 {
+			if _, ok := poolFilter[*p.ParentID]; !ok {
+				continue
+			}
+		}
+		r := row{
+			ID:         p.ID,
+			Name:       p.Name,
+			CIDR:       p.CIDR,
+			ParentID:   *p.ParentID,
+			ParentName: poolName[*p.ParentID],
+			AccountID:  p.AccountID,
+			CreatedAt:  p.CreatedAt,
+		}
+		if p.AccountID != nil {
+			if n, ok := accName[*p.AccountID]; ok {
+				r.AccountName = n
+			}
+			if m, ok := accMeta[*p.AccountID]; ok {
+				r.AccountPlatform = m.Platform
+				r.AccountTier = m.Tier
+				r.AccountEnvironment = m.Environment
+				r.AccountRegions = m.Regions
+			}
+		}
+		items = append(items, r)
+	}
+	// Sort by CreatedAt then ID for deterministic order
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CreatedAt.Equal(items[j].CreatedAt) {
+			return items[i].ID < items[j].ID
+		}
+		return items[i].CreatedAt.Before(items[j].CreatedAt)
+	})
+	total := len(items)
+	// Paginate
+	if pageSize > 0 {
+		start := (page - 1) * pageSize
+		if start > total {
+			start = total
+		}
+		end := start + pageSize
+		if end > total {
+			end = total
+		}
+		items = items[start:end]
+	}
+	type resp struct {
+		Items    []row `json:"items"`
+		Total    int   `json:"total"`
+		Page     int   `json:"page"`
+		PageSize int   `json:"page_size"`
+	}
+	writeJSON(w, http.StatusOK, resp{Items: items, Total: total, Page: page, PageSize: pageSize})
 }
 
 // /api/v1/pools/{id}/blocks?new_prefix_len=24
@@ -498,35 +514,43 @@ func (s *Server) createPool(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-    // Overlap protection: disallow any overlapping CIDRs within the same parent scope
-    // (i.e., among pools sharing the same parent_id, or among top-level pools).
-    {
-        pfxNew, _ := netip.ParsePrefix(in.CIDR)
-        if !pfxNew.Addr().Is4() {
-            writeErr(w, http.StatusBadRequest, "only ipv4 supported for now", "")
-            return
-        }
-        all, err := s.store.ListPools(ctx)
-        if err != nil {
-            writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
-            return
-        }
-        for _, p := range all {
-            if in.ParentID == nil {
-                if p.ParentID != nil { continue }
-            } else {
-                if p.ParentID == nil || *p.ParentID != *in.ParentID { continue }
-            }
-            // Skip comparing with an exact duplicate; DB uniqueness should also catch
-            if strings.EqualFold(strings.TrimSpace(p.CIDR), in.CIDR) { continue }
-            old, err := netip.ParsePrefix(p.CIDR)
-            if err != nil || !old.Addr().Is4() { continue }
-            if prefixesOverlapIPv4(old, pfxNew) {
-                writeErr(w, http.StatusBadRequest, "cidr overlaps with existing block", fmt.Sprintf("conflicts with pool #%d (%s)", p.ID, p.CIDR))
-                return
-            }
-        }
-    }
+	// Overlap protection: disallow any overlapping CIDRs within the same parent scope
+	// (i.e., among pools sharing the same parent_id, or among top-level pools).
+	{
+		pfxNew, _ := netip.ParsePrefix(in.CIDR)
+		if !pfxNew.Addr().Is4() {
+			writeErr(w, http.StatusBadRequest, "only ipv4 supported for now", "")
+			return
+		}
+		all, err := s.store.ListPools(ctx)
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
+			return
+		}
+		for _, p := range all {
+			if in.ParentID == nil {
+				if p.ParentID != nil {
+					continue
+				}
+			} else {
+				if p.ParentID == nil || *p.ParentID != *in.ParentID {
+					continue
+				}
+			}
+			// Skip comparing with an exact duplicate; DB uniqueness should also catch
+			if strings.EqualFold(strings.TrimSpace(p.CIDR), in.CIDR) {
+				continue
+			}
+			old, err := netip.ParsePrefix(p.CIDR)
+			if err != nil || !old.Addr().Is4() {
+				continue
+			}
+			if prefixesOverlapIPv4(old, pfxNew) {
+				writeErr(w, http.StatusBadRequest, "cidr overlaps with existing block", fmt.Sprintf("conflicts with pool #%d (%s)", p.ID, p.CIDR))
+				return
+			}
+		}
+	}
 	p, err := s.store.CreatePool(ctx, in)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err.Error(), "")
@@ -536,63 +560,63 @@ func (s *Server) createPool(w http.ResponseWriter, r *http.Request) {
 }
 
 type blockInfo struct {
-    CIDR                string `json:"cidr"`
-    PrefixLen           int    `json:"prefix_len"`
-    Hosts               uint64 `json:"hosts"`
-    Used                bool   `json:"used"`
-    AssignedID          int64  `json:"assigned_id,omitempty"`
-    AssignedName        string `json:"assigned_name,omitempty"`
-    AssignedAccountID   int64  `json:"assigned_account_id,omitempty"`
-    AssignedAccountName string `json:"assigned_account_name,omitempty"`
-    ExistsElsewhere     bool   `json:"exists_elsewhere,omitempty"`
-    ExistsElsewhereID   int64  `json:"exists_elsewhere_id,omitempty"`
-    ExistsElsewhereName string `json:"exists_elsewhere_name,omitempty"`
+	CIDR                string `json:"cidr"`
+	PrefixLen           int    `json:"prefix_len"`
+	Hosts               uint64 `json:"hosts"`
+	Used                bool   `json:"used"`
+	AssignedID          int64  `json:"assigned_id,omitempty"`
+	AssignedName        string `json:"assigned_name,omitempty"`
+	AssignedAccountID   int64  `json:"assigned_account_id,omitempty"`
+	AssignedAccountName string `json:"assigned_account_name,omitempty"`
+	ExistsElsewhere     bool   `json:"exists_elsewhere,omitempty"`
+	ExistsElsewhereID   int64  `json:"exists_elsewhere_id,omitempty"`
+	ExistsElsewhereName string `json:"exists_elsewhere_name,omitempty"`
 }
 
 func (s *Server) blocksForPool(w http.ResponseWriter, r *http.Request, id int64) {
 	ctx := r.Context()
-    pool, ok, err := s.store.GetPool(ctx, id)
-    if err != nil {
-        writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
-        return
-    }
-    if !ok {
-        writeErr(w, http.StatusNotFound, "not found", "pool")
-        return
-    }
-    nplStr := r.URL.Query().Get("new_prefix_len")
-    if nplStr == "" {
-        writeErr(w, http.StatusBadRequest, "new_prefix_len is required", "")
-        return
-    }
-    npl, err := strconv.Atoi(nplStr)
-    if err != nil || npl <= 0 || npl > 32 {
-        writeErr(w, http.StatusBadRequest, "invalid new_prefix_len", "")
-        return
-    }
+	pool, ok, err := s.store.GetPool(ctx, id)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
+		return
+	}
+	if !ok {
+		writeErr(w, http.StatusNotFound, "not found", "pool")
+		return
+	}
+	nplStr := r.URL.Query().Get("new_prefix_len")
+	if nplStr == "" {
+		writeErr(w, http.StatusBadRequest, "new_prefix_len is required", "")
+		return
+	}
+	npl, err := strconv.Atoi(nplStr)
+	if err != nil || npl <= 0 || npl > 32 {
+		writeErr(w, http.StatusBadRequest, "invalid new_prefix_len", "")
+		return
+	}
 	// Pagination params
 	pageSizeStr := r.URL.Query().Get("page_size")
 	pageStr := r.URL.Query().Get("page")
 	pageSize := 0 // 0 => all
-    if strings.ToLower(pageSizeStr) == "all" {
-        pageSize = 0
-    } else if pageSizeStr != "" {
-        ps, err := strconv.Atoi(pageSizeStr)
-        if err != nil || ps < 0 {
-            writeErr(w, http.StatusBadRequest, "invalid page_size", "")
-            return
-        }
-        pageSize = ps
-    }
-    page := 1
-    if pageStr != "" {
-        p, err := strconv.Atoi(pageStr)
-        if err != nil || p <= 0 {
-            writeErr(w, http.StatusBadRequest, "invalid page", "")
-            return
-        }
-        page = p
-    }
+	if strings.ToLower(pageSizeStr) == "all" {
+		pageSize = 0
+	} else if pageSizeStr != "" {
+		ps, err := strconv.Atoi(pageSizeStr)
+		if err != nil || ps < 0 {
+			writeErr(w, http.StatusBadRequest, "invalid page_size", "")
+			return
+		}
+		pageSize = ps
+	}
+	page := 1
+	if pageStr != "" {
+		p, err := strconv.Atoi(pageStr)
+		if err != nil || p <= 0 {
+			writeErr(w, http.StatusBadRequest, "invalid page", "")
+			return
+		}
+		page = p
+	}
 	// Compute blocks (IPv4 only), returning a page window if requested.
 	offset := 0
 	limit := 0
@@ -600,74 +624,82 @@ func (s *Server) blocksForPool(w http.ResponseWriter, r *http.Request, id int64)
 		limit = pageSize
 		offset = (page - 1) * pageSize
 	}
-    blocks, hosts, total, err := computeSubnetsIPv4Window(pool.CIDR, npl, offset, limit)
-    if err != nil {
-        writeErr(w, http.StatusBadRequest, err.Error(), "")
-        return
-    }
+	blocks, hosts, total, err := computeSubnetsIPv4Window(pool.CIDR, npl, offset, limit)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error(), "")
+		return
+	}
 	// Determine used blocks: exists child pool with exact CIDR match.
-    all, err := s.store.ListPools(ctx)
-    if err != nil {
-        writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
-        return
-    }
+	all, err := s.store.ListPools(ctx)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
+		return
+	}
 	type usedInfo struct {
 		id        int64
 		name      string
 		accountID *int64
 	}
-    used := map[string]usedInfo{}
-    // Collect direct children of the current pool to evaluate overlaps
-    type childPrefix struct { id int64; name string; pfx netip.Prefix; cidr string; accountID *int64 }
-    var children []childPrefix
-    for _, p := range all {
-        if p.ParentID != nil && *p.ParentID == pool.ID {
-            used[p.CIDR] = usedInfo{id: p.ID, name: p.Name, accountID: p.AccountID}
-            if pf, err := netip.ParsePrefix(p.CIDR); err == nil && pf.Addr().Is4() {
-                children = append(children, childPrefix{id:p.ID, name:p.Name, pfx:pf, cidr:p.CIDR, accountID:p.AccountID})
-            }
-        }
-    }
+	used := map[string]usedInfo{}
+	// Collect direct children of the current pool to evaluate overlaps
+	type childPrefix struct {
+		id        int64
+		name      string
+		pfx       netip.Prefix
+		cidr      string
+		accountID *int64
+	}
+	var children []childPrefix
+	for _, p := range all {
+		if p.ParentID != nil && *p.ParentID == pool.ID {
+			used[p.CIDR] = usedInfo{id: p.ID, name: p.Name, accountID: p.AccountID}
+			if pf, err := netip.ParsePrefix(p.CIDR); err == nil && pf.Addr().Is4() {
+				children = append(children, childPrefix{id: p.ID, name: p.Name, pfx: pf, cidr: p.CIDR, accountID: p.AccountID})
+			}
+		}
+	}
 	// Account id -> name map
-    accs, err := s.store.ListAccounts(ctx)
-    if err != nil {
-        writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
-        return
-    }
+	accs, err := s.store.ListAccounts(ctx)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "internal error", err.Error())
+		return
+	}
 	accName := map[int64]string{}
 	for _, a := range accs {
 		accName[a.ID] = a.Name
 	}
-    out := make([]blockInfo, 0, len(blocks))
-    for _, b := range blocks {
-        bi := blockInfo{CIDR: b, PrefixLen: npl, Hosts: hosts}
-        if info, ok := used[b]; ok {
-            bi.Used = true
-            bi.AssignedID = info.id
-            bi.AssignedName = info.name
-            if info.accountID != nil {
-                bi.AssignedAccountID = *info.accountID
-                if n, ok := accName[*info.accountID]; ok {
-                    bi.AssignedAccountName = n
-                }
-            }
-        } else {
-            // mark as unavailable if overlaps any existing direct child with a different CIDR
-            bp, err := netip.ParsePrefix(b)
-            if err == nil && bp.Addr().Is4() {
-                for _, ch := range children {
-                    if ch.cidr == b { continue }
-                    if prefixesOverlapIPv4(ch.pfx, bp) {
-                        bi.ExistsElsewhere = true
-                        bi.ExistsElsewhereID = ch.id
-                        bi.ExistsElsewhereName = ch.name
-                        break
-                    }
-                }
-            }
-        }
-        out = append(out, bi)
-    }
+	out := make([]blockInfo, 0, len(blocks))
+	for _, b := range blocks {
+		bi := blockInfo{CIDR: b, PrefixLen: npl, Hosts: hosts}
+		if info, ok := used[b]; ok {
+			bi.Used = true
+			bi.AssignedID = info.id
+			bi.AssignedName = info.name
+			if info.accountID != nil {
+				bi.AssignedAccountID = *info.accountID
+				if n, ok := accName[*info.accountID]; ok {
+					bi.AssignedAccountName = n
+				}
+			}
+		} else {
+			// mark as unavailable if overlaps any existing direct child with a different CIDR
+			bp, err := netip.ParsePrefix(b)
+			if err == nil && bp.Addr().Is4() {
+				for _, ch := range children {
+					if ch.cidr == b {
+						continue
+					}
+					if prefixesOverlapIPv4(ch.pfx, bp) {
+						bi.ExistsElsewhere = true
+						bi.ExistsElsewhereID = ch.id
+						bi.ExistsElsewhereName = ch.name
+						break
+					}
+				}
+			}
+		}
+		out = append(out, bi)
+	}
 	type resp struct {
 		Items    []blockInfo `json:"items"`
 		Total    int         `json:"total"`
@@ -707,15 +739,17 @@ func validateChildCIDR(parentCIDR, childCIDR string) error {
 
 // prefixesOverlapIPv4 returns true if two IPv4 prefixes overlap in address space.
 func prefixesOverlapIPv4(a, b netip.Prefix) bool {
-    if !a.Addr().Is4() || !b.Addr().Is4() { return false }
-    aStart := ipv4ToUint32(a.Masked().Addr())
-    aEnd, _ := lastAddr(a)
-    bStart := ipv4ToUint32(b.Masked().Addr())
-    bEnd, _ := lastAddr(b)
-    aEndU := ipv4ToUint32(aEnd)
-    bEndU := ipv4ToUint32(bEnd)
-    // Overlap if intervals intersect
-    return aEndU >= bStart && bEndU >= aStart
+	if !a.Addr().Is4() || !b.Addr().Is4() {
+		return false
+	}
+	aStart := ipv4ToUint32(a.Masked().Addr())
+	aEnd, _ := lastAddr(a)
+	bStart := ipv4ToUint32(b.Masked().Addr())
+	bEnd, _ := lastAddr(b)
+	aEndU := ipv4ToUint32(aEnd)
+	bEndU := ipv4ToUint32(bEnd)
+	// Overlap if intervals intersect
+	return aEndU >= bStart && bEndU >= aStart
 }
 
 func computeSubnetsIPv4Window(parentCIDR string, newPrefixLen int, offset, limit int) ([]string, uint64, int, error) {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -171,19 +171,19 @@ func (m *MemoryStore) CreateAccount(ctx context.Context, in domain.CreateAccount
 	defer m.mu.Unlock()
 	id := m.nextAccount
 	m.nextAccount++
-    a := domain.Account{
-        ID:          id,
-        Key:         in.Key,
-        Name:        in.Name,
-        Provider:    in.Provider,
-        ExternalID:  in.ExternalID,
-        Description: in.Description,
-        Platform:    in.Platform,
-        Tier:        in.Tier,
-        Environment: in.Environment,
-        Regions:     append([]string(nil), in.Regions...),
-        CreatedAt:   time.Now().UTC(),
-    }
+	a := domain.Account{
+		ID:          id,
+		Key:         in.Key,
+		Name:        in.Name,
+		Provider:    in.Provider,
+		ExternalID:  in.ExternalID,
+		Description: in.Description,
+		Platform:    in.Platform,
+		Tier:        in.Tier,
+		Environment: in.Environment,
+		Regions:     append([]string(nil), in.Regions...),
+		CreatedAt:   time.Now().UTC(),
+	}
 	m.accounts[id] = a
 	return a, nil
 }
@@ -198,14 +198,16 @@ func (m *MemoryStore) UpdateAccount(ctx context.Context, id int64, update domain
 	if update.Name != "" {
 		a.Name = update.Name
 	}
-    // Allow empty strings to clear optional fields
-    a.Provider = update.Provider
-    a.ExternalID = update.ExternalID
-    a.Description = update.Description
-    a.Platform = update.Platform
-    a.Tier = update.Tier
-    a.Environment = update.Environment
-    if update.Regions != nil { a.Regions = append([]string(nil), update.Regions...) }
+	// Allow empty strings to clear optional fields
+	a.Provider = update.Provider
+	a.ExternalID = update.ExternalID
+	a.Description = update.Description
+	a.Platform = update.Platform
+	a.Tier = update.Tier
+	a.Environment = update.Environment
+	if update.Regions != nil {
+		a.Regions = append([]string(nil), update.Regions...)
+	}
 	m.accounts[id] = a
 	return a, true, nil
 }

--- a/migrations/embed.go
+++ b/migrations/embed.go
@@ -3,6 +3,6 @@ package migrations
 import "embed"
 
 // Files embeds all SQL migration files in this directory.
+//
 //go:embed *.sql
 var Files embed.FS
-


### PR DESCRIPTION
CI improvements and local coverage commands.

- Add Test (race) job: runs `go test -race ./...`
- Add Coverage job: generates `coverage.out`, `coverage.txt`, `coverage.html` artifacts; enforces optional `${{ vars.COVERAGE_THRESHOLD }}`
- Makefile and Justfile targets for local coverage: `make cover`, `make test-race`, `just cover`, `just cover-threshold <percent>`
- Keeps lint runnable locally with version checks

Closes #20.
