### PR TITLE
feat: AWS Organizations discovery with org-mode agent & bulk ingest (Sprint 16b)

### DIFF
--- a/deploy/cloudformation/discovery-role-stackset.yaml
+++ b/deploy/cloudformation/discovery-role-stackset.yaml
@@ -1,0 +1,76 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  CloudPAM Discovery Role — deploy as a CloudFormation StackSet
+  to create the discovery IAM role in all member accounts.
+  The role grants read-only EC2 access and trusts the agent role
+  in the management account.
+
+Parameters:
+  ManagementAccountId:
+    Type: String
+    Description: AWS account ID of the management account where the CloudPAM agent runs
+
+  AgentRoleName:
+    Type: String
+    Default: CloudPAMAgent
+    Description: Name of the IAM role the agent uses in the management account
+
+  RoleName:
+    Type: String
+    Default: CloudPAMDiscoveryRole
+    Description: Name of the IAM role to create in each member account
+
+  ExternalId:
+    Type: String
+    Default: ''
+    Description: External ID for the trust policy (optional but recommended)
+
+Conditions:
+  HasExternalId: !Not [!Equals [!Ref ExternalId, '']]
+
+Resources:
+  CloudPAMDiscoveryRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowManagementAgent
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:${AWS::Partition}:iam::${ManagementAccountId}:role/${AgentRoleName}'
+            Action: sts:AssumeRole
+            Condition: !If
+              - HasExternalId
+              - StringEquals:
+                  sts:ExternalId: !Ref ExternalId
+              - !Ref AWS::NoValue
+      Policies:
+        - PolicyName: CloudPAMEC2ReadOnly
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: EC2ReadOnly
+                Effect: Allow
+                Action:
+                  - ec2:DescribeVpcs
+                  - ec2:DescribeSubnets
+                  - ec2:DescribeAddresses
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:DescribeRegions
+                Resource: '*'
+      Tags:
+        - Key: ManagedBy
+          Value: CloudPAM
+        - Key: Purpose
+          Value: Discovery
+
+Outputs:
+  RoleArn:
+    Description: ARN of the CloudPAM discovery role in this member account
+    Value: !GetAtt CloudPAMDiscoveryRole.Arn
+  RoleName:
+    Description: Name of the discovery role
+    Value: !Ref RoleName

