### PR TITLE
Fix: track cmd/cloudpam entrypoint; restrict ignore to root binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ Thumbs.db
 
 # Go build/cache
 bin/
-cloudpam
+# Ignore only the root-level binary, not cmd/cloudpam/
+/cloudpam
+/cloudpam.exe
 .gocache/
 .gopath/
 .gopath/**

--- a/cmd/cloudpam/main.go
+++ b/cmd/cloudpam/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	ih "cloudpam/internal/http"
+)
+
+func main() {
+	addr := envOr("ADDR", ":8080")
+	if p := os.Getenv("PORT"); p != "" { // Heroku-style
+		addr = ":" + p
+	}
+	flag.StringVar(&addr, "addr", addr, "listen address (host:port)")
+	migrate := flag.String("migrate", "", "run migrations: 'up' to apply, 'status' to show status (sqlite builds only)")
+	flag.Parse()
+
+	// Handle migrations CLI before starting server
+	if *migrate != "" {
+		runMigrationsCLI(*migrate)
+		return
+	}
+
+	// Select storage based on build tags and env (see store_*.go in this package).
+	store := selectStore()
+
+	mux := http.NewServeMux()
+	srv := ih.NewServer(mux, store)
+	srv.RegisterRoutes()
+
+	// Wrap with simple logging middleware
+	handler := ih.LoggingMiddleware(mux)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	log.Printf("cloudpam listening on %s", addr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("server error: %v", err)
+	}
+
+	// Graceful shutdown path (not usually reached in ListenAndServe example)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = server.Shutdown(ctx)
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+// runMigrationsCLI executes migration commands (sqlite builds only).
+func runMigrationsCLI(cmd string) {
+	dsn := os.Getenv("SQLITE_DSN")
+	if dsn == "" {
+		dsn = "file:cloudpam.db?cache=shared&_fk=1"
+	}
+	switch cmd {
+	case "up":
+		// initialize store (runs migrations in sqlite build), then show status
+		_ = selectStore()
+		fallthrough
+	case "status":
+		status := "migrations status not available in this build"
+		if s := sqliteStatus(dsn); s != "" {
+			status = s
+		}
+		log.Println(status)
+	default:
+		log.Printf("unknown migrate command: %s (use 'up' or 'status')", cmd)
+	}
+}

--- a/cmd/cloudpam/store_default.go
+++ b/cmd/cloudpam/store_default.go
@@ -1,0 +1,22 @@
+//go:build !sqlite
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"cloudpam/internal/storage"
+)
+
+// selectStore returns the default storage when built without the 'sqlite' tag.
+// If SQLITE_DSN is set, we log a hint to rebuild with -tags sqlite.
+func selectStore() storage.Store {
+	if os.Getenv("SQLITE_DSN") != "" {
+		log.Printf("SQLITE_DSN set, but binary not built with -tags sqlite; using in-memory store")
+	}
+	return storage.NewMemoryStore()
+}
+
+// sqliteStatus returns schema status string when not built with sqlite tag.
+func sqliteStatus(dsn string) string { return "" }

--- a/cmd/cloudpam/store_sqlite.go
+++ b/cmd/cloudpam/store_sqlite.go
@@ -1,0 +1,36 @@
+//go:build sqlite
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"cloudpam/internal/storage"
+	sqlitestore "cloudpam/internal/storage/sqlite"
+)
+
+// selectStore returns a SQLite-backed store when built with the 'sqlite' tag.
+// Configure with env var SQLITE_DSN (e.g., file:cloudpam.db?cache=shared&_fk=1)
+func selectStore() storage.Store {
+	dsn := os.Getenv("SQLITE_DSN")
+	if dsn == "" {
+		dsn = "file:cloudpam.db?cache=shared&_fk=1"
+	}
+	st, err := sqlitestore.New(dsn)
+	if err != nil {
+		log.Printf("sqlite init failed (%v), falling back to memory store", err)
+		return storage.NewMemoryStore()
+	}
+	log.Printf("using sqlite store: %s", dsn)
+	return st
+}
+
+// sqliteStatus returns migration status when built with sqlite tag.
+func sqliteStatus(dsn string) string {
+	s, err := sqlitestore.Status(dsn)
+	if err != nil {
+		return ""
+	}
+	return s
+}


### PR DESCRIPTION
- Update .gitignore to ignore only root-level ./cloudpam and ./cloudpam.exe\n- Add cmd/cloudpam/{main.go,store_default.go,store_sqlite.go} to Git so CI can build binaries\n\nAfter merge, release tags will include the entrypoint and builds will produce artifacts across OS/arch.