### PR TITLE
feat: add Nix flake with git-aware dev shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,10 @@ coverage*
 # Planning documents and mockups (local only, not committed)
 .planning/
 
+# Nix
+result
+result-*
+.direnv/
+
 # Claude Code local config
 .claude/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770781623,
+        "narHash": "sha256-RYEMTlGCVc67pxVxjOlGd8w6fpF7Bur7gKL88FB0WTs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c05d2232d2feaa4c7a07f1168606917402868195",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "CloudPAM – IP Address Management platform";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        # Derive version from the git revision so every build is traceable.
+        version =
+          if self ? rev
+          then self.rev
+          else self.dirtyRev or "dirty";
+
+        shortRev =
+          if self ? shortRev
+          then self.shortRev
+          else "dirty";
+      in
+      {
+        packages = {
+          default = pkgs.buildGoModule.override { go = pkgs.go_1_24; } {
+            pname = "cloudpam";
+            inherit version;
+            src = self;
+
+            vendorHash = "sha256-VXVgoHG6LYGJtix45h439OZTg/UHQtco0MSsoma6GJc=";
+
+            tags = [ "sqlite" ];
+            ldflags = [
+              "-s" "-w"
+              "-X main.version=${version}"
+              "-X main.gitCommit=${shortRev}"
+            ];
+
+            env.CGO_ENABLED = 0;
+
+            subPackages = [ "cmd/cloudpam" ];
+
+            meta = with pkgs.lib; {
+              description = "Intelligent IP Address Management platform";
+              homepage = "https://github.com/BadgerOps/cloudpam";
+              license = licenses.mit;
+              mainProgram = "cloudpam";
+            };
+          };
+
+          # OCI / Docker image built from the Nix derivation.
+          docker = pkgs.dockerTools.buildLayeredImage {
+            name = "cloudpam";
+            tag = shortRev;
+            contents = [ self.packages.${system}.default pkgs.cacert pkgs.tzdata ];
+            config = {
+              Entrypoint = [ "/bin/cloudpam" ];
+              ExposedPorts."8080/tcp" = {};
+              Env = [ "TZ=UTC" ];
+            };
+          };
+        };
+
+        # Development shell with Go, Just, linting tools, and git-aware prompt.
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            go_1_24
+            just
+            golangci-lint
+            gopls
+            gotools
+            delve
+            docker-client
+            git
+          ];
+
+          shellHook = ''
+            # Git-aware PS1: shows branch, short commit, and dirty state.
+            __cloudpam_ps1() {
+              local branch commit dirty
+              branch=$(git symbolic-ref --short HEAD 2>/dev/null || git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
+              if [ -n "$branch" ]; then
+                commit=$(git rev-parse --short HEAD 2>/dev/null)
+                dirty=""
+                if ! git diff --quiet HEAD -- 2>/dev/null; then
+                  dirty="*"
+                fi
+                echo " ($branch@$commit$dirty)"
+              fi
+            }
+            export PS1='\[\033[1;34m\]cloudpam\[\033[0;33m\]$(__cloudpam_ps1)\[\033[0m\] \w \$ '
+            echo "cloudpam dev shell – Go $(go version | awk '{print $3}')"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
- Add a Nix flake providing reproducible builds (`nix build`), OCI images (`nix build .#docker`), and a dev shell (`nix develop`)
- Dev shell includes Go 1.24, just, golangci-lint, gopls, gotools, delve, docker-client, and git with a git-aware PS1 prompt showing branch, commit, and dirty state
- `.gitignore` updated to exclude `result/`, `result-*`, and `.direnv/`

## Test plan
- [ ] `nix build` produces a working `cloudpam` binary
- [ ] `nix build .#docker` produces an OCI image tagged with the short git rev
- [ ] `nix develop` drops into a shell with Go 1.24 and tools available
- [ ] PS1 shows `cloudpam (branch@commit)` with `*` for dirty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)