### PR TITLE
UI: remove '/' search-focus shortcut to allow CIDR input

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1167,13 +1167,6 @@
             this.$watch('tab', t => { history.replaceState(null,'','#'+t); localStorage.setItem('cp.tab', t); });
           },
           onKey(ev){
-            // "/" focuses search in current tab
-            if (ev.key === '/' && !ev.ctrlKey && !ev.metaKey) {
-              ev.preventDefault();
-              if (this.tab==='pools') this.$root.querySelector('[x-ref=poolSearch]')?.focus();
-              if (this.tab==='analytics') this.$root.querySelector('[x-ref=analyticsSearch]')?.focus();
-              return;
-            }
             // Paging shortcuts on pools blocks view
             if (this.tab==='pools') {
               const poolsCmp = this.$root.__x?.$data?.tab==='pools' ? this.$root.querySelector('section[x-data]')?.__x?.$data : null;


### PR DESCRIPTION
Fix: Remove global '/' keybinding that forced focus to search, which prevented typing CIDRs (e.g., 10.0.0.0/24).\n\n- Change: Delete '/' handler in web/index.html () so it no longer hijacks input.\n- Retain: Other shortcuts (j/k/g/G) for paging in pools view.\n\nTesting: Run `make dev` and verify typing a CIDR in fields no longer jumps to search.\n\nNo server changes; UI-only.