### PR TITLE
CI: inline go-release (derived) + checksums + SBOM (assets attached to Releases)

### DIFF
--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -8,132 +8,76 @@ permissions:
   contents: write
 
 jobs:
-  build-matrix:
-    name: Build archives
+  build-and-upload:
+    name: Build and attach binaries
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: windows
-            goarch: amd64
-          - goos: windows
-            goarch: arm64
-
-    env:
-      GOOS: ${{ matrix.goos }}
-      GOARCH: ${{ matrix.goarch }}
-      CGO_ENABLED: 0
-      VERSION: ${{ github.event.release.tag_name }}
-      APP_VERSION: ${{ github.event.release.tag_name }}
-
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
     steps:
       - name: Checkout tag
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - name: Build and upload asset
+        uses: wangyoucao577/go-release-action@v1.52
         with:
-          go-version: '1.24.x'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goversion: '1.24.x'
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          project_path: ./cmd/cloudpam
+          binary_name: cloudpam
+          flags: -tags sqlite
+          build_flags: -trimpath
+          ldflags: -s -w
+          asset_name: cloudpam_${{ github.event.release.tag_name }}_${{ matrix.goos }}_${{ matrix.goarch }}
+          overwrite: true
 
-      - name: Show tree (debug)
-        run: |
-          pwd
-          ls -la
-          ls -la cmd || true
-          ls -la cmd/cloudpam || true
-
-      - name: Build (sqlite-enabled, static)
-        run: |
-          set -euo pipefail
-          BIN=cloudpam
-          EXT=""
-          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
-          OUT="$BIN$EXT"
-          mkdir -p build
-          echo "Building $GOOS/$GOARCH (sqlite) -> build/$OUT"
-          ENTRY="./cmd/cloudpam"
-          if [ ! -d "$ENTRY" ]; then
-            echo "fallback: ./cmd/cloudpam not found; probing for main package under ./cmd/* or root"
-            pick=""
-            if [ -d cmd ]; then
-              pick=$(for d in cmd/*; do [ -f "$d/main.go" ] && echo "$d"; done | head -n1)
-            fi
-            if [ -z "$pick" ] && [ -f main.go ]; then pick="."; fi
-            if [ -z "$pick" ]; then
-              echo "no entry point found; skipping build for $GOOS/$GOARCH"
-              mkdir -p dist
-              echo "skipped: no entry point on this ref" > dist/SKIPPED_${GOOS}_${GOARCH}.txt
-              exit 0
-            fi
-            ENTRY="$pick"
-            echo "using entry: $ENTRY"
-          fi
-          go build -trimpath -tags sqlite -ldflags "-s -w" -o "build/$OUT" "$ENTRY"
-
-      - name: Package
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-          BASE="cloudpam_${VERSION}_${GOOS}_${GOARCH}"
-          if [ ! -f build/cloudpam ] && [ ! -f build/cloudpam.exe ]; then
-            echo "no binary found; nothing to package"
-            exit 0
-          fi
-          if [ "${GOOS}" = "windows" ]; then \
-            (cd build && zip -9 "../dist/${BASE}.zip" cloudpam.exe) ; \
-          else \
-            tar -C build -czf "dist/${BASE}.tar.gz" cloudpam ; \
-          fi
-
-      - name: Checksums
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd dist
-          if compgen -G "*.tar.gz" > /dev/null || compgen -G "*.zip" > /dev/null; then
-            sha256sum * > SHA256SUMS.txt
-          fi
-
-      - name: Upload artifacts (for workflow logs)
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ format('artifacts-{0}-{1}', matrix.goos, matrix.goarch) }}
-          path: |
-            dist/*
-          if-no-files-found: ignore
-
-  attach-to-release:
-    name: Attach assets to release
-    needs: build-matrix
+  checksums:
+    name: Upload SHA256SUMS
     runs-on: ubuntu-latest
+    needs: build-and-upload
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - name: Download release assets
+        uses: robinraju/release-downloader@v1.11
         with:
-          path: dist
-
-      - name: Flatten artifact directory
+          repository: ${{ github.repository }}
+          tag: ${{ github.event.release.tag_name }}
+          fileName: "cloudpam_*"
+          out-file-path: downloads
+      - name: Generate checksums
         run: |
-          shopt -s globstar nullglob
-          mkdir -p out
-          mv dist/**/dist/* out/ || true
-          ls -la out || true
-
-      - name: Upload to GitHub Release
+          cd downloads
+          sha256sum * > SHA256SUMS.txt
+          ls -la
+      - name: Upload checksum to release
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            out/*
+          files: downloads/SHA256SUMS.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  sbom:
+    name: Upload SBOM (SPDX)
+    runs-on: ubuntu-latest
+    needs: build-and-upload
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Generate SBOM (SPDX JSON)
+        uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+      - name: Upload SBOM to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: sbom.spdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
 
 jobs:
+  # NOTE: This job re-implements the behavior of 'go-release-action' in-line
+  # (derived from wangyoucao577/go-release-action) to build and attach
+  # per-OS/arch binaries directly to the GitHub Release.
   build-and-upload:
     name: Build and attach binaries
     runs-on: ubuntu-latest
@@ -16,26 +19,53 @@ jobs:
       matrix:
         goos: [linux, darwin, windows]
         goarch: [amd64, arm64]
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      CGO_ENABLED: 0
+      VERSION: ${{ github.event.release.tag_name }}
     steps:
       - name: Checkout tag
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: Build and upload asset
-        uses: wangyoucao577/go-release-action@v1.52
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goversion: '1.24.x'
-          goos: ${{ matrix.goos }}
-          goarch: ${{ matrix.goarch }}
-          project_path: ./cmd/cloudpam
-          binary_name: cloudpam
-          flags: -tags sqlite
-          build_flags: -trimpath
-          ldflags: -s -w
-          asset_name: cloudpam_${{ github.event.release.tag_name }}_${{ matrix.goos }}_${{ matrix.goarch }}
-          overwrite: true
+          go-version: '1.24.x'
+
+      - name: Build binary (-tags sqlite)
+        run: |
+          set -euxo pipefail
+          ENTRY=./cmd/cloudpam
+          test -d "$ENTRY" || { echo "entrypoint $ENTRY not found"; exit 1; }
+          BIN=cloudpam
+          EXT=""; [ "$GOOS" = "windows" ] && EXT=".exe"
+          OUT="$BIN$EXT"
+          mkdir -p build
+          echo "Building ${GOOS}/${GOARCH} -> build/${OUT}"
+          go build -trimpath -tags sqlite -ldflags "-s -w" -o "build/${OUT}" "$ENTRY"
+
+      - name: Package archive
+        run: |
+          set -euxo pipefail
+          ASSET_BASE="cloudpam_${VERSION}_${GOOS}_${GOARCH}"
+          mkdir -p dist
+          if [ "$GOOS" = "windows" ]; then
+            (cd build && zip -9 "../dist/${ASSET_BASE}.zip" cloudpam.exe)
+          else
+            tar -C build -czf "dist/${ASSET_BASE}.tar.gz" cloudpam
+          fi
+
+      - name: Attach asset to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*.tar.gz
+            dist/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   checksums:
     name: Upload SHA256SUMS


### PR DESCRIPTION
- Re-implement go-release behavior in-line (derived from wangyoucao577/go-release-action), no third-party action dependency\n- Matrix: linux/darwin/windows on amd64/arm64; sqlite-enabled builds (-tags sqlite)\n- Package tar.gz (Unix) / zip (Windows) and attach per job to the Release\n- Add checksum aggregation job (SHA256SUMS.txt) and SBOM (SPDX JSON) upload\n\nResult: assets and integrity files are visible on the Releases tab.