### PR TITLE
Sprint 9: SQLite feature parity & CI multi-backend testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,80 @@ jobs:
       - name: Test with -race
         run: go test -race ./... -v
 
+  test-sqlite:
+    name: SQLite Tests (race)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-sqlite-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-sqlite-
+            ${{ runner.os }}-go-
+
+      - name: Build (SQLite)
+        run: go build -tags sqlite ./...
+
+      - name: Test with -race (SQLite)
+        run: go test -tags sqlite -race ./... -v
+
+  test-postgres:
+    name: PostgreSQL Tests (race)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: cloudpam_test
+          POSTGRES_USER: cloudpam
+          POSTGRES_PASSWORD: cloudpam
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://cloudpam:cloudpam@localhost:5432/cloudpam_test?sslmode=disable
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-postgres-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-postgres-
+            ${{ runner.os }}-go-
+
+      - name: Build (PostgreSQL)
+        run: go build -tags postgres ./...
+
+      - name: Test with -race (PostgreSQL)
+        run: go test -tags postgres -race ./... -v
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added - Sprint 9: SQLite Feature Parity & CI Multi-Backend Testing
+
+#### SQLite Schema Parity
+- Migration `0006_organizations_roles_permissions.sql`: backport 5 tables from PostgreSQL schema
+  - `organizations` table with default org seed data (id=1, 'Default', 'default', 'free')
+  - `roles` table with 4 built-in roles: admin (10), operator (20), viewer (30), auditor (40)
+  - `permissions` table with 16 granular permissions (pools/accounts/apikeys/audit CRUD)
+  - `role_permissions` junction table with correct mappings per role
+  - `pool_utilization_cache` table for cached stats
+- `ALTER TABLE accounts ADD COLUMN updated_at` for account modification tracking
+
+#### Bug Fixes
+- Fix `GetAccount` in SQLite store scanning only 7 columns instead of 12 — was silently
+  dropping platform, tier, environment, regions, and updated_at fields (#69 follow-up)
+- Add `updated_at` field to `domain.Account` struct for consistency across all backends
+- Update account queries in all 3 backends (in-memory, SQLite, PostgreSQL) to read/write `updated_at`
+
+#### CI: Multi-Backend Testing
+- New `test-sqlite` CI job: runs `go test -tags sqlite -race` on every push/PR
+- New `test-postgres` CI job: PostgreSQL 16 service container with `DATABASE_URL` env var,
+  runs `go test -tags postgres -race` — no testcontainers overhead in CI
+
+#### Issue Housekeeping
+- Closed 7 previously-resolved issues: #22 (modal a11y), #26 (API auth), #37 (Docker build),
+  #68 (server.go refactor), #69 (error handling), #70 (UpdatePoolMeta), #92 (RBAC decision)
+
 ### Added - Sprint 8: PostgreSQL Storage Backend
 
 #### PostgreSQL Store (`-tags postgres`)

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -154,6 +154,7 @@ type Account struct {
 	Environment string    `json:"environment,omitempty"`
 	Regions     []string  `json:"regions,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 // CreateAccount is the input for creating an account.

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -249,6 +249,7 @@ func (m *MemoryStore) CreateAccount(ctx context.Context, in domain.CreateAccount
 	defer m.mu.Unlock()
 	id := m.nextAccount
 	m.nextAccount++
+	now := time.Now().UTC()
 	a := domain.Account{
 		ID:          id,
 		Key:         in.Key,
@@ -260,7 +261,8 @@ func (m *MemoryStore) CreateAccount(ctx context.Context, in domain.CreateAccount
 		Tier:        in.Tier,
 		Environment: in.Environment,
 		Regions:     append([]string(nil), in.Regions...),
-		CreatedAt:   time.Now().UTC(),
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
 	m.accounts[id] = a
 	return a, nil
@@ -286,6 +288,7 @@ func (m *MemoryStore) UpdateAccount(ctx context.Context, id int64, update domain
 	if update.Regions != nil {
 		a.Regions = append([]string(nil), update.Regions...)
 	}
+	a.UpdatedAt = time.Now().UTC()
 	m.accounts[id] = a
 	return a, true, nil
 }

--- a/migrations/0006_organizations_roles_permissions.sql
+++ b/migrations/0006_organizations_roles_permissions.sql
@@ -1,0 +1,129 @@
+-- Organizations, roles, permissions for SQLite feature parity with PostgreSQL
+-- Backport of tables from migrations/postgres/001_core_schema.up.sql
+
+-- =============================================================================
+-- Organizations (multi-tenancy root)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS organizations (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name       TEXT NOT NULL,
+    slug       TEXT NOT NULL UNIQUE,
+    plan       TEXT NOT NULL DEFAULT 'free',
+    settings   TEXT NOT NULL DEFAULT '{}',
+    created_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+-- Default organization for single-tenant deployments
+INSERT OR IGNORE INTO organizations (id, name, slug, plan)
+VALUES (1, 'Default', 'default', 'free');
+
+-- =============================================================================
+-- Roles (RBAC)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS roles (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization_id INTEGER REFERENCES organizations(id),
+    name            TEXT NOT NULL,
+    description     TEXT,
+    is_builtin      INTEGER NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at      TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_roles_org_name
+    ON roles (COALESCE(organization_id, 0), name);
+
+-- =============================================================================
+-- Permissions
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS permissions (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    description TEXT,
+    category    TEXT NOT NULL
+);
+
+-- =============================================================================
+-- Role-Permission Mapping
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id       INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    permission_id TEXT NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+    PRIMARY KEY (role_id, permission_id)
+);
+
+-- =============================================================================
+-- Pool Utilization Cache
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS pool_utilization_cache (
+    pool_id             INTEGER PRIMARY KEY REFERENCES pools(id) ON DELETE CASCADE,
+    total_addresses     INTEGER NOT NULL,
+    allocated_addresses INTEGER NOT NULL DEFAULT 0,
+    child_count         INTEGER NOT NULL DEFAULT 0,
+    updated_at          TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+-- =============================================================================
+-- Add updated_at to accounts table
+-- =============================================================================
+
+ALTER TABLE accounts ADD COLUMN updated_at TIMESTAMP DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'));
+
+-- =============================================================================
+-- Seed Data: Built-in Permissions
+-- =============================================================================
+
+INSERT OR IGNORE INTO permissions (id, name, description, category) VALUES
+    ('pools:create', 'Create Pools', 'Create new IP address pools', 'pools'),
+    ('pools:read', 'Read Pools', 'View pool details and listings', 'pools'),
+    ('pools:update', 'Update Pools', 'Modify pool properties', 'pools'),
+    ('pools:delete', 'Delete Pools', 'Delete pools', 'pools'),
+    ('pools:list', 'List Pools', 'List all pools', 'pools'),
+    ('accounts:create', 'Create Accounts', 'Create new cloud accounts', 'accounts'),
+    ('accounts:read', 'Read Accounts', 'View account details', 'accounts'),
+    ('accounts:update', 'Update Accounts', 'Modify account properties', 'accounts'),
+    ('accounts:delete', 'Delete Accounts', 'Delete accounts', 'accounts'),
+    ('accounts:list', 'List Accounts', 'List all accounts', 'accounts'),
+    ('apikeys:create', 'Create API Keys', 'Create new API keys', 'apikeys'),
+    ('apikeys:read', 'Read API Keys', 'View API key details', 'apikeys'),
+    ('apikeys:delete', 'Delete API Keys', 'Revoke or delete API keys', 'apikeys'),
+    ('apikeys:list', 'List API Keys', 'List all API keys', 'apikeys'),
+    ('audit:read', 'Read Audit Logs', 'View audit log entries', 'audit'),
+    ('audit:list', 'List Audit Logs', 'List audit log entries', 'audit');
+
+-- =============================================================================
+-- Seed Data: Built-in Roles
+-- =============================================================================
+
+-- Use well-known IDs: admin=10, operator=20, viewer=30, auditor=40
+INSERT OR IGNORE INTO roles (id, organization_id, name, description, is_builtin) VALUES
+    (10, NULL, 'admin', 'Full access to all resources', 1),
+    (20, NULL, 'operator', 'Read/write pools and accounts', 1),
+    (30, NULL, 'viewer', 'Read-only access to pools and accounts', 1),
+    (40, NULL, 'auditor', 'Access to audit logs only', 1);
+
+-- Admin: all permissions
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT 10, id FROM permissions;
+
+-- Operator: pools + accounts (all actions)
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT 20, id FROM permissions WHERE category IN ('pools', 'accounts');
+
+-- Viewer: pools:read, pools:list, accounts:read, accounts:list
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES
+    (30, 'pools:read'),
+    (30, 'pools:list'),
+    (30, 'accounts:read'),
+    (30, 'accounts:list');
+
+-- Auditor: audit:read, audit:list
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES
+    (40, 'audit:read'),
+    (40, 'audit:list');


### PR DESCRIPTION
## Summary

- Backport organizations/roles/permissions tables from PostgreSQL to SQLite via migration `0006`
- Fix `GetAccount` bug in SQLite store that silently dropped 5 fields (platform, tier, environment, regions, updated_at)
- Add `Account.UpdatedAt` field to domain model, update queries in all 3 storage backends
- Add CI test jobs for SQLite (`-tags sqlite`) and PostgreSQL (`-tags postgres` with service container)
- Close 7 previously-resolved GitHub issues

### Files Created (1)
| File | Purpose |
|------|---------|
| `migrations/0006_organizations_roles_permissions.sql` | SQLite schema parity: organizations, roles, permissions, role_permissions, pool_utilization_cache tables + seed data |

### Files Modified (6)
| File | Change |
|------|--------|
| `internal/domain/types.go` | Add `UpdatedAt` field to `Account` struct |
| `internal/storage/sqlite/sqlite.go` | Fix `GetAccount` to scan all 12 columns; add `updated_at` to all account queries |
| `internal/storage/store.go` | Set `UpdatedAt` in MemoryStore `CreateAccount`/`UpdateAccount` |
| `internal/storage/postgres/postgres.go` | Add `updated_at` to account queries and `scanAccount` |
| `.github/workflows/test.yml` | Add `test-sqlite` and `test-postgres` CI jobs |
| `docs/CHANGELOG.md` | Sprint 9 changelog entry |

### Issues Closed
- #22 Modal accessibility (Sprint 6)
- #26 API AuthN/Z with roles (Sprints 4+7+8)
- #37 Docker multi-stage build (Sprint 6)
- #68 Refactor large handler file (Sprint 6)
- #69 Standardize error handling (Sprint 6)
- #70 Fix '|| true' in UpdatePoolMeta (Sprint 6)
- #92 ABAC vs RBAC decision (Sprint 7)

## Test plan
- [x] `go test ./...` — in-memory tests pass
- [x] `go test -tags sqlite ./...` — SQLite tests pass (includes new migration)
- [x] `go test -tags postgres ./...` — all 28 PostgreSQL tests pass
- [x] `go build && go build -tags sqlite && go build -tags postgres` — all three compile
- [ ] CI: verify test-sqlite and test-postgres jobs run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)