--- a/deploy/terraform/aws-org-discovery/management-policy/main.tf
+++ b/deploy/terraform/aws-org-discovery/management-policy/main.tf
@@ -1,0 +1,210 @@
+####################################################################
+# CloudPAM Agent — Management Account IAM Resources
+#
+# Creates everything the agent needs to run in the management account:
+#   1. IAM Role the agent assumes (with instance profile for EC2)
+#   2. Policy: organizations:ListAccounts + sts:AssumeRole into members
+#   3. Policy: ec2:Describe* for the management account itself
+#   4. Policy: sts:GetCallerIdentity for identity verification
+####################################################################
+
+variable "role_name" {
+  description = "Name of the IAM role in member accounts (must match member-role module)"
+  type        = string
+  default     = "CloudPAMDiscoveryRole"
+}
+
+variable "agent_role_name" {
+  description = "Name of the IAM role to create for the CloudPAM agent"
+  type        = string
+  default     = "CloudPAMAgent"
+}
+
+variable "create_instance_profile" {
+  description = "Create an EC2 instance profile for the agent role (set false for ECS/Fargate)"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    ManagedBy = "CloudPAM"
+    Purpose   = "Discovery"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_organizations_organization" "current" {}
+data "aws_partition" "current" {}
+
+# ---------------------------------------------------------------------
+# IAM Role for the CloudPAM agent
+# ---------------------------------------------------------------------
+
+resource "aws_iam_role" "cloudpam_agent" {
+  name = var.agent_role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EC2AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+      {
+        Sid    = "ECSAssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# Instance profile (for EC2-based agent deployments)
+resource "aws_iam_instance_profile" "cloudpam_agent" {
+  count = var.create_instance_profile ? 1 : 0
+  name  = var.agent_role_name
+  role  = aws_iam_role.cloudpam_agent.name
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------
+# Policy 1: AWS Organizations access + cross-account AssumeRole
+# ---------------------------------------------------------------------
+
+resource "aws_iam_policy" "org_discovery" {
+  name        = "CloudPAMOrgDiscoveryPolicy"
+  description = "List org accounts and assume the discovery role in each member account"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ListOrgAccounts"
+        Effect = "Allow"
+        Action = [
+          "organizations:ListAccounts",
+          "organizations:DescribeOrganization",
+          "organizations:DescribeAccount"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid      = "AssumeDiscoveryRole"
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = "arn:${data.aws_partition.current.partition}:iam::*:role/${var.role_name}"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "org_discovery" {
+  role       = aws_iam_role.cloudpam_agent.name
+  policy_arn = aws_iam_policy.org_discovery.arn
+}
+
+# ---------------------------------------------------------------------
+# Policy 2: EC2 read-only for management account local discovery
+# ---------------------------------------------------------------------
+
+resource "aws_iam_policy" "ec2_discovery" {
+  name        = "CloudPAMEC2DiscoveryPolicy"
+  description = "Read-only EC2 access for discovering VPCs, subnets, and EIPs"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EC2ReadOnly"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeVpcs",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeRegions"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_discovery" {
+  role       = aws_iam_role.cloudpam_agent.name
+  policy_arn = aws_iam_policy.ec2_discovery.arn
+}
+
+# ---------------------------------------------------------------------
+# Policy 3: STS identity for agent self-identification
+# ---------------------------------------------------------------------
+
+resource "aws_iam_policy" "sts_identity" {
+  name        = "CloudPAMSTSIdentityPolicy"
+  description = "Allow agent to verify its own identity"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "GetCallerIdentity"
+        Effect   = "Allow"
+        Action   = "sts:GetCallerIdentity"
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "sts_identity" {
+  role       = aws_iam_role.cloudpam_agent.name
+  policy_arn = aws_iam_policy.sts_identity.arn
+}
+
+# ---------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------
+
+output "agent_role_arn" {
+  description = "ARN of the IAM role for the CloudPAM agent"
+  value       = aws_iam_role.cloudpam_agent.arn
+}
+
+output "agent_role_name" {
+  description = "Name of the IAM role for the CloudPAM agent"
+  value       = aws_iam_role.cloudpam_agent.name
+}
+
+output "instance_profile_arn" {
+  description = "ARN of the instance profile (if created)"
+  value       = var.create_instance_profile ? aws_iam_instance_profile.cloudpam_agent[0].arn : null
+}
+
+output "org_discovery_policy_arn" {
+  description = "ARN of the Organizations discovery policy"
+  value       = aws_iam_policy.org_discovery.arn
+}
+
+output "ec2_discovery_policy_arn" {
+  description = "ARN of the EC2 discovery policy"
+  value       = aws_iam_policy.ec2_discovery.arn
+}

--- a/deploy/terraform/aws-org-discovery/member-role/main.tf
+++ b/deploy/terraform/aws-org-discovery/member-role/main.tf
@@ -1,0 +1,114 @@
+####################################################################
+# CloudPAM Discovery Role — Member Account
+#
+# Deploy to each member account (via StackSet or per-account apply).
+# Creates:
+#   1. IAM Role trusted by the management account's agent role
+#   2. Inline policy with read-only EC2 permissions for discovery
+####################################################################
+
+variable "management_account_id" {
+  description = "AWS account ID of the management account where the agent runs"
+  type        = string
+}
+
+variable "agent_role_name" {
+  description = "Name of the IAM role the agent uses in the management account"
+  type        = string
+  default     = "CloudPAMAgent"
+}
+
+variable "role_name" {
+  description = "Name of the IAM role to create in this member account"
+  type        = string
+  default     = "CloudPAMDiscoveryRole"
+}
+
+variable "external_id" {
+  description = "External ID for the trust policy (optional but recommended)"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default = {
+    ManagedBy = "CloudPAM"
+    Purpose   = "Discovery"
+  }
+}
+
+data "aws_partition" "current" {}
+
+# ---------------------------------------------------------------------
+# IAM Role — trusted by management account agent
+# ---------------------------------------------------------------------
+
+resource "aws_iam_role" "cloudpam_discovery" {
+  name = var.role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowManagementAgent"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${var.management_account_id}:role/${var.agent_role_name}"
+        }
+        Action = "sts:AssumeRole"
+        Condition = var.external_id != "" ? {
+          StringEquals = {
+            "sts:ExternalId" = var.external_id
+          }
+        } : {}
+      }
+    ]
+  })
+
+  max_session_duration = 3600 # 1 hour — enough for a discovery pass
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------
+# Inline policy — read-only EC2 for VPC/subnet/EIP discovery
+# ---------------------------------------------------------------------
+
+resource "aws_iam_role_policy" "ec2_read_only" {
+  name = "CloudPAMEC2ReadOnly"
+  role = aws_iam_role.cloudpam_discovery.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EC2ReadOnly"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeVpcs",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeRegions"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------
+
+output "role_arn" {
+  description = "ARN of the discovery role in this member account"
+  value       = aws_iam_role.cloudpam_discovery.arn
+}
+
+output "role_name" {
+  description = "Name of the discovery role"
+  value       = aws_iam_role.cloudpam_discovery.name
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,12 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.41.1
+	github.com/aws/aws-sdk-go-v2/config v1.32.7
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.288.0
+	github.com/aws/aws-sdk-go-v2/service/organizations v1.50.2
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
 	github.com/getsentry/sentry-go v0.36.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
@@ -12,6 +18,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
 	golang.org/x/crypto v0.47.0
 	golang.org/x/time v0.5.0
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.38.2
 )
 
@@ -19,20 +26,15 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.1 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.7 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.288.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
@@ -92,7 +94,6 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/grpc v1.78.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.66.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 h1:0ryTNEd
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4/go.mod h1:HQ4qwNZh32C3CBeO6iJLQlgtMzqeG17ziAA/3KDJFow=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 h1:RuNSMoozM8oXlgLG/n6WLaFGoea7/CddrCfIiSA+xdY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17/go.mod h1:F2xxQ9TZz5gDWsclCtPQscGpP0VUOc8RqgFM3vDENmU=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.50.2 h1:D64FjbJyjIRYLpMdNcVnprU7/mh/Vzea4jGMtqQ8QAw=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.50.2/go.mod h1:6WyPYQBJwPA/71gHpvO2f5O7yxn1uQZBm600CiXno1s=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 h1:VrhDvQib/i0lxvr3zqlUwLwJP4fpmpyD9wYG1vfSu+Y=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.5/go.mod h1:k029+U8SY30/3/ras4G/Fnv/b88N4mAfliNn08Dem4M=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 h1:v6EiMvhEYBoHABfbGB4alOYmCIrcgyPPiBE1wZAEbqk=

--- a/internal/discovery/aws/assume_role.go
+++ b/internal/discovery/aws/assume_role.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// AssumeRole returns a credentials provider that assumes the given role in the target account.
+func AssumeRole(ctx context.Context, accountID, roleName, externalID string) (aws.CredentialsProvider, error) {
+	roleARN := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, roleName)
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+
+	var opts []func(*stscreds.AssumeRoleOptions)
+	if externalID != "" {
+		opts = append(opts, func(o *stscreds.AssumeRoleOptions) {
+			o.ExternalID = &externalID
+		})
+	}
+
+	provider := stscreds.NewAssumeRoleProvider(stsClient, roleARN, opts...)
+	return provider, nil
+}

--- a/internal/discovery/aws/org.go
+++ b/internal/discovery/aws/org.go
@@ -1,0 +1,55 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+)
+
+// OrgAccount represents an AWS account discovered via AWS Organizations.
+type OrgAccount struct {
+	ID    string // e.g. "123456789012"
+	Name  string
+	Email string
+}
+
+// ListOrgAccounts enumerates all active accounts in the AWS Organization.
+// Uses the default credential chain (management account credentials).
+func ListOrgAccounts(ctx context.Context) ([]OrgAccount, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	client := organizations.NewFromConfig(cfg)
+	var accounts []OrgAccount
+
+	paginator := organizations.NewListAccountsPaginator(client, &organizations.ListAccountsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, acct := range page.Accounts {
+			if acct.Status != orgtypes.AccountStatusActive {
+				continue
+			}
+			accounts = append(accounts, OrgAccount{
+				ID:    derefString(acct.Id),
+				Name:  derefString(acct.Name),
+				Email: derefString(acct.Email),
+			})
+		}
+	}
+
+	return accounts, nil
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/internal/domain/discovery.go
+++ b/internal/domain/discovery.go
@@ -236,3 +236,27 @@ type AgentRegisterResponse struct {
 	Message        string              `json:"message,omitempty"`
 }
 
+// OrgAccountIngest represents a single AWS account's discovered resources for bulk org ingest.
+type OrgAccountIngest struct {
+	AWSAccountID string               `json:"aws_account_id"`
+	AccountName  string               `json:"account_name"`
+	AccountEmail string               `json:"account_email"`
+	Provider     string               `json:"provider"`
+	Regions      []string             `json:"regions"`
+	Resources    []DiscoveredResource `json:"resources"`
+}
+
+// BulkIngestRequest is the request body for the /api/v1/discovery/ingest/org endpoint.
+type BulkIngestRequest struct {
+	Accounts []OrgAccountIngest `json:"accounts"`
+	AgentID  string             `json:"agent_id,omitempty"`
+}
+
+// BulkIngestResponse is the response body for the /api/v1/discovery/ingest/org endpoint.
+type BulkIngestResponse struct {
+	AccountsProcessed int      `json:"accounts_processed"`
+	AccountsCreated   int      `json:"accounts_created"`
+	TotalResources    int      `json:"total_resources"`
+	Errors            []string `json:"errors,omitempty"`
+}
+

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -35,6 +35,8 @@ type Store interface {
 	DeleteAccount(ctx context.Context, id int64) (bool, error)
 	DeleteAccountCascade(ctx context.Context, id int64) (bool, error)
 	GetAccount(ctx context.Context, id int64) (domain.Account, bool, error)
+	// GetAccountByKey retrieves an account by its unique key (e.g., "aws:123456789012").
+	GetAccountByKey(ctx context.Context, key string) (*domain.Account, error)
 	// Search performs a paginated search across pools and accounts.
 	Search(ctx context.Context, req domain.SearchRequest) (domain.SearchResponse, error)
 	// Close releases resources held by the store
@@ -352,6 +354,18 @@ func (m *MemoryStore) GetAccount(ctx context.Context, id int64) (domain.Account,
 	defer m.mu.RUnlock()
 	a, ok := m.accounts[id]
 	return a, ok, nil
+}
+
+// GetAccountByKey retrieves an account by its unique key.
+func (m *MemoryStore) GetAccountByKey(ctx context.Context, key string) (*domain.Account, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, a := range m.accounts {
+		if a.Key == key {
+			return &a, nil
+		}
+	}
+	return nil, ErrNotFound
 }
 
 // GetPoolWithStats returns a pool with its computed statistics.

--- a/migrations/0012_account_key_unique.sql
+++ b/migrations/0012_account_key_unique.sql
@@ -1,0 +1,2 @@
+-- Add unique index on accounts.key for efficient GetAccountByKey lookups
+CREATE UNIQUE INDEX IF NOT EXISTS idx_accounts_key_unique ON accounts(key);

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -93,6 +93,15 @@ export interface CreatePoolRequest {
   tags?: Record<string, string>
 }
 
+export interface UpdatePoolRequest {
+  name?: string
+  account_id?: number | null
+  type?: PoolType
+  status?: PoolStatus
+  description?: string
+  tags?: Record<string, string>
+}
+
 export interface Account {
   id: number
   key: string
@@ -390,4 +399,23 @@ export interface RecommendationsListResponse {
 export interface GenerateRecommendationsResponse {
   items: Recommendation[]
   total: number
+}
+
+// --- Org discovery types ---
+
+export interface BulkIngestResponse {
+  accounts_processed: number
+  accounts_created: number
+  total_resources: number
+  errors?: string[]
+}
+
+// --- Agent provisioning types ---
+
+export interface AgentProvisionResponse {
+  agent_name: string
+  api_key: string
+  api_key_id: string
+  server_url: string
+  token: string
 }

--- a/ui/src/components/DiscoveryWizard.tsx
+++ b/ui/src/components/DiscoveryWizard.tsx
@@ -1,0 +1,752 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { X, Check, Copy, Download, ChevronLeft, ChevronRight, AlertTriangle, Loader2, Activity } from 'lucide-react'
+import { useAgentProvisioning, useDiscoveryAgents } from '../hooks/useDiscovery'
+import { useAccounts } from '../hooks/useAccounts'
+import { useToast } from '../hooks/useToast'
+import type { Account, CreateAccountRequest, AgentProvisionResponse, DiscoveryAgent } from '../api/types'
+
+type ConfigTab = 'shell' | 'yaml' | 'terraform' | 'docker' | 'iam'
+type DiscoveryMode = 'single' | 'organization'
+
+interface DiscoveryWizardProps {
+  accounts: Account[]
+  onAccountCreated: () => void
+  onClose: () => void
+  onComplete?: () => void
+}
+
+export default function DiscoveryWizard({ accounts, onAccountCreated, onClose, onComplete }: DiscoveryWizardProps) {
+  const [step, setStep] = useState(1)
+  const [discoveryMode, setDiscoveryMode] = useState<DiscoveryMode>('single')
+  const [selectedAccountId, setSelectedAccountId] = useState<number | null>(
+    accounts.length > 0 ? accounts[0].id : null,
+  )
+  const [showNewAccount, setShowNewAccount] = useState(false)
+  const [newAccount, setNewAccount] = useState<CreateAccountRequest>({
+    key: '',
+    name: '',
+    provider: 'aws',
+    regions: [],
+  })
+  const [regionsInput, setRegionsInput] = useState('')
+  const [agentName, setAgentName] = useState('')
+  const [provisionResult, setProvisionResult] = useState<AgentProvisionResponse | null>(null)
+  const [configTab, setConfigTab] = useState<ConfigTab>('shell')
+  const [copied, setCopied] = useState(false)
+  const [keyWarningDismissed, setKeyWarningDismissed] = useState(false)
+
+  // Org mode fields
+  const [orgRoleName, setOrgRoleName] = useState('CloudPAMDiscoveryRole')
+  const [orgExternalId, setOrgExternalId] = useState('')
+  const [orgRegionsInput, setOrgRegionsInput] = useState('us-east-1, us-west-2')
+  const [orgExcludeInput, setOrgExcludeInput] = useState('')
+
+  // Agent status tracking
+  const [connectedAgent, setConnectedAgent] = useState<DiscoveryAgent | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const { createAccount } = useAccounts()
+  const { provision, loading: provisionLoading, error: provisionError } = useAgentProvisioning()
+  const { agents, fetch: fetchAgents } = useDiscoveryAgents()
+  const { showToast } = useToast()
+
+  const selectedAccount = accounts.find(a => a.id === selectedAccountId) ?? null
+
+  // Poll for agent connection when on step 3 with a provisioned agent
+  useEffect(() => {
+    if (step === 3 && provisionResult && !connectedAgent) {
+      // Start polling for agent connection
+      const poll = () => {
+        fetchAgents()
+      }
+      poll() // immediate
+      pollRef.current = setInterval(poll, 5000)
+
+      return () => {
+        if (pollRef.current) {
+          clearInterval(pollRef.current)
+          pollRef.current = null
+        }
+      }
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current)
+        pollRef.current = null
+      }
+    }
+  }, [step, provisionResult, connectedAgent, fetchAgents])
+
+  // Check if the provisioned agent has connected
+  useEffect(() => {
+    if (provisionResult && agents.length > 0) {
+      const match = agents.find(a => a.name === provisionResult.agent_name)
+      if (match) {
+        setConnectedAgent(match)
+        if (pollRef.current) {
+          clearInterval(pollRef.current)
+          pollRef.current = null
+        }
+      }
+    }
+  }, [agents, provisionResult])
+
+  const copyToClipboard = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      showToast('Failed to copy', 'error')
+    }
+  }, [showToast])
+
+  const downloadFile = useCallback((content: string, filename: string) => {
+    const blob = new Blob([content], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [])
+
+  async function handleCreateAccount() {
+    try {
+      const regions = regionsInput.split(',').map(r => r.trim()).filter(Boolean)
+      const account = await createAccount({ ...newAccount, regions })
+      setSelectedAccountId(account.id)
+      setShowNewAccount(false)
+      onAccountCreated()
+      showToast(`Account "${account.name}" created`, 'success')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to create account', 'error')
+    }
+  }
+
+  async function handleProvision() {
+    const name = agentName.trim()
+    if (!name) return
+    try {
+      const result = await provision(name)
+      setProvisionResult(result)
+    } catch {
+      // error is handled in the hook
+    }
+  }
+
+  function handleBack() {
+    if (step === 2 && provisionResult) {
+      if (!keyWarningDismissed) {
+        setKeyWarningDismissed(true)
+        return
+      }
+    }
+    setStep(s => Math.max(1, s - 1))
+    setKeyWarningDismissed(false)
+  }
+
+  function handleNext() {
+    setStep(s => Math.min(3, s + 1))
+    setKeyWarningDismissed(false)
+  }
+
+  // Pre-fill agent name when moving to step 2
+  function goToStep2() {
+    if (discoveryMode === 'single' && selectedAccount && !agentName) {
+      setAgentName(`${selectedAccount.name.toLowerCase().replace(/\s+/g, '-')}-agent`)
+    } else if (discoveryMode === 'organization' && !agentName) {
+      setAgentName('org-discovery-agent')
+    }
+    handleNext()
+  }
+
+  // Generate config content
+  const token = provisionResult?.token ?? '<token>'
+  const accountId = selectedAccountId ?? 0
+  const accountRegions = selectedAccount?.regions ?? []
+  const agentNameFinal = provisionResult?.agent_name ?? agentName
+  const serverUrl = provisionResult?.server_url ?? window.location.origin
+  const isOrg = discoveryMode === 'organization'
+
+  const orgRegions = orgRegionsInput.split(',').map(r => r.trim()).filter(Boolean)
+  const orgExclude = orgExcludeInput.split(',').map(r => r.trim()).filter(Boolean)
+
+  // Single-account configs
+  const shellConfigSingle = `#!/bin/bash
+export CLOUDPAM_BOOTSTRAP_TOKEN="${token}"
+export CLOUDPAM_ACCOUNT_ID=${accountId}
+./cloudpam-agent`
+
+  const yamlConfigSingle = `server_url: "${serverUrl}"
+bootstrap_token: "${token}"
+account_id: ${accountId}
+agent_name: "${agentNameFinal}"
+interval: 5m
+aws:
+  regions: [${accountRegions.map(r => `"${r}"`).join(', ')}]`
+
+  // Org-mode configs
+  const shellConfigOrg = `#!/bin/bash
+export CLOUDPAM_BOOTSTRAP_TOKEN="${token}"
+export CLOUDPAM_AWS_ORG_ENABLED=true
+export CLOUDPAM_AWS_ORG_ROLE_NAME="${orgRoleName}"${orgExternalId ? `
+export CLOUDPAM_AWS_ORG_EXTERNAL_ID="${orgExternalId}"` : ''}
+export CLOUDPAM_AWS_ORG_REGIONS="${orgRegions.join(',')}"${orgExclude.length > 0 ? `
+export CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS="${orgExclude.join(',')}"` : ''}
+./cloudpam-agent`
+
+  const yamlConfigOrg = `server_url: "${serverUrl}"
+bootstrap_token: "${token}"
+agent_name: "${agentNameFinal}"
+aws_org:
+  enabled: true
+  role_name: "${orgRoleName}"${orgExternalId ? `
+  external_id: "${orgExternalId}"` : ''}
+  regions: [${orgRegions.map(r => `"${r}"`).join(', ')}]${orgExclude.length > 0 ? `
+  exclude_accounts: [${orgExclude.map(a => `"${a}"`).join(', ')}]` : ''}`
+
+  const terraformConfigSingle = `variable "cloudpam_bootstrap_token" {
+  default   = "${token}"
+  sensitive = true
+}
+
+resource "null_resource" "cloudpam_agent" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      CLOUDPAM_BOOTSTRAP_TOKEN=\${var.cloudpam_bootstrap_token} \\
+      CLOUDPAM_ACCOUNT_ID=${accountId} \\
+      ./cloudpam-agent
+    EOT
+  }
+}`
+
+  const terraformConfigOrg = `variable "cloudpam_bootstrap_token" {
+  default   = "${token}"
+  sensitive = true
+}
+
+resource "null_resource" "cloudpam_agent" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      CLOUDPAM_BOOTSTRAP_TOKEN=\${var.cloudpam_bootstrap_token} \\
+      CLOUDPAM_AWS_ORG_ENABLED=true \\
+      CLOUDPAM_AWS_ORG_ROLE_NAME=${orgRoleName} \\${orgExternalId ? `
+      CLOUDPAM_AWS_ORG_EXTERNAL_ID=${orgExternalId} \\` : ''}
+      CLOUDPAM_AWS_ORG_REGIONS=${orgRegions.join(',')} \\
+      ./cloudpam-agent
+    EOT
+  }
+}`
+
+  const dockerConfigSingle = `docker run -d \\
+  --name cloudpam-agent \\
+  -e CLOUDPAM_BOOTSTRAP_TOKEN="${token}" \\
+  -e CLOUDPAM_ACCOUNT_ID=${accountId} \\
+  cloudpam/agent:latest`
+
+  const dockerConfigOrg = `docker run -d \\
+  --name cloudpam-agent \\
+  -e CLOUDPAM_BOOTSTRAP_TOKEN="${token}" \\
+  -e CLOUDPAM_AWS_ORG_ENABLED=true \\
+  -e CLOUDPAM_AWS_ORG_ROLE_NAME="${orgRoleName}" \\${orgExternalId ? `
+  -e CLOUDPAM_AWS_ORG_EXTERNAL_ID="${orgExternalId}" \\` : ''}
+  -e CLOUDPAM_AWS_ORG_REGIONS="${orgRegions.join(',')}" \\${orgExclude.length > 0 ? `
+  -e CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS="${orgExclude.join(',')}" \\` : ''}
+  cloudpam/agent:latest`
+
+  const iamSetupContent = `# IAM Setup for AWS Organizations Discovery
+#
+# 1. Deploy the member role to all accounts via CloudFormation StackSet
+#    or Terraform (deploy/terraform/aws-org-discovery/member-role/)
+#
+# 2. Attach the management policy to the agent's IAM role
+#    (deploy/terraform/aws-org-discovery/management-policy/)
+
+# --- Member Account Role (Terraform) ---
+# Deploy to each member account:
+
+resource "aws_iam_role" "${orgRoleName}" {
+  name = "${orgRoleName}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { AWS = "arn:aws:iam::<MANAGEMENT_ACCOUNT_ID>:root" }
+      Action    = "sts:AssumeRole"${orgExternalId ? `
+      Condition = { StringEquals = { "sts:ExternalId" = "${orgExternalId}" } }` : ''}
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "discovery" {
+  role = aws_iam_role.${orgRoleName}.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = [
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeAddresses"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+# --- Management Account Policy ---
+# Attach to the IAM role running the CloudPAM agent:
+
+resource "aws_iam_policy" "cloudpam_org" {
+  name = "CloudPAMOrgDiscoveryPolicy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["organizations:ListAccounts", "organizations:DescribeOrganization"]
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "sts:AssumeRole"
+        Resource = "arn:aws:iam::*:role/${orgRoleName}"
+      }
+    ]
+  })
+}`
+
+  const shellConfig = isOrg ? shellConfigOrg : shellConfigSingle
+  const yamlConfig = isOrg ? yamlConfigOrg : yamlConfigSingle
+  const terraformConfig = isOrg ? terraformConfigOrg : terraformConfigSingle
+  const dockerConfig = isOrg ? dockerConfigOrg : dockerConfigSingle
+
+  const availableTabs: ConfigTab[] = isOrg
+    ? ['shell', 'yaml', 'terraform', 'docker', 'iam']
+    : ['shell', 'yaml', 'terraform', 'docker']
+
+  const configs: Record<ConfigTab, { content: string; filename: string; label: string }> = {
+    shell: { content: shellConfig, filename: `${agentNameFinal}.sh`, label: 'Shell' },
+    yaml: { content: yamlConfig, filename: `${agentNameFinal}.yaml`, label: 'YAML' },
+    terraform: { content: terraformConfig, filename: `${agentNameFinal}.tf`, label: 'Terraform' },
+    docker: { content: dockerConfig, filename: `${agentNameFinal}-docker.sh`, label: 'Docker' },
+    iam: { content: iamSetupContent, filename: `${agentNameFinal}-iam.tf`, label: 'IAM Setup' },
+  }
+
+  const canGoNext = (step === 1 && (discoveryMode === 'organization' || selectedAccountId !== null)) ||
+    (step === 2 && provisionResult !== null)
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b dark:border-gray-700">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Plan Discovery</h2>
+            <div className="flex items-center gap-2 mt-1">
+              {[1, 2, 3].map(s => (
+                <div key={s} className="flex items-center gap-1">
+                  <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium ${
+                    s < step ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' :
+                    s === step ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' :
+                    'bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
+                  }`}>
+                    {s < step ? <Check className="w-3.5 h-3.5" /> : s}
+                  </div>
+                  {s < 3 && <div className={`w-8 h-0.5 ${s < step ? 'bg-green-300 dark:bg-green-700' : 'bg-gray-200 dark:bg-gray-700'}`} />}
+                </div>
+              ))}
+            </div>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-auto px-6 py-4">
+          {/* Step 1: Select Mode & Account */}
+          {step === 1 && (
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">Discovery Mode</h3>
+
+              {/* Mode toggle */}
+              <div className="flex gap-3">
+                <label className={`flex-1 cursor-pointer rounded-lg border-2 p-3 transition-colors ${
+                  discoveryMode === 'single'
+                    ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 dark:border-blue-400'
+                    : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'
+                }`}>
+                  <input
+                    type="radio"
+                    name="mode"
+                    value="single"
+                    checked={discoveryMode === 'single'}
+                    onChange={() => setDiscoveryMode('single')}
+                    className="sr-only"
+                  />
+                  <div className="text-sm font-medium text-gray-900 dark:text-gray-100">Single Account</div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    Discover resources in one AWS account
+                  </div>
+                </label>
+                <label className={`flex-1 cursor-pointer rounded-lg border-2 p-3 transition-colors ${
+                  discoveryMode === 'organization'
+                    ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 dark:border-blue-400'
+                    : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'
+                }`}>
+                  <input
+                    type="radio"
+                    name="mode"
+                    value="organization"
+                    checked={discoveryMode === 'organization'}
+                    onChange={() => setDiscoveryMode('organization')}
+                    className="sr-only"
+                  />
+                  <div className="text-sm font-medium text-gray-900 dark:text-gray-100">AWS Organization</div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    Discover across all member accounts via AssumeRole
+                  </div>
+                </label>
+              </div>
+
+              {/* Single account mode */}
+              {discoveryMode === 'single' && (
+                <div className="space-y-3">
+                  <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">Select Cloud Account</h4>
+                  {!showNewAccount ? (
+                    <>
+                      <select
+                        value={selectedAccountId ?? ''}
+                        onChange={e => setSelectedAccountId(Number(e.target.value))}
+                        className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+                      >
+                        <option value="" disabled>Choose an account...</option>
+                        {accounts.map(a => (
+                          <option key={a.id} value={a.id}>
+                            {a.name} ({a.provider || 'unknown'})
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={() => setShowNewAccount(true)}
+                        className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        + Create new account
+                      </button>
+                    </>
+                  ) : (
+                    <div className="space-y-3 bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+                      <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">New Account</h4>
+                      <div className="grid grid-cols-2 gap-3">
+                        <div>
+                          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Key</label>
+                          <input
+                            value={newAccount.key}
+                            onChange={e => setNewAccount(prev => ({ ...prev, key: e.target.value }))}
+                            placeholder="aws-prod"
+                            className="w-full px-3 py-1.5 border dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-100"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Name</label>
+                          <input
+                            value={newAccount.name}
+                            onChange={e => setNewAccount(prev => ({ ...prev, name: e.target.value }))}
+                            placeholder="AWS Production"
+                            className="w-full px-3 py-1.5 border dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-100"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Provider</label>
+                          <select
+                            value={newAccount.provider}
+                            onChange={e => setNewAccount(prev => ({ ...prev, provider: e.target.value }))}
+                            className="w-full px-3 py-1.5 border dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-100"
+                          >
+                            <option value="aws">AWS</option>
+                            <option value="gcp">GCP</option>
+                            <option value="azure">Azure</option>
+                          </select>
+                        </div>
+                        <div>
+                          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Regions (comma-separated)</label>
+                          <input
+                            value={regionsInput}
+                            onChange={e => setRegionsInput(e.target.value)}
+                            placeholder="us-east-1, us-west-2"
+                            className="w-full px-3 py-1.5 border dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-100"
+                          />
+                        </div>
+                      </div>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={handleCreateAccount}
+                          disabled={!newAccount.key || !newAccount.name}
+                          className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded disabled:opacity-50"
+                        >
+                          Create Account
+                        </button>
+                        <button
+                          onClick={() => setShowNewAccount(false)}
+                          className="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Organization mode */}
+              {discoveryMode === 'organization' && (
+                <div className="space-y-3">
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    The agent will run in the management account and discover resources across all member accounts
+                    using <code className="text-xs bg-gray-100 dark:bg-gray-700 px-1 rounded">sts:AssumeRole</code>.
+                    Accounts are auto-created in CloudPAM.
+                  </p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Role Name</label>
+                      <input
+                        value={orgRoleName}
+                        onChange={e => setOrgRoleName(e.target.value)}
+                        placeholder="CloudPAMDiscoveryRole"
+                        className="w-full px-3 py-1.5 border dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-100"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">External ID (optional)</label>
+                      <input
+                        value={orgExternalId}
+                        onChange={e => setOrgExternalId(e.target.value)}
+                        placeholder="cloudpam-discovery"
+                        className="w-full px-3 py-1.5 border dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-100"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Regions (comma-separated)</label>
+                      <input
+                        value={orgRegionsInput}
+                        onChange={e => setOrgRegionsInput(e.target.value)}
+                        placeholder="us-east-1, us-west-2"
+                        className="w-full px-3 py-1.5 border dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-100"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Exclude Accounts (optional)</label>
+                      <input
+                        value={orgExcludeInput}
+                        onChange={e => setOrgExcludeInput(e.target.value)}
+                        placeholder="123456789012, 987654321098"
+                        className="w-full px-3 py-1.5 border dark:border-gray-600 rounded text-sm dark:bg-gray-700 dark:text-gray-100"
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step 2: Provision Agent */}
+          {step === 2 && (
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">Provision Agent</h3>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {isOrg
+                  ? 'Create a discovery agent for your AWS Organization. This generates a bootstrap token and API key.'
+                  : <>Create a discovery agent for <strong>{selectedAccount?.name}</strong>. This generates a bootstrap token and API key.</>
+                }
+              </p>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Agent Name</label>
+                <input
+                  value={agentName}
+                  onChange={e => setAgentName(e.target.value)}
+                  placeholder="my-agent"
+                  disabled={!!provisionResult}
+                  className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100 disabled:opacity-50"
+                />
+              </div>
+
+              {!provisionResult ? (
+                <>
+                  <button
+                    onClick={handleProvision}
+                    disabled={provisionLoading || !agentName.trim()}
+                    className="px-4 py-2 text-sm bg-green-600 hover:bg-green-700 text-white rounded-lg disabled:opacity-50"
+                  >
+                    {provisionLoading ? 'Provisioning...' : 'Provision Agent'}
+                  </button>
+                  {provisionError && (
+                    <div className="text-sm text-red-600 dark:text-red-400">{provisionError}</div>
+                  )}
+                </>
+              ) : (
+                <div className="space-y-3">
+                  <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-sm font-medium text-green-800 dark:text-green-300">API Key</span>
+                      <button
+                        onClick={() => copyToClipboard(provisionResult.api_key)}
+                        className="flex items-center gap-1 text-xs text-green-700 dark:text-green-400 hover:underline"
+                      >
+                        <Copy className="w-3.5 h-3.5" />
+                        {copied ? 'Copied!' : 'Copy'}
+                      </button>
+                    </div>
+                    <code className="block text-sm font-mono text-green-900 dark:text-green-200 break-all bg-green-100 dark:bg-green-900/40 px-3 py-2 rounded">
+                      {provisionResult.api_key}
+                    </code>
+                    <p className="mt-2 text-xs text-green-700 dark:text-green-400">
+                      <strong>This key is shown only once.</strong> Copy it now. You will not be able to retrieve it later.
+                    </p>
+                  </div>
+
+                  {keyWarningDismissed && (
+                    <div className="flex items-start gap-2 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3">
+                      <AlertTriangle className="w-4 h-4 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
+                      <div className="text-sm text-yellow-700 dark:text-yellow-300">
+                        Going back will not discard the provisioned agent, but the API key above will be lost if you haven&apos;t copied it.
+                        <button
+                          onClick={() => { setKeyWarningDismissed(false); setStep(1) }}
+                          className="block mt-1 text-yellow-800 dark:text-yellow-200 font-medium hover:underline"
+                        >
+                          Go back anyway
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Step 3: Deployment Config */}
+          {step === 3 && (
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">Deployment Configuration</h3>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Choose a deployment method and use the generated configuration to start the agent.
+                {isOrg && ' The "IAM Setup" tab shows the Terraform snippet for member role and management policy.'}
+              </p>
+
+              {/* Tabs */}
+              <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700">
+                {availableTabs.map(tab => (
+                  <button
+                    key={tab}
+                    onClick={() => setConfigTab(tab)}
+                    className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px ${
+                      configTab === tab
+                        ? 'border-blue-600 text-blue-600 dark:text-blue-400'
+                        : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                    }`}
+                  >
+                    {configs[tab].label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Config content */}
+              <div className="relative">
+                <pre className="bg-gray-50 dark:bg-gray-900 border dark:border-gray-700 rounded-lg p-4 text-sm font-mono text-gray-800 dark:text-gray-200 overflow-x-auto whitespace-pre">
+                  {configs[configTab].content}
+                </pre>
+                <div className="absolute top-2 right-2 flex gap-1">
+                  <button
+                    onClick={() => copyToClipboard(configs[configTab].content)}
+                    title="Copy to clipboard"
+                    className="p-1.5 bg-white dark:bg-gray-800 border dark:border-gray-600 rounded text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 shadow-sm"
+                  >
+                    <Copy className="w-4 h-4" />
+                  </button>
+                  <button
+                    onClick={() => downloadFile(configs[configTab].content, configs[configTab].filename)}
+                    title="Download file"
+                    className="p-1.5 bg-white dark:bg-gray-800 border dark:border-gray-600 rounded text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 shadow-sm"
+                  >
+                    <Download className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+
+              {/* Agent connection status */}
+              {provisionResult && (
+                <div className={`flex items-center gap-3 rounded-lg border p-3 ${
+                  connectedAgent
+                    ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800'
+                    : 'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800'
+                }`}>
+                  {connectedAgent ? (
+                    <>
+                      <Activity className="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0" />
+                      <div>
+                        <div className="text-sm font-medium text-green-800 dark:text-green-300">
+                          Agent connected
+                        </div>
+                        <div className="text-xs text-green-700 dark:text-green-400">
+                          <strong>{connectedAgent.name}</strong> is {connectedAgent.status} &mdash; {connectedAgent.hostname || 'unknown host'}, version {connectedAgent.version || 'unknown'}
+                        </div>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <Loader2 className="w-5 h-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0 animate-spin" />
+                      <div>
+                        <div className="text-sm font-medium text-yellow-800 dark:text-yellow-300">
+                          Waiting for agent to connect...
+                        </div>
+                        <div className="text-xs text-yellow-700 dark:text-yellow-400">
+                          Deploy the agent using the configuration above. It will appear here once it sends its first heartbeat.
+                        </div>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t dark:border-gray-700">
+          <div>
+            {step > 1 && (
+              <button
+                onClick={handleBack}
+                className="flex items-center gap-1 px-3 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
+              >
+                <ChevronLeft className="w-4 h-4" />
+                Back
+              </button>
+            )}
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={() => { if (step === 3 && onComplete) onComplete(); onClose() }}
+              className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 border dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              {step === 3 ? 'Done' : 'Cancel'}
+            </button>
+            {step < 3 && (
+              <button
+                onClick={step === 1 ? goToStep2 : handleNext}
+                disabled={!canGoNext}
+                className="flex items-center gap-1 px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg disabled:opacity-50"
+              >
+                Next
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/hooks/useDiscovery.ts
+++ b/ui/src/hooks/useDiscovery.ts
@@ -6,6 +6,7 @@ import type {
   DiscoveryAgentsResponse,
   SyncJob,
   SyncJobsResponse,
+  AgentProvisionResponse,
 } from '../api/types'
 
 export function useDiscoveryResources() {
@@ -97,6 +98,33 @@ export function useSyncJobs() {
   }, [])
 
   return { jobs, loading, error, fetch, triggerSync }
+}
+
+export function useAgentProvisioning() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<AgentProvisionResponse | null>(null)
+
+  const provision = useCallback(async (name: string) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await post<AgentProvisionResponse>(
+        '/api/v1/discovery/agents/provision',
+        { name },
+      )
+      setResult(resp)
+      return resp
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to provision agent'
+      setError(msg)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return { result, loading, error, provision }
 }
 
 export function useDiscoveryAgents() {

--- a/ui/src/hooks/usePools.ts
+++ b/ui/src/hooks/usePools.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
-import { get, post, del } from '../api/client'
-import type { Pool, PoolWithStats, CreatePoolRequest } from '../api/types'
+import { get, post, patch, del } from '../api/client'
+import type { Pool, PoolWithStats, CreatePoolRequest, UpdatePoolRequest } from '../api/types'
 
 export function usePools() {
   const [pools, setPools] = useState<Pool[]>([])
@@ -44,11 +44,17 @@ export function usePools() {
     return pool
   }, [])
 
+  const updatePool = useCallback(async (id: number, data: UpdatePoolRequest) => {
+    const updated = await patch<Pool>(`/api/v1/pools/${id}`, data)
+    setPools(prev => prev.map(p => p.id === id ? updated : p))
+    return updated
+  }, [])
+
   const deletePool = useCallback(async (id: number, force = false) => {
     const qs = force ? '?force=true' : ''
     await del(`/api/v1/pools/${id}${qs}`)
     setPools(prev => prev.filter(p => p.id !== id))
   }, [])
 
-  return { pools, hierarchy, loading, error, fetchPools, fetchHierarchy, getPool, createPool, deletePool }
+  return { pools, hierarchy, loading, error, fetchPools, fetchHierarchy, getPool, createPool, updatePool, deletePool }
 }

--- a/ui/src/pages/BlocksPage.tsx
+++ b/ui/src/pages/BlocksPage.tsx
@@ -1,22 +1,36 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Search, LayoutGrid } from 'lucide-react'
+import { Search, LayoutGrid, Pencil, Trash2, X } from 'lucide-react'
 import { useBlocks } from '../hooks/useBlocks'
 import { useAccounts } from '../hooks/useAccounts'
+import { useToast } from '../hooks/useToast'
+import { patch, del } from '../api/client'
 import StatusBadge from '../components/StatusBadge'
 import { formatHostCount, getHostCount } from '../utils/format'
+import type { Block, PoolType, PoolStatus, UpdatePoolRequest } from '../api/types'
 
 export default function BlocksPage() {
   const navigate = useNavigate()
   const { blocks, loading, error, fetchBlocks } = useBlocks()
   const { accounts, fetchAccounts } = useAccounts()
+  const { showToast } = useToast()
   const [search, setSearch] = useState('')
   const [accountFilter, setAccountFilter] = useState<string>('')
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [editBlock, setEditBlock] = useState<Block | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<Block | null>(null)
+  const [showBulkDelete, setShowBulkDelete] = useState(false)
+  const [actionLoading, setActionLoading] = useState(false)
 
   useEffect(() => {
     fetchBlocks()
     fetchAccounts()
   }, [fetchBlocks, fetchAccounts])
+
+  // Clear selection when filters change
+  useEffect(() => {
+    setSelectedIds(new Set())
+  }, [search, accountFilter])
 
   const filtered = useMemo(() => {
     return blocks.filter(b => {
@@ -30,6 +44,26 @@ export default function BlocksPage() {
     })
   }, [blocks, search, accountFilter])
 
+  const filteredIds = useMemo(() => new Set(filtered.map(b => b.id)), [filtered])
+  const isAllSelected = filtered.length > 0 && filtered.every(b => selectedIds.has(b.id))
+
+  const toggleSelect = useCallback((id: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const toggleSelectAll = useCallback(() => {
+    if (isAllSelected) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(filtered.map(b => b.id)))
+    }
+  }, [isAllSelected, filtered])
+
   // Summary stats
   const summaryStats = useMemo(() => {
     const totalBlocks = filtered.length
@@ -41,6 +75,51 @@ export default function BlocksPage() {
     }
     return { totalBlocks, totalIPs, uniqueAccounts: uniqueAccounts.size }
   }, [filtered])
+
+  async function handleDelete(block: Block) {
+    setActionLoading(true)
+    try {
+      await del(`/api/v1/pools/${block.id}`)
+      showToast(`Deleted ${block.name}`, 'success')
+      setDeleteTarget(null)
+      setSelectedIds(prev => {
+        const next = new Set(prev)
+        next.delete(block.id)
+        return next
+      })
+      await fetchBlocks()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Delete failed', 'error')
+    } finally {
+      setActionLoading(false)
+    }
+  }
+
+  async function handleBulkDelete() {
+    setActionLoading(true)
+    const ids = [...selectedIds].filter(id => filteredIds.has(id))
+    let deleted = 0
+    let failed = 0
+    for (const id of ids) {
+      try {
+        await del(`/api/v1/pools/${id}`)
+        deleted++
+      } catch {
+        failed++
+      }
+    }
+    showToast(
+      `Deleted ${deleted} block${deleted !== 1 ? 's' : ''}${failed > 0 ? `, ${failed} failed` : ''}`,
+      failed > 0 ? 'error' : 'success',
+    )
+    setSelectedIds(new Set())
+    setShowBulkDelete(false)
+    setActionLoading(false)
+    await fetchBlocks()
+  }
+
+  // Count only selected items visible in current filter
+  const visibleSelectedCount = [...selectedIds].filter(id => filteredIds.has(id)).length
 
   return (
     <div className="flex-1 overflow-auto p-6">
@@ -70,6 +149,28 @@ export default function BlocksPage() {
           ))}
         </select>
       </div>
+
+      {/* Action bar */}
+      {visibleSelectedCount > 0 && (
+        <div className="flex items-center gap-3 mb-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg px-4 py-2">
+          <span className="text-sm font-medium text-blue-700 dark:text-blue-300">
+            {visibleSelectedCount} block{visibleSelectedCount !== 1 ? 's' : ''} selected
+          </span>
+          <button
+            onClick={() => setShowBulkDelete(true)}
+            className="flex items-center gap-1 px-3 py-1 text-sm bg-red-600 hover:bg-red-700 text-white rounded"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+            Delete Selected
+          </button>
+          <button
+            onClick={() => setSelectedIds(new Set())}
+            className="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
+          >
+            Clear Selection
+          </button>
+        </div>
+      )}
 
       {/* Summary */}
       <div className="grid grid-cols-3 gap-4 mb-4">
@@ -109,19 +210,36 @@ export default function BlocksPage() {
           <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
+                <th className="px-4 py-2 text-left">
+                  <input
+                    type="checkbox"
+                    checked={isAllSelected}
+                    onChange={toggleSelectAll}
+                    className="rounded border-gray-300 dark:border-gray-600"
+                  />
+                </th>
                 <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Name</th>
                 <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">CIDR</th>
                 <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Parent</th>
                 <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Account</th>
                 <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Tier</th>
                 <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">IPs</th>
+                <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Actions</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
               {filtered.map(b => {
                 const hostCount = getHostCount(b.cidr)
                 return (
-                  <tr key={b.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                  <tr key={b.id} className={`hover:bg-gray-50 dark:hover:bg-gray-700/50 ${selectedIds.has(b.id) ? 'bg-blue-50 dark:bg-blue-900/10' : ''}`}>
+                    <td className="px-4 py-2">
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.has(b.id)}
+                        onChange={() => toggleSelect(b.id)}
+                        className="rounded border-gray-300 dark:border-gray-600"
+                      />
+                    </td>
                     <td className="px-4 py-2 text-sm font-medium text-gray-900 dark:text-gray-100">{b.name}</td>
                     <td className="px-4 py-2 text-sm font-mono text-gray-600 dark:text-gray-300">{b.cidr}</td>
                     <td className="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">{b.parent_name || '-'}</td>
@@ -130,6 +248,24 @@ export default function BlocksPage() {
                       {b.account_tier && <StatusBadge label={b.account_tier} variant="tier" />}
                     </td>
                     <td className="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">{formatHostCount(hostCount)}</td>
+                    <td className="px-4 py-2 text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <button
+                          onClick={() => setEditBlock(b)}
+                          title="Edit block"
+                          className="p-1 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => setDeleteTarget(b)}
+                          title="Delete block"
+                          className="p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </td>
                   </tr>
                 )
               })}
@@ -137,6 +273,220 @@ export default function BlocksPage() {
           </table>
         </div>
       )}
+
+      {/* Edit Modal */}
+      {editBlock && (
+        <EditBlockModal
+          block={editBlock}
+          accounts={accounts}
+          onClose={() => setEditBlock(null)}
+          onSaved={() => {
+            setEditBlock(null)
+            fetchBlocks()
+          }}
+        />
+      )}
+
+      {/* Single Delete Confirmation */}
+      {deleteTarget && (
+        <ConfirmDialog
+          title="Delete Block"
+          message={`Are you sure you want to delete "${deleteTarget.name}" (${deleteTarget.cidr})?`}
+          confirmLabel="Delete"
+          loading={actionLoading}
+          onConfirm={() => handleDelete(deleteTarget)}
+          onCancel={() => setDeleteTarget(null)}
+        />
+      )}
+
+      {/* Bulk Delete Confirmation */}
+      {showBulkDelete && (
+        <ConfirmDialog
+          title="Delete Selected Blocks"
+          message={`Are you sure you want to delete ${visibleSelectedCount} selected block${visibleSelectedCount !== 1 ? 's' : ''}? This cannot be undone.`}
+          confirmLabel={`Delete ${visibleSelectedCount} Block${visibleSelectedCount !== 1 ? 's' : ''}`}
+          loading={actionLoading}
+          onConfirm={handleBulkDelete}
+          onCancel={() => setShowBulkDelete(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+function EditBlockModal({
+  block,
+  accounts,
+  onClose,
+  onSaved,
+}: {
+  block: Block
+  accounts: { id: number; name: string }[]
+  onClose: () => void
+  onSaved: () => void
+}) {
+  const { showToast } = useToast()
+  const [name, setName] = useState(block.name)
+  const [accountId, setAccountId] = useState<string>(block.account_id ? String(block.account_id) : '')
+  const [type, setType] = useState(block.type || 'subnet')
+  const [status, setStatus] = useState(block.status || 'active')
+  const [description, setDescription] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      const data: UpdatePoolRequest = {}
+      if (name !== block.name) data.name = name
+      if (accountId !== (block.account_id ? String(block.account_id) : '')) {
+        data.account_id = accountId ? Number(accountId) : null
+      }
+      if (type !== (block.type || 'subnet')) data.type = type as PoolType
+      if (status !== (block.status || 'active')) data.status = status as PoolStatus
+      if (description) data.description = description
+
+      await patch(`/api/v1/pools/${block.id}`, data)
+      showToast(`Updated ${name}`, 'success')
+      onSaved()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Update failed', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4">
+        <div className="flex items-center justify-between px-6 py-4 border-b dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Edit Block</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="px-6 py-4 space-y-4">
+          <div className="text-sm text-gray-500 dark:text-gray-400 font-mono bg-gray-50 dark:bg-gray-900 px-3 py-2 rounded">
+            {block.cidr}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+            <input
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Account</label>
+            <select
+              value={accountId}
+              onChange={e => setAccountId(e.target.value)}
+              className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+            >
+              <option value="">None</option>
+              {accounts.map(a => (
+                <option key={a.id} value={a.id}>{a.name}</option>
+              ))}
+            </select>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type</label>
+              <select
+                value={type}
+                onChange={e => setType(e.target.value)}
+                className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+              >
+                <option value="supernet">Supernet</option>
+                <option value="region">Region</option>
+                <option value="environment">Environment</option>
+                <option value="vpc">VPC</option>
+                <option value="subnet">Subnet</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Status</label>
+              <select
+                value={status}
+                onChange={e => setStatus(e.target.value)}
+                className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+              >
+                <option value="planned">Planned</option>
+                <option value="active">Active</option>
+                <option value="deprecated">Deprecated</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description</label>
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              rows={3}
+              placeholder="Optional description..."
+              className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+            />
+          </div>
+        </div>
+        <div className="flex justify-end gap-3 px-6 py-4 border-t dark:border-gray-700">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 border dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || !name.trim()}
+            className="px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ConfirmDialog({
+  title,
+  message,
+  confirmLabel,
+  loading,
+  onConfirm,
+  onCancel,
+}: {
+  title: string
+  message: string
+  confirmLabel: string
+  loading: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-sm mx-4">
+        <div className="px-6 py-4">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">{title}</h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400">{message}</p>
+        </div>
+        <div className="flex justify-end gap-3 px-6 py-4 border-t dark:border-gray-700">
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 border dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={loading}
+            className="px-4 py-2 text-sm bg-red-600 hover:bg-red-700 text-white rounded-lg disabled:opacity-50"
+          >
+            {loading ? 'Deleting...' : confirmLabel}
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -9,6 +9,7 @@ import {
   ChevronDown,
   ChevronRight,
   Activity,
+  Wand2,
 } from 'lucide-react'
 import {
   useDiscoveryResources,
@@ -18,6 +19,7 @@ import {
 import { useAccounts } from '../hooks/useAccounts'
 import { useToast } from '../hooks/useToast'
 import StatusBadge from '../components/StatusBadge'
+import DiscoveryWizard from '../components/DiscoveryWizard'
 import { formatTimeAgo } from '../utils/format'
 import type {
   Account,
@@ -37,6 +39,7 @@ export default function DiscoveryPage() {
   const [linkedFilter, setLinkedFilter] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
   const [showGuide, setShowGuide] = useState(false)
+  const [showWizard, setShowWizard] = useState(false)
 
   const { accounts, fetchAccounts } = useAccounts()
   const {
@@ -61,7 +64,7 @@ export default function DiscoveryPage() {
     fetch: fetchAgents,
   } = useDiscoveryAgents()
   const { showToast } = useToast()
-  const agentsRefreshInterval = useRef<NodeJS.Timeout | null>(null)
+  const agentsRefreshInterval = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
     fetchAccounts()
@@ -178,12 +181,30 @@ export default function DiscoveryPage() {
             <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
               Cloud Discovery
             </h2>
-            <p className="text-gray-500 dark:text-gray-400">
+            <p className="text-gray-500 dark:text-gray-400 mb-4">
               Create a cloud account first to start discovering resources.
             </p>
+            <button
+              onClick={() => setShowWizard(true)}
+              className="inline-flex items-center gap-2 rounded bg-green-600 hover:bg-green-700 text-white px-4 py-2 text-sm"
+            >
+              <Wand2 className="w-4 h-4" />
+              Plan Discovery
+            </button>
           </div>
           <SetupGuide defaultOpen />
         </div>
+        {showWizard && (
+          <DiscoveryWizard
+            accounts={accounts}
+            onAccountCreated={fetchAccounts}
+            onClose={() => setShowWizard(false)}
+            onComplete={() => {
+              setTab('agents')
+              fetchAgents(selectedAccountId ?? undefined)
+            }}
+          />
+        )}
       </div>
     )
   }
@@ -216,6 +237,13 @@ export default function DiscoveryPage() {
               </option>
             ))}
           </select>
+          <button
+            onClick={() => setShowWizard(true)}
+            className="flex items-center gap-2 rounded bg-green-600 hover:bg-green-700 text-white px-4 py-1.5 text-sm"
+          >
+            <Wand2 className="w-4 h-4" />
+            Plan Discovery
+          </button>
           <button
             onClick={handleSync}
             className="flex items-center gap-2 rounded bg-blue-600 hover:bg-blue-700 text-white px-4 py-1.5 text-sm"
@@ -303,6 +331,14 @@ export default function DiscoveryPage() {
           agents={agents}
           loading={agentsLoading}
           error={agentsError}
+        />
+      )}
+
+      {showWizard && (
+        <DiscoveryWizard
+          accounts={accounts}
+          onAccountCreated={fetchAccounts}
+          onClose={() => setShowWizard(false)}
         />
       )}
     </div>

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,8 +12,8 @@
         }
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-BWCILrE4.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BwsPcj62.css">
+    <script type="module" crossorigin src="/assets/index-CIh5wwKb.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BHUMyRgw.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- Add AWS Organizations discovery mode: a single agent in the management account discovers VPCs, subnets, and EIPs across all member accounts via `sts:AssumeRole`
- New `POST /api/v1/discovery/ingest/org` bulk ingest endpoint that auto-creates CloudPAM Account records for new AWS accounts and upserts resources
- Terraform modules and CloudFormation StackSet for deploying IAM roles across the organization
- Discovery wizard now supports Organization mode with live agent connection polling

## What Changed

### Agent — Org Mode
- `cmd/cloudpam-agent/config.go`: `AWSOrg` config struct with env vars (`CLOUDPAM_AWS_ORG_ENABLED`, `_ROLE_NAME`, `_EXTERNAL_ID`, `_REGIONS`, `_EXCLUDE_ACCOUNTS`)
- `cmd/cloudpam-agent/main.go`: `runOrgSync()` — enumerates org accounts, filters excludes, AssumeRole per member, discovers resources, builds `BulkIngestRequest`
- `cmd/cloudpam-agent/pusher.go`: `PushOrgResources()` with retry/backoff

### AWS SDK Extensions
- `internal/discovery/aws/org.go`: `ListOrgAccounts()` via `organizations:ListAccounts` paginator (filters to ACTIVE)
- `internal/discovery/aws/assume_role.go`: `AssumeRole()` returns `aws.CredentialsProvider` via `stscreds.NewAssumeRoleProvider`
- `internal/discovery/aws/collector.go`: `NewWithCredentials()` constructor for injecting cross-account credentials

### Server — Bulk Ingest
- `POST /api/v1/discovery/ingest/org` handler: parses `BulkIngestRequest`, auto-creates accounts by key (`aws:<account_id>`), upserts resources
- `GetAccountByKey(ctx, key)` added to Store interface + MemoryStore, SQLite, PostgreSQL implementations
- `migrations/0012_account_key_unique.sql`: unique index on `accounts.key`
- Domain types: `OrgAccountIngest`, `BulkIngestRequest`, `BulkIngestResponse`

### Infrastructure as Code
- `deploy/terraform/aws-org-discovery/management-policy/`: IAM role (EC2+ECS trust), instance profile, 3 policies (org discovery, EC2 read-only, STS identity)
- `deploy/terraform/aws-org-discovery/member-role/`: Cross-account discovery role with least-privilege trust policy, partition-aware ARNs
- `deploy/cloudformation/discovery-role-stackset.yaml`: StackSet template for org-wide member role deployment

### Frontend — Discovery Wizard
- Mode toggle: "Single Account" vs "AWS Organization" radio cards
- Org mode fields: Role Name, External ID, Regions, Exclude Accounts
- Config generation for all tabs (Shell, YAML, Terraform, Docker) with org-aware environment variables
- New "IAM Setup" tab (org-mode only) with inline Terraform snippets
- Agent connection polling: spinner while waiting, green status when connected
- `onComplete` callback navigates to Agents tab

### Docs & Changelog
- `docs/DISCOVERY.md`: AWS Organizations section — architecture, setup, config reference, bulk ingest API, Terraform modules
- `docs/CHANGELOG.md`: Sprint 16b entry
- `CLAUDE.md`: updated implementation status, endpoints, env vars, project structure, migration reference

## Files Changed (27 files, +2296/-30)

| Category | Files |
|----------|-------|
| Agent | `config.go`, `main.go`, `pusher.go` |
| AWS SDK | `org.go` (new), `assume_role.go` (new), `collector.go` |
| Domain | `discovery.go` |
| Storage | `store.go`, `sqlite.go`, `postgres.go` |
| HTTP | `discovery_handlers.go` |
| Migration | `0012_account_key_unique.sql` (new) |
| Terraform | `management-policy/main.tf` (new), `member-role/main.tf` (new) |
| CloudFormation | `discovery-role-stackset.yaml` (new) |
| Frontend | `DiscoveryWizard.tsx` (new), `DiscoveryPage.tsx`, `types.ts`, `useDiscovery.ts`, `usePools.ts`, `BlocksPage.tsx` |
| Docs | `CHANGELOG.md`, `DISCOVERY.md`, `CLAUDE.md` |

## Test plan

- [x] `go test ./...` — all Go tests pass
- [x] `go test -race ./...` — no race conditions
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] `npx vitest run` — 34/34 frontend tests pass
- [x] `npm run build` — production build succeeds
- [x] `golangci-lint` — 0 issues (pre-commit hook)
- [ ] Manual: single-account agent mode still works unchanged
- [ ] Manual: org mode config parses from env vars and YAML
- [ ] Manual: `POST /api/v1/discovery/ingest/org` auto-creates accounts and upserts resources
- [ ] Manual: wizard shows org mode toggle, generates correct configs, IAM setup tab
- [ ] Manual: wizard polls for agent connection and shows live status

🤖 Generated with [Claude Code](https://claude.com/claude-code)