### PR TITLE
feat: agent consumes provisioning bundle with bootstrap token

### DIFF
--- a/cmd/cloudpam-agent/main.go
+++ b/cmd/cloudpam-agent/main.go
@@ -56,6 +56,21 @@ func main() {
 	// Create pusher
 	pusher := NewPusher(cfg.ServerURL, cfg.APIKey, agentID, cfg.RequestTimeout, logger)
 
+	// Register with server if bootstrapped from a provisioning token
+	if cfg.Bootstrapped {
+		logger.Info("registering with server (bootstrap token)")
+		regResp, err := pusher.Register(context.Background(), cfg.AgentName, cfg.AccountID, version, hostname)
+		if err != nil {
+			logger.Error("agent registration failed", "error", err)
+			os.Exit(1)
+		}
+		logger.Info("agent registered",
+			"agent_id", regResp.AgentID,
+			"approval_status", regResp.ApprovalStatus,
+			"message", regResp.Message,
+		)
+	}
+
 	// Create AWS collector
 	collector := aws.New()
 

--- a/deploy/terraform/aws-discovery/main.tf
+++ b/deploy/terraform/aws-discovery/main.tf
@@ -1,0 +1,181 @@
+# CloudPAM Discovery Agent — AWS IAM Configuration
+#
+# Creates the IAM role and policy needed for the cloudpam-agent to discover
+# VPCs, subnets, and Elastic IPs. Supports two modes:
+#
+#   1. EKS IRSA — set oidc_provider_arn, oidc_provider_url, namespace, service_account_name
+#   2. EC2 instance profile — leave OIDC vars empty (defaults)
+#
+# Usage:
+#   terraform init
+#   terraform apply -var="oidc_provider_arn=arn:aws:iam::123456789012:oidc-provider/..." \
+#                   -var="namespace=cloudpam" -var="service_account_name=cloudpam-agent"
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}
+
+# ---------- Variables ----------
+
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+  default     = "cloudpam-discovery"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    ManagedBy = "terraform"
+    Component = "cloudpam-discovery"
+  }
+}
+
+# EKS IRSA variables (leave empty for EC2 instance profile mode)
+variable "oidc_provider_arn" {
+  description = "ARN of the EKS OIDC provider (e.g. arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE). Leave empty for EC2 mode."
+  type        = string
+  default     = ""
+}
+
+variable "oidc_provider_url" {
+  description = "URL of the EKS OIDC provider without https:// (e.g. oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE). Leave empty for EC2 mode."
+  type        = string
+  default     = ""
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace where the agent runs (IRSA mode only)"
+  type        = string
+  default     = "cloudpam"
+}
+
+variable "service_account_name" {
+  description = "Kubernetes service account name for the agent (IRSA mode only)"
+  type        = string
+  default     = "cloudpam-agent"
+}
+
+# ---------- IAM Policy ----------
+
+data "aws_iam_policy_document" "discovery" {
+  statement {
+    sid    = "CloudPAMDiscoveryReadOnly"
+    effect = "Allow"
+
+    actions = [
+      "ec2:DescribeVpcs",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeAddresses",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "discovery" {
+  name        = "${var.name_prefix}-policy"
+  description = "Read-only EC2 networking permissions for CloudPAM discovery agent"
+  policy      = data.aws_iam_policy_document.discovery.json
+  tags        = var.tags
+}
+
+# ---------- Trust Policy ----------
+
+locals {
+  use_irsa = var.oidc_provider_arn != ""
+}
+
+# IRSA trust policy (EKS pods)
+data "aws_iam_policy_document" "irsa_trust" {
+  count = local.use_irsa ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.oidc_provider_url}:sub"
+      values   = ["system:serviceaccount:${var.namespace}:${var.service_account_name}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.oidc_provider_url}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+# EC2 trust policy (instance profile)
+data "aws_iam_policy_document" "ec2_trust" {
+  count = local.use_irsa ? 0 : 1
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+# ---------- IAM Role ----------
+
+resource "aws_iam_role" "discovery" {
+  name               = "${var.name_prefix}-role"
+  assume_role_policy = local.use_irsa ? data.aws_iam_policy_document.irsa_trust[0].json : data.aws_iam_policy_document.ec2_trust[0].json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "discovery" {
+  role       = aws_iam_role.discovery.name
+  policy_arn = aws_iam_policy.discovery.arn
+}
+
+# ---------- EC2 Instance Profile (non-IRSA only) ----------
+
+resource "aws_iam_instance_profile" "discovery" {
+  count = local.use_irsa ? 0 : 1
+  name  = "${var.name_prefix}-instance-profile"
+  role  = aws_iam_role.discovery.name
+  tags  = var.tags
+}
+
+# ---------- Outputs ----------
+
+output "role_arn" {
+  description = "IAM role ARN — use as IRSA annotation or attach to EC2 instances"
+  value       = aws_iam_role.discovery.arn
+}
+
+output "policy_arn" {
+  description = "IAM policy ARN"
+  value       = aws_iam_policy.discovery.arn
+}
+
+output "instance_profile_name" {
+  description = "EC2 instance profile name (only created in EC2 mode)"
+  value       = local.use_irsa ? null : aws_iam_instance_profile.discovery[0].name
+}
+
+output "helm_set_annotation" {
+  description = "Helm --set flag for IRSA role annotation"
+  value       = local.use_irsa ? "--set serviceAccount.annotations.\"eks\\.amazonaws\\.com/role-arn\"=${aws_iam_role.discovery.arn}" : null
+}

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -6,15 +6,22 @@ CloudPAM's discovery subsystem automatically finds VPCs, subnets, and Elastic IP
 
 Discovery follows an **approval workflow**: resources are discovered and stored separately from your pool hierarchy. You decide which resources to import by explicitly linking them to pools. This means discovery never modifies your existing IPAM data without your action.
 
+There are two ways to run discovery:
+
+| Mode | How | Best For |
+|------|-----|----------|
+| **Server-side sync** | Click "Sync Now" or `POST /api/v1/discovery/sync` | Quick setup, CloudPAM server has cloud credentials |
+| **Standalone agent** | Deploy `cloudpam-agent` near your cloud resources | Production, multi-region, least-privilege |
+
 ```
 ┌──────────────┐     ┌──────────────┐     ┌──────────────────────┐
-│ Cloud Account│────▶│  Collector   │────▶│ Discovered Resources │
+│ Cloud Account│────>│  Collector   │────>│ Discovered Resources │
 │ (AWS/GCP/Az) │     │ (API calls)  │     │  (stored separately) │
 └──────────────┘     └──────────────┘     └───────────┬──────────┘
                                                       │
                                               user action: link
                                                       │
-                                                      ▼
+                                                      v
                                           ┌──────────────────────┐
                                           │    CloudPAM Pool     │
                                           │ (your IPAM hierarchy)│
@@ -23,7 +30,7 @@ Discovery follows an **approval workflow**: resources are discovered and stored 
 
 ### Sync Lifecycle
 
-1. **Trigger** — you click "Sync Now" in the UI or call `POST /api/v1/discovery/sync`
+1. **Trigger** — you click "Sync Now" in the UI, call `POST /api/v1/discovery/sync`, or the agent runs on its schedule
 2. **Discover** — the collector calls cloud APIs to enumerate resources
 3. **Upsert** — new resources are created; existing resources are updated with latest data
 4. **Mark stale** — resources not seen in this run are marked `stale` (they may have been deleted from the cloud)
@@ -70,6 +77,7 @@ The pool's CIDR should match (or contain) the resource's CIDR for the associatio
    | Shared credentials file | `~/.aws/credentials` with a `[default]` profile |
    | EC2 instance profile | Runs on EC2 with an attached IAM role |
    | ECS task role | Runs in ECS with a task IAM role |
+   | EKS IRSA | EKS pod with IAM Roles for Service Accounts |
    | SSO / `aws sso login` | Configure with `aws configure sso` |
 
 ### Required IAM Permissions
@@ -93,6 +101,8 @@ The collector needs read-only access to EC2 networking resources:
 }
 ```
 
+A ready-to-use Terraform module is available in `deploy/terraform/aws-discovery/`. See [Terraform Example](#terraform-example) below.
+
 ### What Gets Discovered
 
 | Resource Type | AWS API | Fields Captured |
@@ -103,11 +113,185 @@ The collector needs read-only access to EC2 networking resources:
 
 Tags from all resources are extracted. The `Name` tag becomes the resource's display name.
 
+## Standalone Discovery Agent
+
+The `cloudpam-agent` binary runs alongside your cloud resources and pushes discovered data to the CloudPAM server. This is the recommended approach for production: the agent runs with minimal IAM permissions in your cloud environment, while the CloudPAM server stays outside your cloud boundary.
+
+### Agent Architecture
+
+```
+┌─────────────────────────────┐          ┌─────────────────────────┐
+│       Your AWS Account      │          │    CloudPAM Server      │
+│                             │          │                         │
+│  ┌───────────────────────┐  │  HTTPS   │  POST /discovery/ingest │
+│  │   cloudpam-agent      │──┼─────────>│  POST /agents/heartbeat │
+│  │  - AWS SDK creds      │  │          │  POST /agents/register  │
+│  │  - Bootstrap token    │  │          │                         │
+│  └───────────────────────┘  │          └─────────────────────────┘
+└─────────────────────────────┘
+```
+
+### Quick Start (Bootstrap Token)
+
+The fastest way to deploy an agent is with a **provisioning bundle** — a single base64-encoded token that contains the agent's name, API key, and server URL.
+
+**Step 1: Provision the agent** (on the CloudPAM server)
+
+```bash
+curl -X POST http://localhost:8080/api/v1/discovery/agents/provision \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "prod-us-east-1"}'
+```
+
+Response:
+
+```json
+{
+  "agent_name": "prod-us-east-1",
+  "api_key": "cpk_abc123...",
+  "api_key_id": "key-uuid",
+  "server_url": "http://localhost:8080",
+  "token": "eyJhZ2VudF9uYW1lIjoi..."
+}
+```
+
+Save the `token` value — it's shown only once.
+
+**Step 2: Deploy the agent** with just two environment variables:
+
+```bash
+CLOUDPAM_BOOTSTRAP_TOKEN=eyJhZ2VudF9uYW1lIjoi... \
+CLOUDPAM_ACCOUNT_ID=1 \
+./cloudpam-agent
+```
+
+The agent will:
+1. Decode the token to extract `server_url`, `api_key`, and `agent_name`
+2. Register itself with the server (`POST /api/v1/discovery/agents/register`)
+3. Start the discovery loop (default: every 15 minutes)
+4. Send heartbeats (default: every 1 minute)
+
+### Manual Configuration (Without Token)
+
+You can also configure the agent explicitly using environment variables or a YAML config file. In this mode the agent skips registration and starts discovery immediately.
+
+**Environment variables:**
+
+```bash
+CLOUDPAM_SERVER_URL=https://cloudpam.example.com \
+CLOUDPAM_API_KEY=cpk_abc123... \
+CLOUDPAM_AGENT_NAME=prod-us-east-1 \
+CLOUDPAM_ACCOUNT_ID=1 \
+CLOUDPAM_AWS_REGIONS=us-east-1,us-west-2 \
+./cloudpam-agent
+```
+
+**YAML config file:**
+
+```yaml
+# agent.yaml
+server_url: https://cloudpam.example.com
+api_key: cpk_abc123...
+agent_name: prod-us-east-1
+account_id: 1
+aws_regions:
+  - us-east-1
+  - us-west-2
+sync_interval: 15m
+heartbeat_interval: 1m
+```
+
+```bash
+./cloudpam-agent -config agent.yaml
+```
+
+### Configuration Reference
+
+| Field | Env Var | Default | Description |
+|-------|---------|---------|-------------|
+| `server_url` | `CLOUDPAM_SERVER_URL` | (required) | CloudPAM server URL |
+| `api_key` | `CLOUDPAM_API_KEY` | (required) | API key with `discovery:write` scope |
+| `agent_name` | `CLOUDPAM_AGENT_NAME` | (required) | Human-readable agent name |
+| `account_id` | `CLOUDPAM_ACCOUNT_ID` | (required) | CloudPAM account ID to discover for |
+| `bootstrap_token` | `CLOUDPAM_BOOTSTRAP_TOKEN` | | Base64 provisioning bundle (replaces server_url, api_key, agent_name) |
+| `aws_regions` | `CLOUDPAM_AWS_REGIONS` | SDK default | Comma-separated AWS regions |
+| `sync_interval` | `CLOUDPAM_SYNC_INTERVAL` | `15m` | How often to run discovery |
+| `heartbeat_interval` | `CLOUDPAM_HEARTBEAT_INTERVAL` | `1m` | How often to send heartbeats |
+| `max_retries` | | `3` | Push retry attempts on server error |
+| `retry_backoff` | | `5s` | Initial retry delay (exponential) |
+| `request_timeout` | | `30s` | HTTP request timeout |
+
+When `bootstrap_token` is set and `api_key` is not, the token is decoded and its fields populate `server_url`, `api_key`, and `agent_name`. If `api_key` is set explicitly, the token is ignored.
+
+### Deploying with Docker
+
+```bash
+docker build -f deploy/docker/Dockerfile.agent -t cloudpam-agent .
+
+docker run -e CLOUDPAM_BOOTSTRAP_TOKEN=eyJhZ2VudF9uYW1lIjoi... \
+           -e CLOUDPAM_ACCOUNT_ID=1 \
+           -e AWS_REGION=us-east-1 \
+           cloudpam-agent
+```
+
+### Deploying with Helm (Kubernetes)
+
+A Helm chart is available in `deploy/helm/cloudpam-agent/`:
+
+```bash
+helm install cloudpam-agent deploy/helm/cloudpam-agent/ \
+  --set config.serverUrl=https://cloudpam.example.com \
+  --set config.accountId=1 \
+  --set config.awsRegions='{us-east-1,us-west-2}' \
+  --set apiKey=cpk_abc123... \
+  --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::123456789012:role/cloudpam-discovery
+```
+
+### Agent Health & Monitoring
+
+Agents send periodic heartbeats. Their health status is computed based on last heartbeat:
+
+| Status | Meaning |
+|--------|---------|
+| `healthy` | Heartbeat received within the last 5 minutes |
+| `stale` | No heartbeat for 5-15 minutes |
+| `offline` | No heartbeat for over 15 minutes |
+
+View agent status in the **Agents** tab on the Discovery page, or via:
+
+```bash
+curl http://localhost:8080/api/v1/discovery/agents
+```
+
+## Terraform Example
+
+The `deploy/terraform/aws-discovery/` directory contains a Terraform module that creates the IAM role and policy needed for the discovery agent. It supports both EC2 instance profiles and EKS IRSA (IAM Roles for Service Accounts).
+
+```bash
+cd deploy/terraform/aws-discovery
+
+# For EKS IRSA
+terraform init
+terraform apply \
+  -var="oidc_provider_arn=arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE" \
+  -var="oidc_provider_url=oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE" \
+  -var="namespace=cloudpam" \
+  -var="service_account_name=cloudpam-agent"
+
+# For EC2 instance profile (no OIDC vars needed)
+terraform init
+terraform apply
+```
+
+The module outputs the IAM role ARN, which you pass to the Helm chart or attach to your EC2 instances.
+
+See `deploy/terraform/aws-discovery/main.tf` for the full configuration.
+
 ## API Reference
 
 All discovery endpoints require `account_id` and support RBAC when auth is enabled.
 
-### Trigger a Sync
+### Trigger a Sync (Server-Side)
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/discovery/sync \
@@ -174,21 +358,99 @@ curl 'http://localhost:8080/api/v1/discovery/sync?account_id=1&limit=10'
 curl http://localhost:8080/api/v1/discovery/sync/{job-uuid}
 ```
 
+### Provision an Agent
+
+Creates an API key and returns a bootstrap token for agent deployment.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/discovery/agents/provision \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "prod-us-east-1"}'
+```
+
+### Register an Agent
+
+Called by the agent on first startup (when using a bootstrap token). Not typically called manually.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/discovery/agents/register \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer cpk_abc123...' \
+  -d '{
+    "agent_id": "uuid",
+    "name": "prod-us-east-1",
+    "account_id": 1,
+    "version": "dev",
+    "hostname": "ip-10-0-1-42"
+  }'
+```
+
+### Agent Heartbeat
+
+Sent periodically by the agent. Not typically called manually.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/discovery/agents/heartbeat \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer cpk_abc123...' \
+  -d '{
+    "agent_id": "uuid",
+    "name": "prod-us-east-1",
+    "account_id": 1,
+    "version": "dev",
+    "hostname": "ip-10-0-1-42"
+  }'
+```
+
+### List Agents
+
+```bash
+curl 'http://localhost:8080/api/v1/discovery/agents'
+curl 'http://localhost:8080/api/v1/discovery/agents?account_id=1'
+```
+
+### Approve / Reject an Agent
+
+```bash
+# Approve
+curl -X POST http://localhost:8080/api/v1/discovery/agents/{agent-uuid}/approve
+
+# Reject
+curl -X POST http://localhost:8080/api/v1/discovery/agents/{agent-uuid}/reject
+```
+
+### Ingest Resources (Agent Push)
+
+Called by the agent to push discovered resources. Not typically called manually.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/discovery/ingest \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer cpk_abc123...' \
+  -d '{
+    "account_id": 1,
+    "agent_id": "uuid",
+    "resources": [...]
+  }'
+```
+
 ## RBAC Permissions
 
 When `CLOUDPAM_AUTH_ENABLED=true`, discovery endpoints require the `discovery` resource permission:
 
 | Action | Required Permission | Roles |
 |--------|-------------------|-------|
-| List resources, view sync jobs | `discovery:read` | admin, operator, viewer |
-| Trigger sync, link/unlink | `discovery:create` / `discovery:update` | admin, operator |
+| List resources, view sync jobs, list agents | `discovery:read` | admin, operator, viewer |
+| Trigger sync, provision agents | `discovery:create` | admin, operator |
+| Link/unlink, approve/reject agents | `discovery:update` | admin, operator |
 
 ## Frontend
 
-The Discovery page is at `/discovery` in the CloudPAM UI. It has two tabs:
+The Discovery page is at `/discovery` in the CloudPAM UI. It has three tabs:
 
 - **Resources** — table of discovered cloud resources with search + filters (type, status, linked). Click the link/unlink icons in the Actions column to manage pool associations.
 - **Sync History** — table of past sync jobs showing status, timing, and resource counts.
+- **Agents** — table of registered discovery agents with health status, version, hostname, and last heartbeat time. Auto-refreshes every 30 seconds.
 
 Select a cloud account from the dropdown, then click **Sync Now** to run discovery.
 
@@ -215,18 +477,24 @@ Each cloud provider implements this interface. The AWS collector is registered a
 4. Marks resources not seen in this run as stale
 5. Updates the `SyncJob` with final counts and status
 
+The same `ProcessResources()` method is used by both server-side sync and agent ingest, ensuring consistent resource handling regardless of discovery mode.
+
 ### Storage
 
-Discovery data lives in two tables (`migrations/0008_discovered_resources.sql`):
+Discovery data lives in these tables:
 
-- `discovered_resources` — cloud resources with UUID primary keys, unique on (resource_id, account_id)
-- `sync_jobs` — sync run history with UUID primary keys
+| Table | Migration | Purpose |
+|-------|-----------|---------|
+| `discovered_resources` | `0008_discovered_resources.sql` | Cloud resources with UUID PKs, unique on (resource_id, account_id) |
+| `sync_jobs` | `0008_discovered_resources.sql` | Sync run history with source (local/agent) and agent_id |
+| `discovery_agents` | `0009_discovery_agents.sql` | Registered agents with version, hostname, last_seen_at |
+| (approval columns) | `0010_agent_registration.sql` | Agent approval workflow: status, registered_at, approved_at |
 
-The `DiscoveryStore` interface (`internal/storage/discovery.go`) defines 11 methods. Implementations exist for in-memory and SQLite backends.
+The `DiscoveryStore` interface (`internal/storage/discovery.go`) defines 15 methods. Implementations exist for in-memory and SQLite backends.
 
 ## Adding a New Cloud Provider
 
-To add GCP or Azure discovery (Sprint 14):
+To add GCP or Azure discovery:
 
 1. Create `internal/discovery/gcp/collector.go` (or `azure/`)
 2. Implement the `Collector` interface

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -666,21 +666,29 @@ function AgentsTab({
             <p className="font-medium text-gray-900 dark:text-gray-100 mb-2">
               Quick Start:
             </p>
-            <ol className="list-decimal pl-5 space-y-1">
+            <ol className="list-decimal pl-5 space-y-2">
               <li>
-                Create an API key with <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">discovery:create</code> scope
+                Provision an agent via the API:
+                <pre className="mt-1 bg-gray-100 dark:bg-gray-800 rounded px-2 py-1.5 text-xs font-mono overflow-x-auto whitespace-pre">
+{`curl -X POST /api/v1/discovery/agents/provision \\
+  -H 'Content-Type: application/json' \\
+  -d '{"name": "my-agent"}'`}
+                </pre>
               </li>
               <li>
-                Deploy the agent with environment variables:{' '}
-                <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
-                  CLOUDPAM_SERVER_URL
-                </code>
-                ,{' '}
-                <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
-                  CLOUDPAM_API_KEY
-                </code>
+                Copy the{' '}
+                <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">token</code>{' '}
+                from the response (shown only once)
               </li>
-              <li>Agents will appear here once they send their first heartbeat</li>
+              <li>
+                Deploy the agent with the token:
+                <pre className="mt-1 bg-gray-100 dark:bg-gray-800 rounded px-2 py-1.5 text-xs font-mono overflow-x-auto whitespace-pre">
+{`CLOUDPAM_BOOTSTRAP_TOKEN=<token> \\
+CLOUDPAM_ACCOUNT_ID=1 \\
+./cloudpam-agent`}
+                </pre>
+              </li>
+              <li>The agent registers automatically and appears here once it sends its first heartbeat</li>
             </ol>
           </div>
         </div>
@@ -947,6 +955,72 @@ ec2:DescribeAddresses`}
             </div>
             <p className="text-xs text-gray-500 dark:text-gray-500">
               GCP and Azure collectors are planned for a future release.
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Agent Deployment */}
+      <div className={sectionClass}>
+        <button onClick={() => toggle('agent')} className={headerClass}>
+          {openSection === 'agent' ? (
+            <ChevronDown className="w-4 h-4 text-gray-400" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-gray-400" />
+          )}
+          Deploying a Discovery Agent
+        </button>
+        {openSection === 'agent' && (
+          <div className={bodyClass}>
+            <p>
+              For production use, deploy the <strong>cloudpam-agent</strong>{' '}
+              binary near your cloud resources. It discovers VPCs, subnets, and
+              Elastic IPs, then pushes data to this server over HTTPS.
+            </p>
+            <div className="bg-gray-50 dark:bg-gray-900 rounded p-3 space-y-2">
+              <div className="flex items-start gap-2">
+                <span className="font-mono text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 px-1.5 py-0.5 rounded mt-0.5">
+                  1
+                </span>
+                <span>
+                  <strong>Provision</strong> &mdash;{' '}
+                  <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+                    POST /api/v1/discovery/agents/provision
+                  </code>{' '}
+                  to get a bootstrap token
+                </span>
+              </div>
+              <div className="flex items-start gap-2">
+                <span className="font-mono text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 px-1.5 py-0.5 rounded mt-0.5">
+                  2
+                </span>
+                <span>
+                  <strong>Deploy</strong> &mdash; set{' '}
+                  <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+                    CLOUDPAM_BOOTSTRAP_TOKEN
+                  </code>{' '}
+                  and{' '}
+                  <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+                    CLOUDPAM_ACCOUNT_ID
+                  </code>
+                </span>
+              </div>
+              <div className="flex items-start gap-2">
+                <span className="font-mono text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 px-1.5 py-0.5 rounded mt-0.5">
+                  3
+                </span>
+                <span>
+                  <strong>Monitor</strong> &mdash; agents register automatically
+                  and appear in the Agents tab
+                </span>
+              </div>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-500">
+              The token contains the server URL, API key, and agent name. See{' '}
+              <code className="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+                docs/DISCOVERY.md
+              </code>{' '}
+              for Docker, Helm, and Terraform deployment guides.
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary

Completes the agent provisioning flow from PR #114. Operators can now deploy `cloudpam-agent` with a single bootstrap token instead of manually configuring `server_url`, `api_key`, and `agent_name` separately.

- **Bootstrap token support** — new `CLOUDPAM_BOOTSTRAP_TOKEN` env var / `bootstrap_token` YAML field. On startup the agent decodes the base64 bundle, registers with the server, and begins discovery.
- **`Register()` method on Pusher** — calls `POST /api/v1/discovery/agents/register` with the agent's UUID, name, account ID, version, and hostname. Registration failure prevents the scheduler from starting.
- **Backward compatible** — explicit `api_key` takes precedence over the bootstrap token. Agents configured the old way skip registration entirely.
- **Comprehensive docs rewrite** — `docs/DISCOVERY.md` now covers both server-side sync and standalone agent deployment, including quick start, manual config, Docker, Helm, and Terraform examples, full API reference for all agent endpoints, and updated RBAC/storage sections.
- **Terraform module** — `deploy/terraform/aws-discovery/main.tf` creates the IAM role and policy for the agent, supporting both EKS IRSA and EC2 instance profiles.
- **UI updates** — agents tab empty state now shows the provisioning token workflow; setup guide adds a "Deploying a Discovery Agent" section.

## Files Changed

| File | Change |
|------|--------|
| `cmd/cloudpam-agent/config.go` | `BootstrapToken` field, `decodeBootstrapToken()`, updated `Validate()` |
| `cmd/cloudpam-agent/pusher.go` | `Register()` method |
| `cmd/cloudpam-agent/main.go` | Registration step before scheduler when bootstrapped |
| `docs/DISCOVERY.md` | Full rewrite with agent docs, API reference, Terraform section |
| `deploy/terraform/aws-discovery/main.tf` | New Terraform module (IAM role + policy, IRSA/EC2) |
| `ui/src/pages/DiscoveryPage.tsx` | Updated quick start guide and setup guide |

## Deployment Flow

```
Admin                          Server                         Agent
  │                              │                              │
  ├─ POST /agents/provision ────>│                              │
  │<── {token, api_key, ...} ────│                              │
  │                              │                              │
  ├── give token to operator ───────────────────────────────────>│
  │                              │                              │
  │                              │<── POST /agents/register ────│
  │                              │── {agent_id, approved} ─────>│
  │                              │                              │
  │                              │<── POST /discovery/ingest ───│ (every 15m)
  │                              │<── POST /agents/heartbeat ───│ (every 1m)
```

## Test plan

- [x] `go build ./cmd/cloudpam-agent` — compiles clean
- [x] `go vet ./cmd/cloudpam-agent/...` — no issues
- [x] `go test -race ./...` — all tests pass
- [ ] Manual end-to-end: provision agent, copy token, run with `CLOUDPAM_BOOTSTRAP_TOKEN` + `CLOUDPAM_ACCOUNT_ID`, verify registration and discovery loop
- [ ] Manual: verify explicit `api_key` config still works (no registration step)
- [ ] Review Terraform module with `terraform validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)