### PR TITLE
fix: changelog v0.3.1 — release workflow chain bugfix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/CHANGELOG.md`: this entry
 - `CLAUDE.md`: updated with org discovery endpoint, env vars, migration, deployment modules
 
+## [0.3.1] - 2026-02-14
+
+### Fixed
+- Auto-release workflow now chains container image and binary builds via `workflow_call` instead of relying on the `release: [published]` event, which is silently ignored when created by `GITHUB_TOKEN` (GitHub Actions limitation)
+- `release-builds.yml` and `container-images.yml` accept both `release: [published]` (manual releases) and `workflow_call` (auto-release), resolving the tag via `inputs.tag || github.event.release.tag_name`
+
 ## [0.3.0] - 2026-02-14
 
 ### Added - Release Infrastructure
@@ -517,7 +523,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IPv4 only (IPv6 planned)
 - Block detection marks exact CIDR matches as used
 
-[Unreleased]: https://github.com/BadgerOps/cloudpam/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/BadgerOps/cloudpam/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/BadgerOps/cloudpam/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/BadgerOps/cloudpam/releases/tag/v0.3.0
 [0.2.0]: https://github.com/BadgerOps/cloudpam/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/BadgerOps/cloudpam/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- Bumps changelog to v0.3.1 for the release workflow chain fix already on master
- When merged, the auto-release workflow will detect the new `## [0.3.1]` heading, create the GitHub Release + tag, and this time correctly chain into container image and binary builds via `workflow_call`

### What was fixed (on master in cf56ef2)
`GITHUB_TOKEN`-created events don't trigger other workflows (GitHub Actions limitation). The v0.3.0 auto-release created the GitHub Release, but the `release: [published]` event was silently dropped — so neither `container-images.yml` nor `release-builds.yml` ran.

The fix adds `workflow_call` triggers to both downstream workflows, and has `release.yml` call them directly with `uses:` after creating the release.

## Test plan
- [ ] Merge to master → auto-release creates v0.3.1 tag + GitHub Release
- [ ] Container Images workflow runs (called via `workflow_call`)
- [ ] Release Builds workflow runs (called via `workflow_call`)
- [ ] GHCR images published: `ghcr.io/badgerops/cloudpam/server:0.3.1` and `agent:0.3.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)