### PR TITLE
docs: fix broken README links, move planning docs to docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,22 +50,21 @@ Recent planning session produced these design documents:
 
 | Document | Purpose |
 |----------|---------|
-| `IMPLEMENTATION_ROADMAP.md` | 20-week phased implementation plan |
-| `REVIEW.md` | Code review with prioritized issues |
-| `DATABASE_SCHEMA.md` | Complete PostgreSQL/SQLite schema |
-| `AUTH_FLOWS.md` | OAuth2/OIDC and API key authentication |
-| `SMART_PLANNING.md` | Analysis engine and AI planning architecture |
-| `OBSERVABILITY.md` | Logging, metrics, tracing, audit logging |
-| `API_EXAMPLES.md` | API usage examples |
-| `DEPLOYMENT.md` | Kubernetes and cloud deployment guides |
-| `CLEANUP.md` | Documentation consolidation notes |
+| `docs/IMPLEMENTATION_ROADMAP.md` | 20-week phased implementation plan |
+| `docs/REVIEW.md` | Code review with prioritized issues |
+| `docs/DATABASE_SCHEMA.md` | Complete PostgreSQL/SQLite schema |
+| `docs/AUTH_FLOWS.md` | OAuth2/OIDC and API key authentication |
+| `docs/SMART_PLANNING.md` | Analysis engine and AI planning architecture |
+| `docs/OBSERVABILITY.md` | Logging, metrics, tracing, audit logging |
+| `docs/API_EXAMPLES.md` | API usage examples |
+| `docs/DEPLOYMENT.md` | Kubernetes and cloud deployment guides |
 | `docs/DISCOVERY.md` | Cloud discovery setup, AWS config, API reference |
 | `docs/DISCOVERY_AGENT_PLAN.md` | Standalone discovery agent architecture plan |
 
 **OpenAPI Specifications**:
 - `docs/openapi.yaml` - Core IPAM API (current)
-- `openapi-smart-planning.yaml` - Smart Planning API (planned)
-- `openapi-observability.yaml` - Audit/observability API (planned)
+- `.planning/openapi/openapi-smart-planning.yaml` - Smart Planning API (planned)
+- `.planning/openapi/openapi-observability.yaml` - Audit/observability API (planned)
 
 ## Build System & Commands
 

--- a/docs/API_EXAMPLES.md
+++ b/docs/API_EXAMPLES.md
@@ -1,0 +1,1430 @@
+# CloudPAM API Examples
+
+Practical examples for common API operations.
+
+## Authentication
+
+### Using API Key
+
+```bash
+# All requests require authentication
+curl -X GET "https://cloudpam.example.com/api/v1/pools" \
+  -H "X-API-Key: cpam_v1_abc12345_x7k9mN2pQr5tVw8yZa4bCd6eF"
+```
+
+### Using Bearer Token (from OAuth flow)
+
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/pools" \
+  -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIs..."
+```
+
+---
+
+## Pool Management
+
+### List All Pools (Flat)
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/pools?limit=10" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440001",
+      "name": "Global Address Space",
+      "description": "Root allocation for all networks",
+      "cidr": "10.0.0.0/8",
+      "type": "supernet",
+      "parent_id": null,
+      "tags": {
+        "managed_by": "cloudpam"
+      },
+      "created_at": "2024-01-10T08:00:00Z",
+      "updated_at": "2024-01-10T08:00:00Z"
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440002",
+      "name": "US East Region",
+      "cidr": "10.1.0.0/16",
+      "type": "region",
+      "parent_id": "550e8400-e29b-41d4-a716-446655440001",
+      "tags": {
+        "region": "us-east-1"
+      },
+      "created_at": "2024-01-10T08:05:00Z",
+      "updated_at": "2024-01-10T08:05:00Z"
+    }
+  ],
+  "meta": {
+    "total": 47,
+    "limit": 10,
+    "has_more": true,
+    "next_cursor": "eyJpZCI6IjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAxMCJ9"
+  }
+}
+```
+
+### Get Pool Tree (Hierarchical)
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/pools/tree" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "roots": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440001",
+      "name": "Global Address Space",
+      "cidr": "10.0.0.0/8",
+      "type": "supernet",
+      "utilization": {
+        "total_addresses": 16777216,
+        "allocated_addresses": 131072,
+        "available_addresses": 16646144,
+        "utilization_percent": 0.78,
+        "child_count": 2
+      },
+      "children": [
+        {
+          "id": "550e8400-e29b-41d4-a716-446655440002",
+          "name": "US East Region",
+          "cidr": "10.1.0.0/16",
+          "type": "region",
+          "utilization": {
+            "total_addresses": 65536,
+            "allocated_addresses": 1024,
+            "utilization_percent": 1.56,
+            "child_count": 3
+          },
+          "children": [
+            {
+              "id": "550e8400-e29b-41d4-a716-446655440010",
+              "name": "US East Production",
+              "cidr": "10.1.0.0/20",
+              "type": "environment",
+              "tags": { "environment": "production" },
+              "children": []
+            },
+            {
+              "id": "550e8400-e29b-41d4-a716-446655440011",
+              "name": "US East Staging",
+              "cidr": "10.1.16.0/20",
+              "type": "environment",
+              "tags": { "environment": "staging" },
+              "children": []
+            }
+          ]
+        },
+        {
+          "id": "550e8400-e29b-41d4-a716-446655440003",
+          "name": "US West Region",
+          "cidr": "10.2.0.0/16",
+          "type": "region",
+          "children": []
+        }
+      ]
+    }
+  ],
+  "total_pools": 47,
+  "max_depth": 5
+}
+```
+
+### Create Pool
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/pools" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "EU West Production VPC",
+    "description": "Production workloads in eu-west-1",
+    "cidr": "10.3.0.0/20",
+    "type": "vpc",
+    "parent_id": "550e8400-e29b-41d4-a716-446655440003",
+    "tags": {
+      "environment": "production",
+      "region": "eu-west-1",
+      "cost_center": "engineering"
+    }
+  }'
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440050",
+  "name": "EU West Production VPC",
+  "description": "Production workloads in eu-west-1",
+  "cidr": "10.3.0.0/20",
+  "type": "vpc",
+  "parent_id": "550e8400-e29b-41d4-a716-446655440003",
+  "tags": {
+    "environment": "production",
+    "region": "eu-west-1",
+    "cost_center": "engineering"
+  },
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T10:30:00Z",
+  "created_by": "550e8400-e29b-41d4-a716-446655440099"
+}
+```
+
+**Error Response (409 Conflict):**
+```json
+{
+  "error": {
+    "code": "CIDR_CONFLICT",
+    "message": "CIDR 10.3.0.0/20 overlaps with existing pool",
+    "conflicting_pools": [
+      {
+        "id": "550e8400-e29b-41d4-a716-446655440025",
+        "name": "EU West Staging",
+        "cidr": "10.3.0.0/22"
+      }
+    ]
+  }
+}
+```
+
+### Allocate from Pool
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/pools/550e8400-e29b-41d4-a716-446655440050/allocate" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "app-tier-subnet",
+    "prefix_length": 24,
+    "type": "subnet",
+    "strategy": "first_fit",
+    "tags": {
+      "tier": "application",
+      "auto_allocated": "true"
+    }
+  }'
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440051",
+  "name": "app-tier-subnet",
+  "cidr": "10.3.0.0/24",
+  "type": "subnet",
+  "parent_id": "550e8400-e29b-41d4-a716-446655440050",
+  "tags": {
+    "tier": "application",
+    "auto_allocated": "true"
+  },
+  "created_at": "2024-01-15T10:35:00Z",
+  "updated_at": "2024-01-15T10:35:00Z"
+}
+```
+
+### Validate CIDR Before Creation
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/pools/validate-cidr" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "cidr": "10.1.0.0/24",
+    "parent_id": "550e8400-e29b-41d4-a716-446655440002"
+  }'
+```
+
+**Response:**
+```json
+{
+  "valid": true,
+  "cidr": "10.1.0.0/24",
+  "normalized_cidr": "10.1.0.0/24",
+  "network_address": "10.1.0.0",
+  "broadcast_address": "10.1.0.255",
+  "total_addresses": 256,
+  "usable_addresses": 254,
+  "prefix_length": 24,
+  "ip_version": 4,
+  "fits_in_parent": true,
+  "conflicts": [
+    {
+      "pool_id": "550e8400-e29b-41d4-a716-446655440010",
+      "pool_name": "US East Production",
+      "cidr": "10.1.0.0/20",
+      "overlap_type": "contained_by"
+    }
+  ],
+  "warnings": [
+    "CIDR is contained within existing pool 'US East Production' (10.1.0.0/20)"
+  ]
+}
+```
+
+---
+
+## Schema Planning
+
+### List Available Templates
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/schema-templates?category=enterprise" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "template-enterprise-multi-region",
+      "name": "Enterprise Multi-Region",
+      "description": "Hierarchical structure for enterprises with multiple regions and environments",
+      "category": "enterprise",
+      "is_builtin": true,
+      "structure": {
+        "levels": [
+          { "name": "region", "prefix_length": 16, "naming_pattern": "{region}" },
+          { "name": "environment", "prefix_length": 20, "naming_pattern": "{region}-{env}" },
+          { "name": "vpc", "prefix_length": 22, "naming_pattern": "{region}-{env}-vpc{n}" },
+          { "name": "subnet", "prefix_length": 24, "naming_pattern": "{region}-{env}-{tier}" }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "regions",
+          "type": "multi_select",
+          "label": "Regions",
+          "required": true,
+          "options": [
+            { "value": "us-east-1", "label": "US East (N. Virginia)" },
+            { "value": "us-west-2", "label": "US West (Oregon)" },
+            { "value": "eu-west-1", "label": "EU (Ireland)" }
+          ]
+        },
+        {
+          "name": "environments",
+          "type": "multi_select",
+          "label": "Environments",
+          "required": true,
+          "default": "production,staging",
+          "options": [
+            { "value": "production", "label": "Production" },
+            { "value": "staging", "label": "Staging" },
+            { "value": "development", "label": "Development" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Generate Schema Plan
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/schema-plans/generate" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "template_id": "template-enterprise-multi-region",
+    "root_cidr": "10.0.0.0/8",
+    "parameters": {
+      "regions": ["us-east-1", "us-west-2"],
+      "environments": ["production", "staging"],
+      "vpcs_per_env": 2,
+      "subnets_per_vpc": 3
+    }
+  }'
+```
+
+**Response:**
+```json
+{
+  "id": null,
+  "name": "Generated Plan",
+  "status": "draft",
+  "template_id": "template-enterprise-multi-region",
+  "root_cidr": "10.0.0.0/8",
+  "parameters": {
+    "regions": ["us-east-1", "us-west-2"],
+    "environments": ["production", "staging"]
+  },
+  "pools": [
+    {
+      "temp_id": "tmp-1",
+      "name": "us-east-1",
+      "cidr": "10.0.0.0/16",
+      "type": "region",
+      "parent_temp_id": null,
+      "tags": { "region": "us-east-1" }
+    },
+    {
+      "temp_id": "tmp-2",
+      "name": "us-east-1-production",
+      "cidr": "10.0.0.0/20",
+      "type": "environment",
+      "parent_temp_id": "tmp-1",
+      "tags": { "region": "us-east-1", "environment": "production" }
+    },
+    {
+      "temp_id": "tmp-3",
+      "name": "us-east-1-production-vpc1",
+      "cidr": "10.0.0.0/22",
+      "type": "vpc",
+      "parent_temp_id": "tmp-2",
+      "tags": { "region": "us-east-1", "environment": "production", "vpc": "1" }
+    },
+    {
+      "temp_id": "tmp-4",
+      "name": "us-east-1-production-vpc1-app",
+      "cidr": "10.0.0.0/24",
+      "type": "subnet",
+      "parent_temp_id": "tmp-3",
+      "tags": { "tier": "application" }
+    },
+    {
+      "temp_id": "tmp-5",
+      "name": "us-east-1-production-vpc1-data",
+      "cidr": "10.0.1.0/24",
+      "type": "subnet",
+      "parent_temp_id": "tmp-3",
+      "tags": { "tier": "data" }
+    },
+    {
+      "temp_id": "tmp-6",
+      "name": "us-east-1-production-vpc1-web",
+      "cidr": "10.0.2.0/24",
+      "type": "subnet",
+      "parent_temp_id": "tmp-3",
+      "tags": { "tier": "web" }
+    }
+  ]
+}
+```
+
+### Save Schema Plan
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/schema-plans" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Q1 2024 Network Expansion",
+    "description": "Adding US West and EU regions for global expansion",
+    "template_id": "template-enterprise-multi-region",
+    "root_cidr": "10.0.0.0/8",
+    "pools": [
+      {
+        "temp_id": "tmp-1",
+        "name": "us-west-2",
+        "cidr": "10.2.0.0/16",
+        "type": "region",
+        "parent_temp_id": null,
+        "tags": { "region": "us-west-2" }
+      }
+    ]
+  }'
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440100",
+  "name": "Q1 2024 Network Expansion",
+  "description": "Adding US West and EU regions for global expansion",
+  "status": "draft",
+  "template_id": "template-enterprise-multi-region",
+  "root_cidr": "10.0.0.0/8",
+  "pools": [...],
+  "created_at": "2024-01-15T11:00:00Z",
+  "updated_at": "2024-01-15T11:00:00Z",
+  "created_by": "550e8400-e29b-41d4-a716-446655440099"
+}
+```
+
+### Preview Plan Application
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/schema-plans/550e8400-e29b-41d4-a716-446655440100/preview" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "pools": [
+    {
+      "temp_id": "tmp-1",
+      "name": "us-west-2",
+      "cidr": "10.2.0.0/16",
+      "type": "region",
+      "status": "will_create"
+    }
+  ],
+  "total_pools": 12,
+  "conflicts": [],
+  "warnings": [
+    "Pool 'us-west-2' (10.2.0.0/16) will use 25% of remaining address space"
+  ]
+}
+```
+
+### Apply Schema Plan
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/schema-plans/550e8400-e29b-41d4-a716-446655440100/apply" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "dry_run": false }'
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "pools_created": 12,
+  "pools": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440200",
+      "name": "us-west-2",
+      "cidr": "10.2.0.0/16",
+      "type": "region"
+    }
+  ],
+  "errors": []
+}
+```
+
+---
+
+## Cloud Accounts
+
+### Add AWS Account
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/accounts" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Production AWS",
+    "provider": "aws",
+    "provider_account_id": "123456789012",
+    "auth_type": "iam_role",
+    "auth_config": {
+      "role_arn": "arn:aws:iam::123456789012:role/CloudPAMDiscovery",
+      "external_id": "cloudpam-prod-abc123"
+    },
+    "regions": ["us-east-1", "us-west-2", "eu-west-1"],
+    "auto_sync": true,
+    "sync_interval_minutes": 30
+  }'
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440300",
+  "name": "Production AWS",
+  "provider": "aws",
+  "status": "connected",
+  "provider_account_id": "123456789012",
+  "auth_type": "iam_role",
+  "auth_config": {
+    "role_arn": "arn:aws:iam::123456789012:role/CloudPAMDiscovery"
+  },
+  "regions": ["us-east-1", "us-west-2", "eu-west-1"],
+  "last_sync": null,
+  "resource_counts": {
+    "vpcs": 0,
+    "subnets": 0,
+    "network_interfaces": 0,
+    "elastic_ips": 0
+  },
+  "created_at": "2024-01-15T12:00:00Z",
+  "updated_at": "2024-01-15T12:00:00Z"
+}
+```
+
+### Add GCP Account
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/accounts" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Production GCP",
+    "provider": "gcp",
+    "provider_account_id": "my-gcp-project-123",
+    "auth_type": "workload_identity",
+    "auth_config": {
+      "service_account_email": "cloudpam@my-gcp-project-123.iam.gserviceaccount.com",
+      "project_id": "my-gcp-project-123"
+    },
+    "regions": ["us-central1", "us-east1", "europe-west1"],
+    "auto_sync": true
+  }'
+```
+
+### Test Account Connection
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/accounts/550e8400-e29b-41d4-a716-446655440300/test" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "latency_ms": 245,
+  "permissions_valid": true,
+  "missing_permissions": [],
+  "error": null
+}
+```
+
+**Error Response:**
+```json
+{
+  "success": false,
+  "latency_ms": 1523,
+  "permissions_valid": false,
+  "missing_permissions": [
+    "ec2:DescribeSubnets",
+    "ec2:DescribeNetworkInterfaces"
+  ],
+  "error": "Access denied for ec2:DescribeSubnets"
+}
+```
+
+### Trigger Manual Sync
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/accounts/550e8400-e29b-41d4-a716-446655440300/sync" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response (202 Accepted):**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440400",
+  "account_id": "550e8400-e29b-41d4-a716-446655440300",
+  "status": "pending",
+  "started_at": "2024-01-15T12:30:00Z",
+  "completed_at": null
+}
+```
+
+---
+
+## Discovery
+
+### List Discovered Resources
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/discovery/resources?account_id=550e8400-e29b-41d4-a716-446655440300&status=untracked&limit=20" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440500",
+      "account_id": "550e8400-e29b-41d4-a716-446655440300",
+      "provider": "aws",
+      "resource_type": "vpc",
+      "resource_id": "vpc-0abc123def456789",
+      "name": "production-vpc",
+      "region": "us-east-1",
+      "cidr": "172.16.0.0/16",
+      "status": "untracked",
+      "linked_pool_id": null,
+      "metadata": {
+        "aws_vpc_id": "vpc-0abc123def456789",
+        "is_default": false,
+        "state": "available",
+        "tags": {
+          "Name": "production-vpc",
+          "Environment": "production"
+        }
+      },
+      "first_seen": "2024-01-15T12:35:00Z",
+      "last_seen": "2024-01-15T12:35:00Z"
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440501",
+      "account_id": "550e8400-e29b-41d4-a716-446655440300",
+      "provider": "aws",
+      "resource_type": "subnet",
+      "resource_id": "subnet-0abc123def456789",
+      "name": "production-app-subnet",
+      "region": "us-east-1",
+      "cidr": "172.16.1.0/24",
+      "status": "untracked",
+      "linked_pool_id": null,
+      "metadata": {
+        "aws_subnet_id": "subnet-0abc123def456789",
+        "vpc_id": "vpc-0abc123def456789",
+        "availability_zone": "us-east-1a",
+        "available_ip_count": 251
+      },
+      "first_seen": "2024-01-15T12:35:00Z",
+      "last_seen": "2024-01-15T12:35:00Z"
+    }
+  ],
+  "meta": {
+    "total": 47,
+    "limit": 20,
+    "has_more": true,
+    "next_cursor": "eyJpZCI6IjU1MGU4NDAw..."
+  }
+}
+```
+
+### Link Resource to Pool
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/discovery/resources/550e8400-e29b-41d4-a716-446655440500/link" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pool_id": "550e8400-e29b-41d4-a716-446655440050"
+  }'
+```
+
+**Response:**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440500",
+  "status": "tracked",
+  "linked_pool_id": "550e8400-e29b-41d4-a716-446655440050"
+}
+```
+
+### Get Drift Report
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/discovery/drift?severity=warning" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "generated_at": "2024-01-15T13:00:00Z",
+  "summary": {
+    "total_resources": 156,
+    "tracked": 142,
+    "untracked": 8,
+    "conflicts": 4,
+    "orphaned": 2
+  },
+  "items": [
+    {
+      "resource": {
+        "id": "550e8400-e29b-41d4-a716-446655440510",
+        "resource_type": "subnet",
+        "resource_id": "subnet-0xyz789",
+        "name": "unknown-subnet",
+        "cidr": "10.1.5.0/24"
+      },
+      "drift_type": "untracked",
+      "severity": "warning",
+      "expected": null,
+      "actual": {
+        "cidr": "10.1.5.0/24",
+        "region": "us-east-1"
+      },
+      "recommendation": "This subnet exists in AWS but is not managed by CloudPAM. Consider linking it to an existing pool or creating a new pool."
+    },
+    {
+      "resource": {
+        "id": "550e8400-e29b-41d4-a716-446655440511",
+        "resource_type": "subnet",
+        "resource_id": "subnet-0conflict",
+        "name": "conflicting-subnet",
+        "cidr": "10.1.0.0/24"
+      },
+      "drift_type": "conflict",
+      "severity": "critical",
+      "expected": {
+        "pool_name": "us-east-production-app",
+        "cidr": "10.1.0.0/24"
+      },
+      "actual": {
+        "cidr": "10.1.0.0/25",
+        "region": "us-east-1"
+      },
+      "recommendation": "CIDR mismatch: Pool defines 10.1.0.0/24 but AWS shows 10.1.0.0/25. Update pool or investigate AWS configuration."
+    }
+  ]
+}
+```
+
+---
+
+## AI Planning
+
+### Create Conversation
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/planning/ai/conversations" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+    "user_id": "550e8400-e29b-41d4-a716-446655440099",
+    "title": "Kubernetes Cluster Planning"
+  }'
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "conv-550e8400-e29b-41d4-a716-446655441000",
+  "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+  "user_id": "550e8400-e29b-41d4-a716-446655440099",
+  "title": "Kubernetes Cluster Planning",
+  "status": "active",
+  "messages": [],
+  "generated_plans": [],
+  "context": {
+    "available_pools": 12,
+    "total_available_space": "10.0.0.0/8 - 67% available"
+  },
+  "created_at": "2024-01-15T15:00:00Z",
+  "updated_at": "2024-01-15T15:00:00Z"
+}
+```
+
+### Send Message (User Intent)
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/planning/ai/conversations/conv-550e8400-e29b-41d4-a716-446655441000/messages" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "I need to plan networking for a new Kubernetes cluster in production. We will have about 100 nodes and use Calico for pod networking. The cluster will be in us-east-1."
+  }'
+```
+
+**Response (AI generates plan):**
+```json
+{
+  "id": "msg-550e8400-e29b-41d4-a716-446655441001",
+  "role": "assistant",
+  "content": "Based on your current production infrastructure (10.1.0.0/16, region-first hierarchy), I recommend the following allocation for your Kubernetes cluster:\n\n**Node Network**: 10.1.8.0/22 (1,024 addresses)\n- Room for 100 nodes + growth headroom\n- Adjacent to existing production workloads\n\n**Pod CIDR**: 10.1.64.0/18 (16,384 addresses)\n- Calico default 256 pods per node = 25,600 pods max\n- A /18 provides good runway\n\n**Service CIDR**: 10.1.128.0/20 (4,096 addresses)\n- Kubernetes services typically need fewer IPs\n\nWould you like me to create this plan?",
+  "generated_plan": {
+    "id": "plan-550e8400-e29b-41d4-a716-446655441100",
+    "name": "k8s-cluster-us-east-1",
+    "status": "draft",
+    "allocations": [
+      {
+        "name": "k8s-nodes",
+        "cidr": "10.1.8.0/22",
+        "type": "subnet",
+        "purpose": "Kubernetes node network"
+      },
+      {
+        "name": "k8s-pods",
+        "cidr": "10.1.64.0/18",
+        "type": "pod_cidr",
+        "purpose": "Calico pod network"
+      },
+      {
+        "name": "k8s-services",
+        "cidr": "10.1.128.0/20",
+        "type": "service_cidr",
+        "purpose": "Kubernetes services"
+      }
+    ],
+    "warnings": []
+  },
+  "ai_metadata": {
+    "model": "claude-3-5-sonnet",
+    "provider": "anthropic",
+    "tokens_used": 1247
+  },
+  "created_at": "2024-01-15T15:01:00Z"
+}
+```
+
+### List Conversation Plans
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/planning/ai/conversations/conv-550e8400-e29b-41d4-a716-446655441000/plans" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "plans": [
+    {
+      "id": "plan-550e8400-e29b-41d4-a716-446655441100",
+      "name": "k8s-cluster-us-east-1",
+      "status": "draft",
+      "created_at": "2024-01-15T15:01:00Z",
+      "allocation_count": 3,
+      "total_addresses": 21504
+    }
+  ]
+}
+```
+
+### Validate Plan Before Applying
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/planning/ai/conversations/conv-550e8400-e29b-41d4-a716-446655441000/plans/plan-550e8400-e29b-41d4-a716-446655441100/validate" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "valid": true,
+  "warnings": [
+    {
+      "code": "LARGE_ALLOCATION",
+      "message": "Pod CIDR 10.1.64.0/18 allocates 16,384 addresses. Consider if this is necessary.",
+      "severity": "info"
+    }
+  ],
+  "conflicts": []
+}
+```
+
+### Apply Plan (Dry Run)
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/planning/ai/conversations/conv-550e8400-e29b-41d4-a716-446655441000/plans/plan-550e8400-e29b-41d4-a716-446655441100/apply" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dry_run": true,
+    "confirm": false
+  }'
+```
+
+**Response (Dry Run Preview):**
+```json
+{
+  "success": true,
+  "dry_run": true,
+  "pools_to_create": 3,
+  "preview": [
+    {
+      "name": "k8s-nodes",
+      "cidr": "10.1.8.0/22",
+      "parent": "us-east-1-production",
+      "action": "create"
+    },
+    {
+      "name": "k8s-pods",
+      "cidr": "10.1.64.0/18",
+      "parent": "us-east-1-production",
+      "action": "create"
+    },
+    {
+      "name": "k8s-services",
+      "cidr": "10.1.128.0/20",
+      "parent": "us-east-1-production",
+      "action": "create"
+    }
+  ],
+  "summary": "This will create 3 pools with a total of 21,504 IP addresses."
+}
+```
+
+### Apply Plan (Confirmed)
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/planning/ai/conversations/conv-550e8400-e29b-41d4-a716-446655441000/plans/plan-550e8400-e29b-41d4-a716-446655441100/apply" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dry_run": false,
+    "confirm": true
+  }'
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "pools_created": 3,
+  "summary": "Created 3 pools for Kubernetes cluster in us-east-1",
+  "created_pools": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655442001",
+      "name": "k8s-nodes",
+      "cidr": "10.1.8.0/22"
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655442002",
+      "name": "k8s-pods",
+      "cidr": "10.1.64.0/18"
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655442003",
+      "name": "k8s-services",
+      "cidr": "10.1.128.0/20"
+    }
+  ]
+}
+```
+
+### Export Plan as Terraform
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/planning/ai/conversations/conv-550e8400-e29b-41d4-a716-446655441000/plans/plan-550e8400-e29b-41d4-a716-446655441100/export?format=terraform" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "format": "terraform",
+  "content": "# Generated by CloudPAM AI Planning\n# Plan: k8s-cluster-us-east-1\n\nresource \"aws_subnet\" \"k8s_nodes\" {\n  vpc_id     = var.vpc_id\n  cidr_block = \"10.1.8.0/22\"\n\n  tags = {\n    Name        = \"k8s-nodes\"\n    Environment = \"production\"\n    ManagedBy   = \"cloudpam\"\n  }\n}\n\nresource \"aws_subnet\" \"k8s_pods\" {\n  vpc_id     = var.vpc_id\n  cidr_block = \"10.1.64.0/18\"\n\n  tags = {\n    Name        = \"k8s-pods\"\n    Environment = \"production\"\n    ManagedBy   = \"cloudpam\"\n  }\n}\n\nresource \"aws_subnet\" \"k8s_services\" {\n  vpc_id     = var.vpc_id\n  cidr_block = \"10.1.128.0/20\"\n\n  tags = {\n    Name        = \"k8s-services\"\n    Environment = \"production\"\n    ManagedBy   = \"cloudpam\"\n  }\n}\n"
+}
+```
+
+### Update Conversation Title
+
+**Request:**
+```bash
+curl -X PATCH "https://cloudpam.example.com/api/v1/planning/ai/conversations/conv-550e8400-e29b-41d4-a716-446655441000" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "K8s Production Cluster - US East"
+  }'
+```
+
+**Response:**
+```json
+{
+  "id": "conv-550e8400-e29b-41d4-a716-446655441000",
+  "title": "K8s Production Cluster - US East",
+  "status": "active",
+  "updated_at": "2024-01-15T15:10:00Z"
+}
+```
+
+### Delete/Archive Conversation
+
+**Request:**
+```bash
+curl -X DELETE "https://cloudpam.example.com/api/v1/planning/ai/conversations/conv-550e8400-e29b-41d4-a716-446655441000" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:** `204 No Content`
+
+---
+
+## Users and Roles
+
+### List Users
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/users" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440099",
+      "email": "admin@example.com",
+      "name": "Admin User",
+      "status": "active",
+      "role": {
+        "id": "role-admin",
+        "name": "Admin"
+      },
+      "teams": [
+        { "id": "team-1", "name": "Platform Team", "role": "lead" }
+      ],
+      "last_login": "2024-01-15T09:00:00Z",
+      "created_at": "2024-01-01T00:00:00Z"
+    }
+  ],
+  "meta": {
+    "total": 15,
+    "limit": 20,
+    "has_more": false
+  }
+}
+```
+
+### Invite User
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/users" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "newuser@example.com",
+    "name": "New User",
+    "role_id": "role-editor",
+    "team_ids": ["team-1", "team-2"]
+  }'
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440150",
+  "email": "newuser@example.com",
+  "name": "New User",
+  "status": "invited",
+  "role": {
+    "id": "role-editor",
+    "name": "Editor"
+  },
+  "teams": [
+    { "id": "team-1", "name": "Platform Team", "role": "member" },
+    { "id": "team-2", "name": "US East Team", "role": "member" }
+  ],
+  "created_at": "2024-01-15T14:00:00Z"
+}
+```
+
+### Create API Token
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/api-tokens" \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "CI/CD Pipeline Token",
+    "scopes": ["pools:read", "pools:write", "discovery:read"],
+    "expires_in_days": 90
+  }'
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440600",
+  "name": "CI/CD Pipeline Token",
+  "prefix": "abc12345",
+  "token": "cpam_v1_abc12345_x7k9mN2pQr5tVw8yZa4bCd6eFgHiJkLmNoPqRsTuVwXyZ",
+  "scopes": ["pools:read", "pools:write", "discovery:read"],
+  "expires_at": "2024-04-15T14:00:00Z",
+  "created_at": "2024-01-15T14:00:00Z",
+  "created_by": "550e8400-e29b-41d4-a716-446655440099"
+}
+```
+
+> **Note:** The full `token` value is only returned once at creation. Store it securely!
+
+---
+
+## Audit Log
+
+### Query Audit Events
+
+**Request:**
+```bash
+curl -X GET "https://cloudpam.example.com/api/v1/audit/events?resource_type=pool&action=create&from=2024-01-01T00:00:00Z&limit=10" \
+  -H "X-API-Key: $API_KEY"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440700",
+      "timestamp": "2024-01-15T10:30:00Z",
+      "actor": {
+        "id": "550e8400-e29b-41d4-a716-446655440099",
+        "type": "user",
+        "name": "Admin User",
+        "email": "admin@example.com",
+        "ip_address": "192.168.1.100"
+      },
+      "action": "create",
+      "resource_type": "pool",
+      "resource_id": "550e8400-e29b-41d4-a716-446655440050",
+      "resource_name": "EU West Production VPC",
+      "changes": {
+        "before": null,
+        "after": {
+          "name": "EU West Production VPC",
+          "cidr": "10.3.0.0/20",
+          "type": "vpc"
+        }
+      },
+      "metadata": {
+        "request_id": "req-abc123",
+        "user_agent": "Mozilla/5.0..."
+      }
+    }
+  ],
+  "meta": {
+    "total": 234,
+    "limit": 10,
+    "has_more": true,
+    "next_cursor": "eyJ0cyI6IjIwMjQtMDEtMTVUMTA6MjU6MDBaIn0="
+  }
+}
+```
+
+### Export Audit Log
+
+**Request:**
+```bash
+curl -X POST "https://cloudpam.example.com/api/v1/audit/export" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "format": "csv",
+    "from": "2024-01-01T00:00:00Z",
+    "to": "2024-01-31T23:59:59Z",
+    "filters": {
+      "actions": ["create", "delete"],
+      "resource_types": ["pool", "account"]
+    }
+  }'
+```
+
+**Response (CSV):**
+```csv
+timestamp,actor_email,action,resource_type,resource_id,resource_name,ip_address
+2024-01-15T10:30:00Z,admin@example.com,create,pool,550e8400...,EU West Production VPC,192.168.1.100
+2024-01-14T15:45:00Z,admin@example.com,create,account,550e8400...,Production AWS,192.168.1.100
+```
+
+---
+
+## Error Handling
+
+### Validation Error
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "fields": [
+      {
+        "field": "cidr",
+        "message": "Invalid CIDR notation",
+        "code": "INVALID_FORMAT"
+      },
+      {
+        "field": "name",
+        "message": "Name is required",
+        "code": "REQUIRED"
+      }
+    ]
+  }
+}
+```
+
+### Authentication Error
+
+```json
+{
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "Invalid or expired API key"
+  }
+}
+```
+
+### Permission Error
+
+```json
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "You do not have permission to delete pools",
+    "details": {
+      "required_permission": "pools:delete",
+      "user_permissions": ["pools:read", "pools:write"]
+    }
+  }
+}
+```
+
+### Rate Limit Error
+
+```json
+{
+  "error": {
+    "code": "RATE_LIMITED",
+    "message": "Too many requests",
+    "details": {
+      "limit": 100,
+      "reset_at": "2024-01-15T14:01:00Z"
+    }
+  }
+}
+```
+
+---
+
+## SDK Examples
+
+### Go Client
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "github.com/badgerops/cloudpam-go"
+)
+
+func main() {
+    client := cloudpam.NewClient(
+        cloudpam.WithAPIKey("cpam_v1_abc12345_..."),
+        cloudpam.WithBaseURL("https://cloudpam.example.com"),
+    )
+
+    // List pools
+    pools, err := client.Pools.List(context.Background(), &cloudpam.PoolListOptions{
+        Type:   cloudpam.PoolTypeVPC,
+        Limit:  20,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for _, pool := range pools.Data {
+        fmt.Printf("Pool: %s (%s)\n", pool.Name, pool.CIDR)
+    }
+
+    // Create pool
+    newPool, err := client.Pools.Create(context.Background(), &cloudpam.CreatePoolRequest{
+        Name:     "New Subnet",
+        CIDR:     "10.5.0.0/24",
+        Type:     cloudpam.PoolTypeSubnet,
+        ParentID: "parent-pool-id",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Created pool: %s\n", newPool.ID)
+}
+```
+
+### Python Client
+
+```python
+from cloudpam import CloudPAMClient
+
+client = CloudPAMClient(
+    api_key="cpam_v1_abc12345_...",
+    base_url="https://cloudpam.example.com"
+)
+
+# List pools
+pools = client.pools.list(type="vpc", limit=20)
+for pool in pools.data:
+    print(f"Pool: {pool.name} ({pool.cidr})")
+
+# Create pool
+new_pool = client.pools.create(
+    name="New Subnet",
+    cidr="10.5.0.0/24",
+    type="subnet",
+    parent_id="parent-pool-id"
+)
+print(f"Created pool: {new_pool.id}")
+
+# Allocate from pool
+allocated = client.pools.allocate(
+    pool_id="parent-pool-id",
+    prefix_length=26,
+    name="web-tier",
+    tags={"tier": "web"}
+)
+print(f"Allocated: {allocated.cidr}")
+```
+
+### Terraform Provider
+
+```hcl
+terraform {
+  required_providers {
+    cloudpam = {
+      source  = "badgerops/cloudpam"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "cloudpam" {
+  api_key  = var.cloudpam_api_key
+  base_url = "https://cloudpam.example.com"
+}
+
+# Allocate a new subnet from a pool
+resource "cloudpam_allocation" "app_subnet" {
+  pool_id       = "parent-pool-id"
+  name          = "app-subnet-${var.environment}"
+  prefix_length = 24
+  type          = "subnet"
+
+  tags = {
+    environment = var.environment
+    tier        = "application"
+  }
+}
+
+# Use the allocated CIDR in AWS
+resource "aws_subnet" "app" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = cloudpam_allocation.app_subnet.cidr
+
+  tags = {
+    Name = cloudpam_allocation.app_subnet.name
+  }
+}
+```

--- a/docs/AUTH_FLOWS.md
+++ b/docs/AUTH_FLOWS.md
@@ -1,0 +1,588 @@
+# CloudPAM Authentication & Authorization
+
+This document details the authentication and authorization architecture for CloudPAM.
+
+## Overview
+
+CloudPAM supports two authentication methods:
+1. **OAuth 2.0 / OIDC** - For user sessions via web UI
+2. **API Keys** - For programmatic access and integrations
+
+Authorization uses Role-Based Access Control (RBAC) with future support for Attribute-Based Access Control (ABAC).
+
+## Authentication Flows
+
+### 1. OAuth 2.0 / OIDC Flow (User Sessions)
+
+CloudPAM acts as an OIDC Relying Party, supporting any OIDC-compliant Identity Provider.
+
+```
+┌─────────┐      ┌──────────────┐      ┌─────────────────┐      ┌─────────┐
+│  User   │      │  CloudPAM    │      │  Identity       │      │ CloudPAM│
+│ Browser │      │  Frontend    │      │  Provider       │      │   API   │
+└────┬────┘      └──────┬───────┘      └────────┬────────┘      └────┬────┘
+     │                  │                       │                     │
+     │  1. Click Login  │                       │                     │
+     │─────────────────>│                       │                     │
+     │                  │                       │                     │
+     │  2. Redirect to IdP                      │                     │
+     │<─────────────────│                       │                     │
+     │                  │                       │                     │
+     │  3. Authenticate with IdP               │                     │
+     │─────────────────────────────────────────>│                     │
+     │                  │                       │                     │
+     │  4. IdP redirects with auth code         │                     │
+     │<────────────────────────────────────────│                     │
+     │                  │                       │                     │
+     │  5. Send code to backend                │                     │
+     │─────────────────────────────────────────────────────────────>│
+     │                  │                       │                     │
+     │                  │      6. Exchange code for tokens           │
+     │                  │                       │<────────────────────│
+     │                  │                       │                     │
+     │                  │      7. Return tokens │                     │
+     │                  │                       │────────────────────>│
+     │                  │                       │                     │
+     │  8. Set session cookie + return user     │                     │
+     │<────────────────────────────────────────────────────────────│
+     │                  │                       │                     │
+```
+
+#### Token Flow Details
+
+1. **Authorization Request**: Frontend redirects to IdP with:
+   - `client_id`: CloudPAM's registered client ID
+   - `redirect_uri`: Callback URL (e.g., `https://cloudpam.example.com/auth/callback`)
+   - `response_type`: `code`
+   - `scope`: `openid profile email`
+   - `state`: CSRF protection token
+   - `nonce`: Replay attack protection
+
+2. **Token Exchange**: Backend exchanges auth code for tokens:
+   - `access_token`: Short-lived (1 hour), used for API calls
+   - `id_token`: Contains user identity claims
+   - `refresh_token`: Long-lived (7 days), used to refresh access tokens
+
+3. **Session Management**:
+   - HTTP-only secure cookie stores encrypted session ID
+   - Session maps to user record and cached permissions
+   - Access token refresh happens automatically before expiration
+
+#### API Endpoints
+
+```
+POST /api/v1/auth/login
+  - Initiates OAuth flow, returns redirect URL
+
+GET /api/v1/auth/callback?code=...&state=...
+  - Handles OAuth callback, exchanges code for tokens
+  - Creates/updates user record
+  - Returns session cookie
+
+POST /api/v1/auth/refresh
+  - Refreshes access token using refresh token
+  - Called automatically by frontend
+
+POST /api/v1/auth/logout
+  - Invalidates session
+  - Optionally triggers IdP logout (if supported)
+
+GET /api/v1/auth/userinfo
+  - Returns current user info from session
+```
+
+#### IdP Configuration
+
+CloudPAM supports these Identity Providers:
+
+| Provider | Configuration |
+|----------|---------------|
+| Okta | Standard OIDC discovery |
+| Azure AD | Standard OIDC + tenant-specific endpoints |
+| Google Workspace | Standard OIDC |
+| Auth0 | Standard OIDC discovery |
+| Keycloak | Standard OIDC discovery |
+| Generic OIDC | Manual endpoint configuration |
+
+**Required IdP Claims:**
+- `sub` - Unique user identifier
+- `email` - User email (required)
+- `name` - Display name (optional)
+- `picture` - Avatar URL (optional)
+- `groups` - Group membership for role mapping (optional)
+
+### 2. API Key Authentication
+
+For programmatic access without user context (CI/CD, scripts, integrations).
+
+```
+┌──────────────┐                              ┌─────────────────┐
+│   Client     │                              │   CloudPAM API  │
+│ (Script/CI)  │                              │                 │
+└──────┬───────┘                              └────────┬────────┘
+       │                                               │
+       │  Request with X-API-Key header               │
+       │──────────────────────────────────────────────>│
+       │                                               │
+       │                        Validate key, check scopes
+       │                                               │
+       │  Response (or 401/403)                        │
+       │<──────────────────────────────────────────────│
+       │                                               │
+```
+
+#### API Key Format
+
+```
+cpam_v1_<prefix>_<secret>
+
+Example: cpam_v1_abc12345_x7k9mN2pQr5tVw8yZa4bCd6eF
+         │    │  │        │
+         │    │  │        └─ Secret portion (never logged)
+         │    │  └─ Prefix for identification (logged, displayed)
+         │    └─ Version identifier
+         └─ CloudPAM identifier
+```
+
+#### Key Storage
+
+- API keys are hashed (Argon2id) before storage
+- Only the prefix is stored in plaintext for identification
+- Full key is shown exactly once at creation time
+
+#### Key Scopes
+
+API keys have granular scopes limiting their access:
+
+| Scope | Description |
+|-------|-------------|
+| `pools:read` | Read pool information |
+| `pools:write` | Create, update, delete pools |
+| `accounts:read` | Read cloud account info |
+| `accounts:write` | Manage cloud accounts |
+| `discovery:read` | Read discovered resources |
+| `discovery:sync` | Trigger discovery syncs |
+| `schema:read` | Read schema plans/templates |
+| `schema:write` | Create and apply schema plans |
+| `audit:read` | Read audit logs |
+| `users:read` | Read user information (admin) |
+| `users:write` | Manage users (admin) |
+| `org:read` | Read organization settings |
+| `org:write` | Manage organization (admin) |
+
+#### Rate Limiting
+
+API keys have configurable rate limits:
+
+```yaml
+# Per-key configuration
+rate_limit:
+  requests_per_minute: 100   # Default
+  requests_per_hour: 1000
+  burst: 20                   # Max concurrent requests
+```
+
+## Authorization (RBAC)
+
+### Built-in Roles
+
+| Role | Description | Key Permissions |
+|------|-------------|-----------------|
+| **Admin** | Full access | All permissions |
+| **Editor** | Manage resources | pools:*, accounts:*, schema:*, discovery:* |
+| **Viewer** | Read-only access | *:read only |
+
+### Permission Structure
+
+Permissions follow the pattern: `resource:action`
+
+```
+pools:read          - View pools
+pools:write         - Create/update pools
+pools:delete        - Delete pools
+pools:allocate      - Allocate from pools
+
+accounts:read       - View cloud accounts
+accounts:write      - Create/update accounts
+accounts:delete     - Remove accounts
+accounts:sync       - Trigger syncs
+
+schema:read         - View plans/templates
+schema:write        - Create/update plans
+schema:apply        - Apply schema plans
+
+discovery:read      - View discovered resources
+discovery:link      - Link resources to pools
+discovery:sync      - Trigger discovery
+
+audit:read          - View audit logs
+audit:export        - Export audit data
+
+users:read          - View users
+users:invite        - Invite new users
+users:write         - Update users
+users:delete        - Remove users
+
+roles:read          - View roles
+roles:write         - Manage custom roles
+
+org:read            - View org settings
+org:write           - Update org settings
+
+teams:read          - View teams
+teams:write         - Manage teams
+```
+
+### Custom Roles
+
+Admins can create custom roles with specific permission sets:
+
+```json
+{
+  "name": "Network Engineer",
+  "description": "Can manage pools and view discovery",
+  "permissions": [
+    "pools:read",
+    "pools:write",
+    "pools:allocate",
+    "discovery:read",
+    "accounts:read",
+    "schema:read"
+  ]
+}
+```
+
+### Team-Based Access (Pool Scoping)
+
+Teams can have access scoped to specific pools:
+
+```json
+{
+  "team": "us-east-team",
+  "pool_access": [
+    {
+      "pool_id": "pool-us-east-prod",
+      "access_level": "admin",
+      "include_children": true
+    },
+    {
+      "pool_id": "pool-us-east-staging",
+      "access_level": "edit",
+      "include_children": true
+    }
+  ]
+}
+```
+
+Access levels:
+- **view**: Read-only access to pool and children
+- **edit**: Can allocate and modify pool properties
+- **admin**: Full control including delete
+
+### Permission Resolution
+
+1. Check user's global role permissions
+2. If denied, check team-based pool access
+3. Apply most permissive access found
+
+```go
+func (a *Authorizer) CanAccess(user *User, resource Resource, action string) bool {
+    // 1. Global role check
+    if user.Role.HasPermission(resource.Type + ":" + action) {
+        return true
+    }
+
+    // 2. Team-based pool access check
+    if resource.Type == "pool" {
+        for _, team := range user.Teams {
+            if access := team.GetPoolAccess(resource.ID); access != nil {
+                if access.AllowsAction(action) {
+                    return true
+                }
+            }
+        }
+    }
+
+    return false
+}
+```
+
+## Session Security
+
+### Cookie Configuration
+
+```go
+http.Cookie{
+    Name:     "cloudpam_session",
+    Value:    encryptedSessionID,
+    Path:     "/",
+    Domain:   ".cloudpam.example.com",
+    MaxAge:   86400 * 7,  // 7 days
+    Secure:   true,       // HTTPS only
+    HttpOnly: true,       // No JS access
+    SameSite: http.SameSiteLaxMode,
+}
+```
+
+### Session Storage
+
+```sql
+CREATE TABLE sessions (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id),
+    access_token_encrypted BYTEA NOT NULL,
+    refresh_token_encrypted BYTEA NOT NULL,
+    access_token_expires_at TIMESTAMPTZ NOT NULL,
+    refresh_token_expires_at TIMESTAMPTZ NOT NULL,
+    ip_address INET,
+    user_agent TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    last_activity_at TIMESTAMPTZ DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX idx_sessions_expires ON sessions(refresh_token_expires_at)
+    WHERE revoked_at IS NULL;
+```
+
+### Token Encryption
+
+Tokens are encrypted at rest using AES-256-GCM:
+
+```go
+func (s *SessionStore) EncryptToken(token string) ([]byte, error) {
+    block, _ := aes.NewCipher(s.encryptionKey)
+    gcm, _ := cipher.NewGCM(block)
+
+    nonce := make([]byte, gcm.NonceSize())
+    io.ReadFull(rand.Reader, nonce)
+
+    return gcm.Seal(nonce, nonce, []byte(token), nil), nil
+}
+```
+
+## User Provisioning
+
+### Just-in-Time (JIT) Provisioning
+
+When SSO is enabled with auto-provisioning:
+
+1. User authenticates with IdP
+2. CloudPAM receives ID token with claims
+3. If user doesn't exist:
+   - Create user record from claims
+   - Assign default role
+   - Map IdP groups to roles (if configured)
+4. If user exists:
+   - Update profile from claims
+   - Re-evaluate role mapping
+
+### Role Mapping from IdP Groups
+
+```json
+{
+  "role_mapping": [
+    {
+      "claim": "groups",
+      "value": "cloudpam-admins",
+      "role_id": "role-admin"
+    },
+    {
+      "claim": "groups",
+      "value": "network-engineers",
+      "role_id": "role-editor"
+    },
+    {
+      "claim": "department",
+      "value": "IT",
+      "role_id": "role-viewer"
+    }
+  ],
+  "default_role_id": "role-viewer"
+}
+```
+
+## Security Headers
+
+All API responses include:
+
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-XSS-Protection: 1; mode=block
+Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'
+Referrer-Policy: strict-origin-when-cross-origin
+```
+
+## Audit Logging
+
+All authentication events are logged:
+
+```json
+{
+  "timestamp": "2024-01-15T10:30:00Z",
+  "event_type": "auth.login",
+  "actor": {
+    "id": "user-123",
+    "email": "user@example.com",
+    "ip_address": "192.168.1.100",
+    "user_agent": "Mozilla/5.0..."
+  },
+  "details": {
+    "method": "oidc",
+    "provider": "okta",
+    "session_id": "sess-abc123"
+  },
+  "result": "success"
+}
+```
+
+Logged events:
+- `auth.login` - Successful login
+- `auth.login_failed` - Failed login attempt
+- `auth.logout` - User logout
+- `auth.session_expired` - Session expiration
+- `auth.token_refresh` - Token refresh
+- `auth.api_key_used` - API key authentication
+- `auth.api_key_created` - New API key created
+- `auth.api_key_revoked` - API key revoked
+- `auth.permission_denied` - Authorization failure
+
+## Implementation Notes
+
+### Go Middleware Chain
+
+```go
+func AuthMiddleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // 1. Try API key auth
+        if apiKey := r.Header.Get("X-API-Key"); apiKey != "" {
+            token, err := validateAPIKey(apiKey)
+            if err != nil {
+                respondUnauthorized(w, "Invalid API key")
+                return
+            }
+            ctx := context.WithValue(r.Context(), "auth", &AuthContext{
+                Type:   "api_key",
+                Token:  token,
+                Scopes: token.Scopes,
+            })
+            next.ServeHTTP(w, r.WithContext(ctx))
+            return
+        }
+
+        // 2. Try session cookie auth
+        session, err := getSessionFromCookie(r)
+        if err != nil {
+            respondUnauthorized(w, "Authentication required")
+            return
+        }
+
+        // 3. Check if access token needs refresh
+        if session.AccessTokenExpiresSoon() {
+            if err := refreshAccessToken(session); err != nil {
+                respondUnauthorized(w, "Session expired")
+                return
+            }
+        }
+
+        ctx := context.WithValue(r.Context(), "auth", &AuthContext{
+            Type:    "session",
+            User:    session.User,
+            Session: session,
+        })
+        next.ServeHTTP(w, r.WithContext(ctx))
+    })
+}
+
+func RequirePermission(permission string) func(http.Handler) http.Handler {
+    return func(next http.Handler) http.Handler {
+        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            auth := r.Context().Value("auth").(*AuthContext)
+
+            if !auth.HasPermission(permission) {
+                auditLog.Log("auth.permission_denied", auth, permission)
+                respondForbidden(w, "Insufficient permissions")
+                return
+            }
+
+            next.ServeHTTP(w, r)
+        })
+    }
+}
+```
+
+### Route Protection Example
+
+```go
+r := chi.NewRouter()
+
+// Public routes
+r.Get("/health", healthHandler)
+r.Get("/ready", readyHandler)
+
+// Auth routes
+r.Route("/auth", func(r chi.Router) {
+    r.Post("/login", loginHandler)
+    r.Get("/callback", callbackHandler)
+    r.With(AuthMiddleware).Post("/logout", logoutHandler)
+    r.With(AuthMiddleware).Post("/refresh", refreshHandler)
+})
+
+// Protected API routes
+r.Route("/api/v1", func(r chi.Router) {
+    r.Use(AuthMiddleware)
+
+    r.Route("/pools", func(r chi.Router) {
+        r.With(RequirePermission("pools:read")).Get("/", listPools)
+        r.With(RequirePermission("pools:write")).Post("/", createPool)
+        r.With(RequirePermission("pools:read")).Get("/{id}", getPool)
+        r.With(RequirePermission("pools:write")).Patch("/{id}", updatePool)
+        r.With(RequirePermission("pools:delete")).Delete("/{id}", deletePool)
+    })
+
+    // Admin-only routes
+    r.Route("/users", func(r chi.Router) {
+        r.Use(RequirePermission("users:read"))
+        r.Get("/", listUsers)
+        r.With(RequirePermission("users:invite")).Post("/", inviteUser)
+        // ...
+    })
+})
+```
+
+## Future: ABAC Support
+
+Planned attribute-based access control will enable policies like:
+
+```yaml
+policies:
+  - name: "region-restricted-access"
+    effect: allow
+    resources:
+      - type: pool
+        conditions:
+          - attribute: tags.region
+            operator: in
+            value: "${user.allowed_regions}"
+    actions: ["read", "allocate"]
+
+  - name: "environment-write-restriction"
+    effect: deny
+    resources:
+      - type: pool
+        conditions:
+          - attribute: tags.environment
+            operator: equals
+            value: "production"
+    actions: ["write", "delete"]
+    subjects:
+      conditions:
+        - attribute: role
+          operator: not_in
+          value: ["admin", "senior-engineer"]
+```
+
+This will be implemented as a policy evaluation engine that runs after RBAC checks.

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -1,0 +1,703 @@
+# CloudPAM Database Schema
+
+This document defines the database schema for CloudPAM, supporting both PostgreSQL (production) and SQLite (development/lightweight deployments).
+
+## Design Principles
+
+1. **UUID Primary Keys**: All tables use UUIDs for global uniqueness and easier multi-instance sync
+2. **Soft Deletes**: Critical entities support soft deletion via `deleted_at` timestamp
+3. **Audit Trail**: All mutations tracked via triggers and audit_events table
+4. **Hierarchical Data**: Pools use adjacency list with materialized path for efficient queries
+5. **JSON Metadata**: Flexible metadata stored as JSONB (PostgreSQL) or JSON (SQLite)
+
+## Database Compatibility
+
+| Feature | PostgreSQL | SQLite |
+|---------|------------|--------|
+| UUID type | Native `UUID` | `TEXT` (36 chars) |
+| JSON | `JSONB` (indexed) | `JSON` (text) |
+| Arrays | Native `TEXT[]` | JSON array in TEXT |
+| INET type | Native `INET` | `TEXT` |
+| Timestamps | `TIMESTAMPTZ` | `TEXT` (ISO 8601) |
+| Full-text search | `tsvector` + GIN | FTS5 virtual table |
+| CIDR operations | Native operators | Custom functions |
+
+## Entity Relationship Diagram
+
+```
+┌─────────────────┐       ┌─────────────────┐       ┌─────────────────┐
+│  organizations  │───┐   │     users       │       │     roles       │
+└─────────────────┘   │   └────────┬────────┘       └────────┬────────┘
+                      │            │                         │
+                      │            │    ┌────────────────────┘
+                      │            │    │
+                      │            ▼    ▼
+                      │   ┌─────────────────┐       ┌─────────────────┐
+                      │   │   user_roles    │       │   permissions   │
+                      │   └─────────────────┘       └─────────────────┘
+                      │                                      │
+                      │   ┌─────────────────┐       ┌────────┴────────┐
+                      │   │     teams       │◄──────│ role_permissions│
+                      │   └────────┬────────┘       └─────────────────┘
+                      │            │
+                      │            ▼
+                      │   ┌─────────────────┐       ┌─────────────────┐
+                      │   │  team_members   │       │team_pool_access │
+                      │   └─────────────────┘       └─────────────────┘
+                      │                                      │
+                      │                                      │
+                      ▼                                      ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                              pools                                   │
+│  (hierarchical - parent_id references self)                         │
+└─────────────────────────────────────────────────────────────────────┘
+         │                    │                           │
+         │                    │                           │
+         ▼                    ▼                           ▼
+┌─────────────────┐  ┌─────────────────┐       ┌─────────────────┐
+│  planned_pools  │  │linked_resources │       │   allocations   │
+└────────┬────────┘  └─────────────────┘       └─────────────────┘
+         │                    ▲
+         │                    │
+┌────────┴────────┐  ┌────────┴────────┐       ┌─────────────────┐
+│  schema_plans   │  │discovered_      │◄──────│    accounts     │
+└─────────────────┘  │resources        │       └────────┬────────┘
+         ▲           └─────────────────┘                │
+         │                    ▲                         │
+┌────────┴────────┐           │                         ▼
+│schema_templates │  ┌────────┴────────┐       ┌─────────────────┐
+└─────────────────┘  │   sync_jobs     │       │   collectors    │
+                     └─────────────────┘       └─────────────────┘
+
+┌─────────────────┐  ┌─────────────────┐       ┌─────────────────┐
+│   api_tokens    │  │    sessions     │       │  audit_events   │
+└─────────────────┘  └─────────────────┘       └─────────────────┘
+
+┌─────────────────┐
+│   sso_config    │
+└─────────────────┘
+```
+
+## Table Definitions
+
+### Core Tables
+
+#### organizations
+Primary tenant/organization entity.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Organization ID |
+| name | VARCHAR(255) | NOT NULL | Display name |
+| slug | VARCHAR(100) | UNIQUE, NOT NULL | URL-safe identifier |
+| plan | VARCHAR(50) | NOT NULL DEFAULT 'free' | Subscription plan |
+| settings | JSONB | DEFAULT '{}' | Organization settings |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | Creation timestamp |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | Last update |
+| deleted_at | TIMESTAMPTZ | NULL | Soft delete timestamp |
+
+#### users
+User accounts (authenticated via OAuth/OIDC).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | User ID |
+| organization_id | UUID | FK organizations(id) | Owning organization |
+| email | VARCHAR(255) | NOT NULL | Email address |
+| name | VARCHAR(255) | | Display name |
+| avatar_url | TEXT | | Profile picture URL |
+| status | VARCHAR(20) | NOT NULL DEFAULT 'invited' | active/invited/disabled |
+| external_id | VARCHAR(255) | | IdP subject identifier |
+| metadata | JSONB | DEFAULT '{}' | Additional user data |
+| last_login_at | TIMESTAMPTZ | | Last successful login |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| deleted_at | TIMESTAMPTZ | | Soft delete |
+
+**Indexes:**
+- UNIQUE (organization_id, email) WHERE deleted_at IS NULL
+- INDEX (external_id)
+- INDEX (status)
+
+#### roles
+Role definitions for RBAC.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Role ID |
+| organization_id | UUID | FK organizations(id), NULL | NULL = built-in role |
+| name | VARCHAR(100) | NOT NULL | Role name |
+| description | TEXT | | Role description |
+| is_builtin | BOOLEAN | NOT NULL DEFAULT FALSE | System-defined role |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+**Indexes:**
+- UNIQUE (organization_id, name)
+
+#### permissions
+Available permissions in the system.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | VARCHAR(100) | PK | Permission ID (e.g., 'pools:write') |
+| name | VARCHAR(100) | NOT NULL | Display name |
+| description | TEXT | | Permission description |
+| category | VARCHAR(50) | NOT NULL | Grouping category |
+
+#### role_permissions
+Many-to-many: roles to permissions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| role_id | UUID | PK, FK roles(id) | |
+| permission_id | VARCHAR(100) | PK, FK permissions(id) | |
+
+#### user_roles
+User role assignments.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| user_id | UUID | PK, FK users(id) | |
+| role_id | UUID | PK, FK roles(id) | |
+| assigned_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| assigned_by | UUID | FK users(id) | Who assigned the role |
+
+### Pool Management
+
+#### pools
+Hierarchical IP address pools.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Pool ID |
+| organization_id | UUID | FK organizations(id), NOT NULL | Owning org |
+| parent_id | UUID | FK pools(id), NULL | Parent pool (NULL = root) |
+| name | VARCHAR(255) | NOT NULL | Pool name |
+| description | TEXT | | Pool description |
+| cidr | VARCHAR(50) | NOT NULL | CIDR notation (e.g., 10.0.0.0/16) |
+| type | VARCHAR(50) | NOT NULL | supernet/region/environment/vpc/subnet/reserved |
+| path | TEXT | NOT NULL | Materialized path (e.g., '/root-id/parent-id/this-id') |
+| depth | INTEGER | NOT NULL DEFAULT 0 | Depth in hierarchy |
+| tags | JSONB | DEFAULT '{}' | Key-value tags |
+| metadata | JSONB | DEFAULT '{}' | Custom metadata |
+| created_by | UUID | FK users(id) | Creator |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| deleted_at | TIMESTAMPTZ | | Soft delete |
+
+**Indexes:**
+- UNIQUE (organization_id, cidr) WHERE deleted_at IS NULL
+- INDEX (parent_id)
+- INDEX (organization_id, type)
+- INDEX (path) -- For hierarchical queries
+- INDEX USING GIN (tags) -- PostgreSQL only
+- INDEX (cidr) -- For overlap detection
+
+**Constraints:**
+- CHECK (cidr ~ '^[0-9]{1,3}(\.[0-9]{1,3}){3}/[0-9]{1,2}$') -- PostgreSQL
+- CHECK (depth >= 0)
+
+#### pool_utilization_cache
+Cached utilization stats (updated by triggers/background job).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| pool_id | UUID | PK, FK pools(id) | |
+| total_addresses | BIGINT | NOT NULL | Total IPs in CIDR |
+| allocated_addresses | BIGINT | NOT NULL DEFAULT 0 | IPs in children |
+| child_count | INTEGER | NOT NULL DEFAULT 0 | Direct children |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | Last recalculation |
+
+### Schema Planning
+
+#### schema_templates
+IP schema planning templates.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Template ID |
+| organization_id | UUID | FK organizations(id), NULL | NULL = built-in |
+| name | VARCHAR(255) | NOT NULL | Template name |
+| description | TEXT | | Template description |
+| category | VARCHAR(50) | NOT NULL | enterprise/cloud/hybrid/small-business/custom |
+| structure | JSONB | NOT NULL | Hierarchical structure definition |
+| parameters | JSONB | DEFAULT '[]' | Configurable parameters |
+| is_builtin | BOOLEAN | NOT NULL DEFAULT FALSE | System template |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+#### schema_plans
+Saved schema plans (draft or applied).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Plan ID |
+| organization_id | UUID | FK organizations(id), NOT NULL | |
+| template_id | UUID | FK schema_templates(id), NULL | Source template |
+| name | VARCHAR(255) | NOT NULL | Plan name |
+| description | TEXT | | Plan description |
+| status | VARCHAR(20) | NOT NULL DEFAULT 'draft' | draft/applied/archived |
+| root_cidr | VARCHAR(50) | NOT NULL | Root CIDR for plan |
+| parameters | JSONB | DEFAULT '{}' | Template parameters used |
+| created_by | UUID | FK users(id) | |
+| applied_by | UUID | FK users(id), NULL | Who applied it |
+| applied_at | TIMESTAMPTZ | NULL | When applied |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+**Indexes:**
+- INDEX (organization_id, status)
+- INDEX (template_id)
+
+#### planned_pools
+Pools defined within a schema plan.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Planned pool ID |
+| plan_id | UUID | FK schema_plans(id), NOT NULL | Parent plan |
+| temp_id | VARCHAR(100) | NOT NULL | Temporary ID within plan |
+| parent_temp_id | VARCHAR(100) | NULL | Parent's temp_id |
+| name | VARCHAR(255) | NOT NULL | Planned pool name |
+| cidr | VARCHAR(50) | NOT NULL | Planned CIDR |
+| type | VARCHAR(50) | NOT NULL | Pool type |
+| tags | JSONB | DEFAULT '{}' | Planned tags |
+| pool_id | UUID | FK pools(id), NULL | Actual pool after apply |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+**Indexes:**
+- INDEX (plan_id)
+- UNIQUE (plan_id, temp_id)
+
+### Cloud Integration
+
+#### accounts
+Cloud provider accounts.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Account ID |
+| organization_id | UUID | FK organizations(id), NOT NULL | |
+| name | VARCHAR(255) | NOT NULL | Display name |
+| provider | VARCHAR(20) | NOT NULL | aws/gcp/azure |
+| provider_account_id | VARCHAR(100) | | AWS Account ID, GCP Project, etc. |
+| status | VARCHAR(20) | NOT NULL DEFAULT 'disconnected' | connected/disconnected/error |
+| auth_type | VARCHAR(50) | NOT NULL | iam_role/workload_identity/service_account/access_key |
+| auth_config_encrypted | BYTEA | NOT NULL | Encrypted auth configuration |
+| regions | JSONB | DEFAULT '[]' | Enabled regions array |
+| auto_sync | BOOLEAN | NOT NULL DEFAULT TRUE | Auto-sync enabled |
+| sync_interval_minutes | INTEGER | NOT NULL DEFAULT 60 | Sync frequency |
+| last_sync_at | TIMESTAMPTZ | NULL | Last successful sync |
+| last_error | TEXT | NULL | Last error message |
+| created_by | UUID | FK users(id) | |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| deleted_at | TIMESTAMPTZ | | Soft delete |
+
+**Indexes:**
+- UNIQUE (organization_id, provider, provider_account_id) WHERE deleted_at IS NULL
+- INDEX (status)
+- INDEX (organization_id, provider)
+
+#### collectors
+Discovery collector registrations.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Collector ID |
+| organization_id | UUID | FK organizations(id), NOT NULL | |
+| name | VARCHAR(255) | NOT NULL | Collector name |
+| version | VARCHAR(50) | | Collector version |
+| status | VARCHAR(20) | NOT NULL DEFAULT 'offline' | online/offline/degraded |
+| last_heartbeat_at | TIMESTAMPTZ | NULL | Last heartbeat |
+| metadata | JSONB | DEFAULT '{}' | Collector metadata |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+#### collector_accounts
+Many-to-many: collectors to accounts.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| collector_id | UUID | PK, FK collectors(id) | |
+| account_id | UUID | PK, FK accounts(id) | |
+
+#### discovered_resources
+Resources found via cloud discovery.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Resource ID |
+| organization_id | UUID | FK organizations(id), NOT NULL | |
+| account_id | UUID | FK accounts(id), NOT NULL | Source account |
+| provider | VARCHAR(20) | NOT NULL | aws/gcp/azure |
+| resource_type | VARCHAR(50) | NOT NULL | vpc/subnet/network_interface/elastic_ip/instance |
+| resource_id | VARCHAR(255) | NOT NULL | Cloud provider resource ID |
+| name | VARCHAR(255) | | Resource name |
+| region | VARCHAR(50) | NOT NULL | Cloud region |
+| cidr | VARCHAR(50) | NULL | CIDR if applicable |
+| ip_address | VARCHAR(50) | NULL | IP address if applicable |
+| status | VARCHAR(20) | NOT NULL DEFAULT 'untracked' | tracked/untracked/conflict/orphaned |
+| linked_pool_id | UUID | FK pools(id), NULL | Linked pool |
+| metadata | JSONB | DEFAULT '{}' | Provider-specific metadata |
+| first_seen_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | First discovery |
+| last_seen_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | Latest sync |
+| deleted_at | TIMESTAMPTZ | NULL | No longer exists in cloud |
+
+**Indexes:**
+- UNIQUE (account_id, resource_type, resource_id)
+- INDEX (organization_id, status)
+- INDEX (linked_pool_id)
+- INDEX (cidr) -- For conflict detection
+- INDEX (last_seen_at) -- For orphan detection
+
+#### sync_jobs
+Discovery sync job tracking.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Job ID |
+| account_id | UUID | FK accounts(id), NOT NULL | |
+| collector_id | UUID | FK collectors(id), NULL | |
+| status | VARCHAR(20) | NOT NULL DEFAULT 'pending' | pending/running/completed/failed |
+| started_at | TIMESTAMPTZ | NULL | Job start |
+| completed_at | TIMESTAMPTZ | NULL | Job completion |
+| resources_discovered | INTEGER | DEFAULT 0 | Total found |
+| resources_added | INTEGER | DEFAULT 0 | New resources |
+| resources_updated | INTEGER | DEFAULT 0 | Changed resources |
+| resources_removed | INTEGER | DEFAULT 0 | Disappeared |
+| error | TEXT | NULL | Error message if failed |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+**Indexes:**
+- INDEX (account_id, created_at DESC)
+- INDEX (status)
+
+### Teams
+
+#### teams
+Team definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Team ID |
+| organization_id | UUID | FK organizations(id), NOT NULL | |
+| name | VARCHAR(255) | NOT NULL | Team name |
+| description | TEXT | | Team description |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| deleted_at | TIMESTAMPTZ | | Soft delete |
+
+**Indexes:**
+- UNIQUE (organization_id, name) WHERE deleted_at IS NULL
+
+#### team_members
+Team membership.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| team_id | UUID | PK, FK teams(id) | |
+| user_id | UUID | PK, FK users(id) | |
+| role | VARCHAR(20) | NOT NULL DEFAULT 'member' | member/lead |
+| joined_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+#### team_pool_access
+Team access to specific pools.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Access rule ID |
+| team_id | UUID | FK teams(id), NOT NULL | |
+| pool_id | UUID | FK pools(id), NOT NULL | |
+| access_level | VARCHAR(20) | NOT NULL | view/edit/admin |
+| include_children | BOOLEAN | NOT NULL DEFAULT TRUE | Apply to children |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+**Indexes:**
+- UNIQUE (team_id, pool_id)
+- INDEX (pool_id)
+
+### Authentication
+
+#### sessions
+User sessions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Session ID |
+| user_id | UUID | FK users(id), NOT NULL | |
+| access_token_encrypted | BYTEA | NOT NULL | Encrypted access token |
+| refresh_token_encrypted | BYTEA | NOT NULL | Encrypted refresh token |
+| access_token_expires_at | TIMESTAMPTZ | NOT NULL | Access token expiry |
+| refresh_token_expires_at | TIMESTAMPTZ | NOT NULL | Refresh token expiry |
+| ip_address | VARCHAR(50) | | Client IP |
+| user_agent | TEXT | | Browser/client info |
+| last_activity_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| revoked_at | TIMESTAMPTZ | NULL | Revocation timestamp |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+**Indexes:**
+- INDEX (user_id)
+- INDEX (refresh_token_expires_at) WHERE revoked_at IS NULL
+
+#### api_tokens
+API tokens for programmatic access.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Token ID |
+| organization_id | UUID | FK organizations(id), NOT NULL | |
+| user_id | UUID | FK users(id), NOT NULL | Token owner |
+| name | VARCHAR(255) | NOT NULL | Token name |
+| prefix | VARCHAR(20) | NOT NULL | First chars for identification |
+| token_hash | BYTEA | NOT NULL | Argon2id hash of token |
+| scopes | JSONB | NOT NULL | Array of scope strings |
+| last_used_at | TIMESTAMPTZ | NULL | Last usage |
+| expires_at | TIMESTAMPTZ | NULL | NULL = no expiration |
+| revoked_at | TIMESTAMPTZ | NULL | Revocation timestamp |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+**Indexes:**
+- INDEX (organization_id, user_id)
+- INDEX (prefix) -- For lookup by prefix
+- INDEX (token_hash) -- For validation
+
+#### sso_config
+SSO/OIDC configuration.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Config ID |
+| organization_id | UUID | FK organizations(id), UNIQUE | One per org |
+| enabled | BOOLEAN | NOT NULL DEFAULT FALSE | SSO enabled |
+| provider_type | VARCHAR(20) | NOT NULL DEFAULT 'oidc' | oidc/saml |
+| issuer_url | TEXT | | OIDC issuer URL |
+| client_id | VARCHAR(255) | | OAuth client ID |
+| client_secret_encrypted | BYTEA | | Encrypted client secret |
+| scopes | JSONB | DEFAULT '["openid", "profile", "email"]' | |
+| role_mapping | JSONB | DEFAULT '[]' | Claim to role mapping |
+| auto_provision_users | BOOLEAN | NOT NULL DEFAULT TRUE | |
+| default_role_id | UUID | FK roles(id), NULL | Default role for new users |
+| created_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+| updated_at | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | |
+
+### Audit
+
+#### audit_events
+Audit log of all changes.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| id | UUID | PK | Event ID |
+| organization_id | UUID | NOT NULL | Org context |
+| timestamp | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | Event time |
+| actor_id | UUID | NULL | User/token ID |
+| actor_type | VARCHAR(20) | NOT NULL | user/api_token/system |
+| actor_email | VARCHAR(255) | | Actor email if user |
+| actor_ip | VARCHAR(50) | | Client IP |
+| action | VARCHAR(50) | NOT NULL | create/update/delete/login/etc. |
+| resource_type | VARCHAR(50) | NOT NULL | pool/account/user/etc. |
+| resource_id | UUID | NOT NULL | Affected resource |
+| resource_name | VARCHAR(255) | | Resource name at time of event |
+| changes | JSONB | | { before: {}, after: {} } |
+| metadata | JSONB | DEFAULT '{}' | Additional context |
+
+**Indexes:**
+- INDEX (organization_id, timestamp DESC)
+- INDEX (actor_id, timestamp DESC)
+- INDEX (resource_type, resource_id)
+- INDEX (action)
+
+**Partitioning (PostgreSQL):**
+Consider range partitioning by timestamp for large deployments.
+
+## CIDR Operations
+
+### PostgreSQL
+Use native `inet` and `cidr` types with operators:
+
+```sql
+-- Check if CIDR contains another
+SELECT '10.0.0.0/8'::cidr >> '10.1.0.0/16'::cidr;  -- true
+
+-- Check overlap
+SELECT '10.0.0.0/16'::cidr && '10.0.128.0/17'::cidr;  -- true
+
+-- Get network address
+SELECT network('10.0.0.5/24'::cidr);  -- 10.0.0.0/24
+```
+
+### SQLite
+Use custom functions (registered in Go):
+
+```sql
+-- Custom functions needed:
+-- cidr_contains(parent, child) -> boolean
+-- cidr_overlaps(cidr1, cidr2) -> boolean
+-- cidr_network(cidr) -> text
+-- cidr_broadcast(cidr) -> text
+-- cidr_size(cidr) -> integer
+```
+
+## Triggers
+
+### PostgreSQL Triggers
+
+```sql
+-- Update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply to all tables with updated_at
+CREATE TRIGGER update_pools_updated_at
+    BEFORE UPDATE ON pools
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at();
+
+-- Update pool path on insert/update
+CREATE OR REPLACE FUNCTION update_pool_path()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.parent_id IS NULL THEN
+        NEW.path = '/' || NEW.id::text;
+        NEW.depth = 0;
+    ELSE
+        SELECT path || '/' || NEW.id::text, depth + 1
+        INTO NEW.path, NEW.depth
+        FROM pools WHERE id = NEW.parent_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_pool_path_trigger
+    BEFORE INSERT OR UPDATE OF parent_id ON pools
+    FOR EACH ROW
+    EXECUTE FUNCTION update_pool_path();
+
+-- Audit trigger
+CREATE OR REPLACE FUNCTION audit_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO audit_events (
+        id, organization_id, timestamp, actor_id, actor_type,
+        action, resource_type, resource_id, resource_name, changes
+    ) VALUES (
+        gen_random_uuid(),
+        COALESCE(NEW.organization_id, OLD.organization_id),
+        NOW(),
+        current_setting('app.current_user_id', true)::uuid,
+        COALESCE(current_setting('app.current_actor_type', true), 'system'),
+        TG_OP,
+        TG_TABLE_NAME,
+        COALESCE(NEW.id, OLD.id),
+        COALESCE(NEW.name, OLD.name),
+        jsonb_build_object(
+            'before', CASE WHEN TG_OP != 'INSERT' THEN to_jsonb(OLD) END,
+            'after', CASE WHEN TG_OP != 'DELETE' THEN to_jsonb(NEW) END
+        )
+    );
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER audit_pools
+    AFTER INSERT OR UPDATE OR DELETE ON pools
+    FOR EACH ROW EXECUTE FUNCTION audit_trigger();
+```
+
+### SQLite Triggers
+
+SQLite triggers are more limited but can achieve similar results:
+
+```sql
+-- Updated_at trigger
+CREATE TRIGGER update_pools_updated_at
+    AFTER UPDATE ON pools
+BEGIN
+    UPDATE pools SET updated_at = datetime('now')
+    WHERE id = NEW.id;
+END;
+
+-- Pool path trigger (simplified)
+CREATE TRIGGER update_pool_path_insert
+    AFTER INSERT ON pools
+    WHEN NEW.parent_id IS NOT NULL
+BEGIN
+    UPDATE pools SET
+        path = (SELECT path FROM pools WHERE id = NEW.parent_id) || '/' || NEW.id,
+        depth = (SELECT depth + 1 FROM pools WHERE id = NEW.parent_id)
+    WHERE id = NEW.id;
+END;
+```
+
+## Migration Strategy
+
+### Version Table
+
+```sql
+CREATE TABLE schema_migrations (
+    version BIGINT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    description TEXT
+);
+```
+
+### Migration Naming
+
+```
+migrations/
+├── postgres/
+│   ├── 001_initial_schema.up.sql
+│   ├── 001_initial_schema.down.sql
+│   ├── 002_add_teams.up.sql
+│   ├── 002_add_teams.down.sql
+│   └── ...
+└── sqlite/
+    ├── 001_initial_schema.up.sql
+    ├── 001_initial_schema.down.sql
+    └── ...
+```
+
+## Performance Considerations
+
+### Indexing Strategy
+
+1. **Primary lookups**: UUID primary keys, indexed by default
+2. **Foreign key columns**: Always indexed
+3. **Frequently filtered columns**: status, type, provider
+4. **Range queries**: timestamp columns
+5. **Text search**: Full-text indexes for name/description
+6. **JSON fields**: GIN indexes on JSONB columns (PostgreSQL)
+
+### Query Optimization
+
+1. **Pool tree queries**: Use materialized path for subtree queries
+   ```sql
+   SELECT * FROM pools WHERE path LIKE '/root-id/%';
+   ```
+
+2. **Utilization calculation**: Cache in pool_utilization_cache, refresh async
+
+3. **Audit queries**: Partition by timestamp for large datasets
+
+4. **Discovery queries**: Index on (account_id, last_seen_at) for sync operations
+
+### Connection Pooling
+
+- PostgreSQL: Use PgBouncer or built-in pool (20-50 connections)
+- SQLite: Single connection with WAL mode
+
+```sql
+-- SQLite WAL mode
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+PRAGMA cache_size=-64000;  -- 64MB cache
+PRAGMA busy_timeout=5000;
+```

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,1281 @@
+# CloudPAM Deployment Guide
+
+This document covers deployment options for CloudPAM, from local development to production-grade cloud deployments.
+
+## Architecture Overview
+
+CloudPAM follows a modular architecture that supports multiple deployment patterns:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Load Balancer                            │
+│                    (Cloud LB / ALB / nginx)                     │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+┌─────────────────────────────▼───────────────────────────────────┐
+│                      CloudPAM API Server                        │
+│                    (Stateless, Horizontally Scalable)           │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐             │
+│  │   REST API  │  │   Auth/RBAC │  │  Schema     │             │
+│  │   Handlers  │  │   Middleware│  │  Planning   │             │
+│  └─────────────┘  └─────────────┘  └─────────────┘             │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+┌─────────────────────────────▼───────────────────────────────────┐
+│                       Data Layer                                │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  PostgreSQL (Production) / SQLite (Dev/Single-node)     │   │
+│  └─────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                    Discovery Collectors                         │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐             │
+│  │ AWS Collector│  │GCP Collector│  │Azure Collect│             │
+│  │   (Optional) │  │  (Optional) │  │  (Future)   │             │
+│  └─────────────┘  └─────────────┘  └─────────────┘             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Deployment Options
+
+| Option | Use Case | Complexity | Scalability |
+|--------|----------|------------|-------------|
+| Docker Compose | Local dev, small teams | Low | Single node |
+| Cloud Run | GCP-native, auto-scaling | Medium | High |
+| AWS ECS Fargate | AWS-native, serverless | Medium | High |
+| Kubernetes (GKE/EKS) | Multi-cloud, enterprise | High | Very High |
+
+---
+
+## 1. Local Development (Docker Compose)
+
+### Prerequisites
+- Docker Engine 24.0+
+- Docker Compose v2.20+
+- 2GB RAM minimum
+
+### Quick Start
+
+```yaml
+# docker-compose.yml
+version: '3.9'
+
+services:
+  cloudpam:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - CLOUDPAM_ENV=development
+      - CLOUDPAM_DB_TYPE=sqlite
+      - CLOUDPAM_DB_PATH=/data/cloudpam.db
+      - CLOUDPAM_LOG_LEVEL=debug
+      - CLOUDPAM_CORS_ORIGINS=http://localhost:3000
+    volumes:
+      - cloudpam-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # Optional: PostgreSQL for production-like testing
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: cloudpam
+      POSTGRES_USER: cloudpam
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    profiles:
+      - postgres
+
+volumes:
+  cloudpam-data:
+  postgres-data:
+```
+
+### Development Dockerfile
+
+```dockerfile
+# Dockerfile
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=1 GOOS=linux go build -o cloudpam ./cmd/cloudpam
+
+# Runtime image
+FROM alpine:3.19
+
+RUN apk add --no-cache ca-certificates sqlite-libs curl
+WORKDIR /app
+
+COPY --from=builder /app/cloudpam .
+COPY --from=builder /app/web ./web
+
+EXPOSE 8080
+CMD ["./cloudpam"]
+```
+
+### Running Locally
+
+```bash
+# Start with SQLite (simplest)
+docker compose up -d
+
+# Start with PostgreSQL
+POSTGRES_PASSWORD=securepassword docker compose --profile postgres up -d
+
+# View logs
+docker compose logs -f cloudpam
+
+# Access at http://localhost:8080
+```
+
+### Development with Hot Reload
+
+```yaml
+# docker-compose.dev.yml
+version: '3.9'
+
+services:
+  cloudpam-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/app
+      - go-mod-cache:/go/pkg/mod
+    environment:
+      - CLOUDPAM_ENV=development
+      - CLOUDPAM_DB_TYPE=sqlite
+      - CLOUDPAM_DB_PATH=/data/cloudpam.db
+    command: ["air", "-c", ".air.toml"]
+
+volumes:
+  go-mod-cache:
+```
+
+---
+
+## 2. Google Cloud Run
+
+Cloud Run provides serverless container deployment with automatic scaling and built-in load balancing.
+
+### Architecture
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                    Google Cloud Platform                       │
+│                                                                │
+│  ┌──────────────────────────────────────────────────────────┐ │
+│  │                    Cloud Run Service                      │ │
+│  │  ┌────────────┐  ┌────────────┐  ┌────────────┐         │ │
+│  │  │ Instance 1 │  │ Instance 2 │  │ Instance N │         │ │
+│  │  │ (auto-scaled)│ │           │  │            │         │ │
+│  │  └────────────┘  └────────────┘  └────────────┘         │ │
+│  └──────────────────────────┬───────────────────────────────┘ │
+│                             │                                  │
+│  ┌──────────────────────────▼───────────────────────────────┐ │
+│  │              Cloud SQL (PostgreSQL)                       │ │
+│  │        Private IP via VPC Connector                       │ │
+│  └──────────────────────────────────────────────────────────┘ │
+│                                                                │
+│  ┌──────────────────────────────────────────────────────────┐ │
+│  │              Secret Manager                               │ │
+│  │    (DB credentials, API keys, OAuth secrets)              │ │
+│  └──────────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Prerequisites
+- Google Cloud project with billing enabled
+- gcloud CLI installed and configured
+- Artifact Registry repository created
+
+### Terraform Configuration
+
+```hcl
+# terraform/gcp/main.tf
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP Region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+# Enable required APIs
+resource "google_project_service" "services" {
+  for_each = toset([
+    "run.googleapis.com",
+    "sqladmin.googleapis.com",
+    "secretmanager.googleapis.com",
+    "vpcaccess.googleapis.com",
+    "artifactregistry.googleapis.com",
+  ])
+
+  project = var.project_id
+  service = each.value
+}
+
+# VPC for private connectivity
+resource "google_compute_network" "vpc" {
+  name                    = "cloudpam-vpc"
+  project                 = var.project_id
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "cloudpam-subnet"
+  project       = var.project_id
+  region        = var.region
+  network       = google_compute_network.vpc.id
+  ip_cidr_range = "10.0.0.0/24"
+}
+
+# VPC Connector for Cloud Run -> Cloud SQL
+resource "google_vpc_access_connector" "connector" {
+  name          = "cloudpam-connector"
+  project       = var.project_id
+  region        = var.region
+  ip_cidr_range = "10.8.0.0/28"
+  network       = google_compute_network.vpc.name
+}
+
+# Cloud SQL PostgreSQL
+resource "google_sql_database_instance" "postgres" {
+  name             = "cloudpam-db-${var.environment}"
+  project          = var.project_id
+  region           = var.region
+  database_version = "POSTGRES_16"
+
+  settings {
+    tier              = "db-f1-micro"  # Adjust for production
+    availability_type = "REGIONAL"     # For HA
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = google_compute_network.vpc.id
+    }
+
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "03:00"
+      point_in_time_recovery_enabled = true
+    }
+
+    database_flags {
+      name  = "log_checkpoints"
+      value = "on"
+    }
+  }
+
+  deletion_protection = true
+}
+
+resource "google_sql_database" "database" {
+  name     = "cloudpam"
+  instance = google_sql_database_instance.postgres.name
+  project  = var.project_id
+}
+
+resource "google_sql_user" "user" {
+  name     = "cloudpam"
+  instance = google_sql_database_instance.postgres.name
+  project  = var.project_id
+  password = random_password.db_password.result
+}
+
+resource "random_password" "db_password" {
+  length  = 32
+  special = true
+}
+
+# Secret Manager for DB password
+resource "google_secret_manager_secret" "db_password" {
+  secret_id = "cloudpam-db-password"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "db_password" {
+  secret      = google_secret_manager_secret.db_password.id
+  secret_data = random_password.db_password.result
+}
+
+# Artifact Registry for container images
+resource "google_artifact_registry_repository" "repo" {
+  location      = var.region
+  repository_id = "cloudpam"
+  project       = var.project_id
+  format        = "DOCKER"
+}
+
+# Service Account for Cloud Run
+resource "google_service_account" "cloudpam" {
+  account_id   = "cloudpam-service"
+  display_name = "CloudPAM Service Account"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "cloudpam_sql" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.cloudpam.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "cloudpam_secret" {
+  secret_id = google_secret_manager_secret.db_password.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cloudpam.email}"
+}
+
+# Cloud Run Service
+resource "google_cloud_run_v2_service" "cloudpam" {
+  name     = "cloudpam"
+  location = var.region
+  project  = var.project_id
+
+  template {
+    service_account = google_service_account.cloudpam.email
+
+    vpc_access {
+      connector = google_vpc_access_connector.connector.id
+      egress    = "PRIVATE_RANGES_ONLY"
+    }
+
+    containers {
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/cloudpam/cloudpam:latest"
+
+      ports {
+        container_port = 8080
+      }
+
+      env {
+        name  = "CLOUDPAM_ENV"
+        value = var.environment
+      }
+
+      env {
+        name  = "CLOUDPAM_DB_TYPE"
+        value = "postgres"
+      }
+
+      env {
+        name  = "CLOUDPAM_DB_HOST"
+        value = google_sql_database_instance.postgres.private_ip_address
+      }
+
+      env {
+        name  = "CLOUDPAM_DB_NAME"
+        value = google_sql_database.database.name
+      }
+
+      env {
+        name  = "CLOUDPAM_DB_USER"
+        value = google_sql_user.user.name
+      }
+
+      env {
+        name = "CLOUDPAM_DB_PASSWORD"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.db_password.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      resources {
+        limits = {
+          cpu    = "1000m"
+          memory = "512Mi"
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/health"
+        }
+        initial_delay_seconds = 5
+        period_seconds        = 10
+        failure_threshold     = 3
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/health"
+        }
+        period_seconds = 30
+      }
+    }
+
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 10
+    }
+  }
+
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+}
+
+# IAM for public access (or use IAP for authenticated access)
+resource "google_cloud_run_service_iam_member" "public" {
+  location = google_cloud_run_v2_service.cloudpam.location
+  project  = google_cloud_run_v2_service.cloudpam.project
+  service  = google_cloud_run_v2_service.cloudpam.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+output "service_url" {
+  value = google_cloud_run_v2_service.cloudpam.uri
+}
+```
+
+### Cloud Build Configuration
+
+```yaml
+# cloudbuild.yaml
+steps:
+  # Build the container
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/cloudpam/cloudpam:${SHORT_SHA}'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/cloudpam/cloudpam:latest'
+      - '.'
+
+  # Push to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '--all-tags'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/cloudpam/cloudpam'
+
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'cloudpam'
+      - '--image'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/cloudpam/cloudpam:${SHORT_SHA}'
+      - '--region'
+      - '${_REGION}'
+      - '--platform'
+      - 'managed'
+
+substitutions:
+  _REGION: us-central1
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+```
+
+---
+
+## 3. AWS Deployment (ECS Fargate)
+
+ECS Fargate provides serverless container orchestration with deep AWS integration.
+
+### Architecture
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                        AWS Account                             │
+│                                                                │
+│  ┌──────────────────────────────────────────────────────────┐ │
+│  │                Application Load Balancer                  │ │
+│  │              (HTTPS termination, routing)                 │ │
+│  └──────────────────────────┬───────────────────────────────┘ │
+│                             │                                  │
+│  ┌──────────────────────────▼───────────────────────────────┐ │
+│  │                    ECS Fargate Cluster                    │ │
+│  │  ┌────────────┐  ┌────────────┐  ┌────────────┐         │ │
+│  │  │   Task 1   │  │   Task 2   │  │   Task N   │         │ │
+│  │  │ (auto-scaled)│ │           │  │            │         │ │
+│  │  └────────────┘  └────────────┘  └────────────┘         │ │
+│  └──────────────────────────┬───────────────────────────────┘ │
+│                             │                                  │
+│  ┌──────────────────────────▼───────────────────────────────┐ │
+│  │                    RDS PostgreSQL                         │ │
+│  │              (Multi-AZ for production)                    │ │
+│  └──────────────────────────────────────────────────────────┘ │
+│                                                                │
+│  ┌──────────────────────────────────────────────────────────┐ │
+│  │                  Secrets Manager                          │ │
+│  │        (DB credentials, OAuth client secrets)             │ │
+│  └──────────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Terraform Configuration
+
+```hcl
+# terraform/aws/main.tf
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "region" {
+  default = "us-east-1"
+}
+
+variable "environment" {
+  default = "production"
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# VPC
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = "cloudpam-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["${var.region}a", "${var.region}b", "${var.region}c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = var.environment != "production"
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+# Security Groups
+resource "aws_security_group" "alb" {
+  name        = "cloudpam-alb-sg"
+  description = "ALB security group"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "cloudpam-ecs-sg"
+  description = "ECS tasks security group"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name        = "cloudpam-rds-sg"
+  description = "RDS security group"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+}
+
+# RDS PostgreSQL
+resource "aws_db_subnet_group" "main" {
+  name       = "cloudpam-db-subnet"
+  subnet_ids = module.vpc.private_subnets
+}
+
+resource "random_password" "db_password" {
+  length  = 32
+  special = true
+}
+
+resource "aws_secretsmanager_secret" "db_password" {
+  name = "cloudpam/db-password"
+}
+
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id = aws_secretsmanager_secret.db_password.id
+  secret_string = jsonencode({
+    username = "cloudpam"
+    password = random_password.db_password.result
+  })
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier     = "cloudpam-${var.environment}"
+  engine         = "postgres"
+  engine_version = "16.1"
+  instance_class = "db.t3.micro"  # Adjust for production
+
+  allocated_storage     = 20
+  max_allocated_storage = 100
+  storage_encrypted     = true
+
+  db_name  = "cloudpam"
+  username = "cloudpam"
+  password = random_password.db_password.result
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  multi_az               = var.environment == "production"
+  backup_retention_period = 7
+  skip_final_snapshot    = var.environment != "production"
+
+  performance_insights_enabled = true
+}
+
+# ECR Repository
+resource "aws_ecr_repository" "cloudpam" {
+  name                 = "cloudpam"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+# ECS Cluster
+resource "aws_ecs_cluster" "main" {
+  name = "cloudpam-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+# ECS Task Execution Role
+resource "aws_iam_role" "ecs_execution" {
+  name = "cloudpam-ecs-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution" {
+  role       = aws_iam_role.ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "ecs_secrets" {
+  name = "cloudpam-secrets-access"
+  role = aws_iam_role.ecs_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "secretsmanager:GetSecretValue"
+      ]
+      Resource = [aws_secretsmanager_secret.db_password.arn]
+    }]
+  })
+}
+
+# ECS Task Role (for application permissions)
+resource "aws_iam_role" "ecs_task" {
+  name = "cloudpam-ecs-task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+    }]
+  })
+}
+
+# Add permissions for cloud discovery (AWS)
+resource "aws_iam_role_policy" "cloud_discovery" {
+  name = "cloudpam-cloud-discovery"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeAddresses"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+# CloudWatch Log Group
+resource "aws_cloudwatch_log_group" "cloudpam" {
+  name              = "/ecs/cloudpam"
+  retention_in_days = 30
+}
+
+# ECS Task Definition
+resource "aws_ecs_task_definition" "cloudpam" {
+  family                   = "cloudpam"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name  = "cloudpam"
+    image = "${aws_ecr_repository.cloudpam.repository_url}:latest"
+
+    portMappings = [{
+      containerPort = 8080
+      protocol      = "tcp"
+    }]
+
+    environment = [
+      { name = "CLOUDPAM_ENV", value = var.environment },
+      { name = "CLOUDPAM_DB_TYPE", value = "postgres" },
+      { name = "CLOUDPAM_DB_HOST", value = aws_db_instance.postgres.address },
+      { name = "CLOUDPAM_DB_NAME", value = "cloudpam" },
+    ]
+
+    secrets = [
+      {
+        name      = "CLOUDPAM_DB_USER"
+        valueFrom = "${aws_secretsmanager_secret.db_password.arn}:username::"
+      },
+      {
+        name      = "CLOUDPAM_DB_PASSWORD"
+        valueFrom = "${aws_secretsmanager_secret.db_password.arn}:password::"
+      }
+    ]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.cloudpam.name
+        awslogs-region        = var.region
+        awslogs-stream-prefix = "ecs"
+      }
+    }
+
+    healthCheck = {
+      command     = ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+      interval    = 30
+      timeout     = 5
+      retries     = 3
+      startPeriod = 60
+    }
+  }])
+}
+
+# Application Load Balancer
+resource "aws_lb" "main" {
+  name               = "cloudpam-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = module.vpc.public_subnets
+}
+
+resource "aws_lb_target_group" "cloudpam" {
+  name        = "cloudpam-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = module.vpc.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    path                = "/health"
+    matcher             = "200"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# Note: You'll need an ACM certificate for HTTPS
+# resource "aws_lb_listener" "https" { ... }
+
+# ECS Service
+resource "aws_ecs_service" "cloudpam" {
+  name            = "cloudpam"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.cloudpam.arn
+  desired_count   = 2
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = module.vpc.private_subnets
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.cloudpam.arn
+    container_name   = "cloudpam"
+    container_port   = 8080
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+}
+
+# Auto Scaling
+resource "aws_appautoscaling_target" "ecs" {
+  max_capacity       = 10
+  min_capacity       = 2
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.cloudpam.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  name               = "cloudpam-cpu-scaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.ecs.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 70.0
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 60
+  }
+}
+
+output "alb_dns_name" {
+  value = aws_lb.main.dns_name
+}
+
+output "ecr_repository_url" {
+  value = aws_ecr_repository.cloudpam.repository_url
+}
+```
+
+---
+
+## 4. Kubernetes (GKE/EKS)
+
+For enterprise deployments requiring maximum control and multi-cloud portability.
+
+### Helm Chart Structure
+
+```
+helm/cloudpam/
+├── Chart.yaml
+├── values.yaml
+├── values-gke.yaml
+├── values-eks.yaml
+├── templates/
+│   ├── _helpers.tpl
+│   ├── deployment.yaml
+│   ├── service.yaml
+│   ├── ingress.yaml
+│   ├── hpa.yaml
+│   ├── configmap.yaml
+│   ├── secret.yaml
+│   └── serviceaccount.yaml
+```
+
+### Chart.yaml
+
+```yaml
+# helm/cloudpam/Chart.yaml
+apiVersion: v2
+name: cloudpam
+description: Cloud-native IP Address Management
+version: 0.1.0
+appVersion: "0.1.0"
+```
+
+### values.yaml
+
+```yaml
+# helm/cloudpam/values.yaml
+replicaCount: 2
+
+image:
+  repository: cloudpam
+  tag: latest
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: cloudpam.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: cloudpam-tls
+      hosts:
+        - cloudpam.example.com
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+config:
+  environment: production
+  logLevel: info
+
+database:
+  type: postgres
+  host: ""
+  name: cloudpam
+  existingSecret: cloudpam-db-credentials
+
+# Cloud provider specific
+cloudProvider: ""  # gke or eks
+```
+
+### Deployment Template
+
+```yaml
+# helm/cloudpam/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cloudpam.fullname" . }}
+  labels:
+    {{- include "cloudpam.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cloudpam.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cloudpam.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "cloudpam.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: CLOUDPAM_ENV
+              value: {{ .Values.config.environment }}
+            - name: CLOUDPAM_LOG_LEVEL
+              value: {{ .Values.config.logLevel }}
+            - name: CLOUDPAM_DB_TYPE
+              value: {{ .Values.database.type }}
+            - name: CLOUDPAM_DB_HOST
+              value: {{ .Values.database.host }}
+            - name: CLOUDPAM_DB_NAME
+              value: {{ .Values.database.name }}
+            - name: CLOUDPAM_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: username
+            - name: CLOUDPAM_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: password
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+```
+
+### GKE-specific Values
+
+```yaml
+# helm/cloudpam/values-gke.yaml
+cloudProvider: gke
+
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: cloudpam@PROJECT_ID.iam.gserviceaccount.com
+
+ingress:
+  className: gce
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: cloudpam-ip
+    networking.gke.io/managed-certificates: cloudpam-cert
+```
+
+### EKS-specific Values
+
+```yaml
+# helm/cloudpam/values-eks.yaml
+cloudProvider: eks
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/cloudpam-role
+
+ingress:
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:REGION:ACCOUNT:certificate/CERT_ID
+```
+
+---
+
+## Environment Variables Reference
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `CLOUDPAM_ENV` | Environment (development/staging/production) | development | No |
+| `CLOUDPAM_DB_TYPE` | Database type (sqlite/postgres) | sqlite | No |
+| `CLOUDPAM_DB_PATH` | SQLite file path | ./cloudpam.db | SQLite only |
+| `CLOUDPAM_DB_HOST` | PostgreSQL host | - | Postgres only |
+| `CLOUDPAM_DB_PORT` | PostgreSQL port | 5432 | No |
+| `CLOUDPAM_DB_NAME` | Database name | cloudpam | Postgres only |
+| `CLOUDPAM_DB_USER` | Database user | - | Postgres only |
+| `CLOUDPAM_DB_PASSWORD` | Database password | - | Postgres only |
+| `CLOUDPAM_DB_SSL_MODE` | SSL mode (disable/require/verify-full) | require | No |
+| `CLOUDPAM_LOG_LEVEL` | Log level (debug/info/warn/error) | info | No |
+| `CLOUDPAM_LOG_FORMAT` | Log format (json/text) | json | No |
+| `CLOUDPAM_PORT` | HTTP server port | 8080 | No |
+| `CLOUDPAM_CORS_ORIGINS` | Allowed CORS origins | - | No |
+| `CLOUDPAM_OAUTH_ISSUER` | OIDC issuer URL | - | OAuth only |
+| `CLOUDPAM_OAUTH_CLIENT_ID` | OAuth client ID | - | OAuth only |
+| `CLOUDPAM_OAUTH_CLIENT_SECRET` | OAuth client secret | - | OAuth only |
+| `CLOUDPAM_SENTRY_DSN` | Sentry DSN for error tracking | - | No |
+
+---
+
+## Security Best Practices
+
+### Network Security
+- Deploy database in private subnets only
+- Use VPC peering or private endpoints for cloud APIs
+- Enable TLS everywhere (ALB/Ingress terminates, internal can be HTTP in VPC)
+- Restrict security groups to minimum required ports
+
+### Secrets Management
+- Never commit secrets to version control
+- Use cloud-native secrets managers (Secret Manager, Secrets Manager)
+- Rotate database passwords regularly
+- Use short-lived credentials where possible (Workload Identity, IRSA)
+
+### IAM & Access
+- Follow principle of least privilege
+- Use service accounts with specific permissions
+- Enable audit logging for all admin actions
+- Implement RBAC at application level
+
+### Container Security
+- Run containers as non-root
+- Use read-only root filesystem
+- Scan images for vulnerabilities
+- Pin image versions (avoid :latest in production)
+
+---
+
+## Monitoring & Observability
+
+### Recommended Stack
+- **Metrics**: Prometheus + Grafana (or Cloud Monitoring)
+- **Logging**: Structured JSON logs → Cloud Logging / CloudWatch
+- **Tracing**: OpenTelemetry → Cloud Trace / X-Ray
+- **Alerting**: PagerDuty / Opsgenie integration
+
+### Key Metrics to Monitor
+- Request latency (p50, p95, p99)
+- Error rate (4xx, 5xx)
+- Database connection pool usage
+- Discovery sync success/failure rate
+- Memory and CPU utilization
+
+### Health Endpoints
+- `GET /health` - Basic liveness check
+- `GET /ready` - Readiness including DB connectivity
+- `GET /metrics` - Prometheus metrics (future)
+
+---
+
+## Disaster Recovery
+
+### Backup Strategy
+- PostgreSQL: Daily automated backups, point-in-time recovery enabled
+- Retain backups for 7 days (dev) / 30 days (prod)
+- Test restore procedures quarterly
+
+### Multi-Region (Future)
+- Active-passive with read replicas
+- DNS failover with health checks
+- Database replication lag monitoring
+
+---
+
+## Cost Optimization
+
+| Component | Dev/Small | Production |
+|-----------|-----------|------------|
+| Cloud Run | Min instances: 0-1 | Min instances: 2-3 |
+| ECS Fargate | 0.25 vCPU, 0.5GB | 0.5-1 vCPU, 1-2GB |
+| Database | db.t3.micro / db-f1-micro | db.t3.medium / db-custom |
+| NAT Gateway | Single | Per-AZ (optional) |
+
+### Cost-Saving Tips
+- Use committed use discounts for stable workloads
+- Schedule dev environments to shut down outside business hours
+- Enable auto-scaling with appropriate min/max bounds
+- Use spot/preemptible instances for non-critical workloads

--- a/docs/IMPLEMENTATION_ROADMAP.md
+++ b/docs/IMPLEMENTATION_ROADMAP.md
@@ -1,0 +1,1062 @@
+# CloudPAM Implementation Roadmap
+
+## Executive Summary
+
+CloudPAM is an intelligent IP Address Management (IPAM) platform designed to manage, analyze, and optimize network infrastructure across cloud providers and on-premises environments. The platform combines intelligent discovery, gap analysis, and AI-powered planning to provide organizations with comprehensive IP address lifecycle management.
+
+**Project Vision**: Enable organizations to optimize their IP address allocation strategies through intelligent analysis, automated discovery, and AI-assisted planning.
+
+**Key Goals**:
+1. Centralize IP address management across multi-cloud and hybrid environments
+2. Provide intelligent analysis and recommendations for address space optimization
+3. Enable natural language planning through AI integration
+4. Support enterprise-scale deployments with multi-tenancy and SSO
+5. Maintain complete audit trails for compliance and governance
+
+**Timeline**: 20 weeks (5 phases)
+**Target Audience**: Enterprise network teams, cloud architects, infrastructure engineers
+
+---
+
+## Phase 1: Foundation (Weeks 1-4)
+
+**Objective**: Build core API infrastructure, authentication, database layer, and basic pool management operations.
+
+### Week 1-2: Project Setup & Core Infrastructure
+
+**Activities**:
+- Initialize Go project structure with module dependencies
+- Set up development environment (Docker Compose for PostgreSQL/SQLite)
+- Implement CI/CD pipeline (GitHub Actions)
+- Create HTTP server framework with chi router
+- Set up logging, metrics, and error handling middleware
+- Implement database abstraction layer supporting both PostgreSQL and SQLite
+
+**Deliverables**:
+- [ ] Git repository with proper structure
+- [ ] Docker Compose development environment
+- [ ] HTTP server running on port 8080
+- [ ] Database connection pool with support for both PostgreSQL and SQLite
+- [ ] Observability framework (see [OBSERVABILITY.md](OBSERVABILITY.md)):
+  - [ ] Structured logging with slog (JSON output)
+  - [ ] OpenTelemetry metrics (Prometheus export)
+  - [ ] Distributed tracing (Jaeger)
+  - [ ] Health check endpoints (`/health`, `/ready`)
+- [ ] Local observability stack (see [docker-compose.observability.yml](deploy/docker-compose.observability.yml))
+
+**Success Criteria**:
+- Server starts cleanly and responds to `/health` endpoint
+- Database migrations run successfully on both database types
+- All errors properly logged and tracked
+- Code builds and tests run in CI/CD
+
+### Week 2-3: Database Layer & Migrations
+
+**Activities**:
+- Implement database migration system (versioned SQL files)
+- Create all core tables: organizations, users, roles, permissions, pools
+- Implement PostgreSQL and SQLite migrations
+- Create indexes and constraints for optimal query performance
+- Implement audit event logging with triggers
+- Build database abstraction layer
+
+**Deliverables**:
+- [ ] Complete schema migrations for PostgreSQL
+- [ ] Complete schema migrations for SQLite
+- [ ] Migration runner in Go
+- [ ] Database initialization scripts
+- [ ] Performance indexes on all key queries
+
+**Success Criteria**:
+- Migrations run without errors on both database types
+- All indexes created correctly
+- Audit triggers fire on data mutations
+- Schema passes validation with database tools
+
+### Week 3-4: Authentication & Authorization
+
+**Activities**:
+- Implement OAuth2/OIDC provider abstraction
+- Build session management with encryption
+- Implement API token generation and validation
+- Create RBAC middleware and permission checking
+- Build user provisioning system
+- Implement audit logging for auth events
+
+**Deliverables**:
+- [ ] OIDC provider configuration interface
+- [ ] Session store with encryption (AES-256-GCM)
+- [ ] API token generation and storage (Argon2id hashing)
+- [ ] Auth middleware stack
+- [ ] Permission validation middleware
+- [ ] User provisioning endpoints
+- [ ] Auth audit logging
+
+**Success Criteria**:
+- Successfully authenticate via OIDC (test with Keycloak locally)
+- API keys generate and validate correctly
+- Permission checks block unauthorized requests
+- All auth events logged to audit table
+- Session tokens refresh automatically
+
+### Week 4: Basic Pool CRUD Operations
+
+**Activities**:
+- Implement pool entity and repository layer
+- Create pool CRUD endpoints (POST, GET, PATCH, DELETE)
+- Implement hierarchical pool operations (create sub-pools)
+- Build pool querying with filters and pagination
+- Implement materialized path for efficient hierarchy queries
+- Add soft delete support
+
+**Deliverables**:
+- [ ] Pool repository with full CRUD operations
+- [ ] REST endpoints: `/api/v1/pools/*`
+- [ ] Hierarchical pool creation and navigation
+- [ ] Pool search and filtering
+- [ ] Request/response validation
+- [ ] Comprehensive error handling
+
+**Success Criteria**:
+- Create root pool with CIDR
+- Create child pools within parent
+- Query pools with pagination
+- Update pool properties
+- Soft delete and recovery
+- All operations audit logged
+
+**Phase 1 Success Metrics**:
+- Core infrastructure passes all tests
+- Authentication tested with real OIDC provider
+- 100+ API requests/second sustained on basic operations
+- Database handles 10,000 pools without performance degradation
+
+---
+
+## Phase 2: Cloud Integration (Weeks 5-8)
+
+**Objective**: Integrate with AWS/GCP/Azure, implement discovery sync engine, and enable drift detection.
+
+### Week 5: Cloud Account Management
+
+**Activities**:
+- Design cloud provider abstraction layer
+- Implement AWS IAM role assumption flow
+- Implement GCP service account authentication
+- Implement Azure managed identity flow
+- Build account registration endpoints
+- Create account credential encryption system
+- Implement health checks and connectivity testing
+
+**Deliverables**:
+- [ ] Cloud account entity and repository
+- [ ] OAuth2 flows for each cloud provider
+- [ ] Credential encryption/decryption system
+- [ ] Account management endpoints: `/api/v1/accounts/*`
+- [ ] Health check endpoints for connected accounts
+- [ ] Account listing with status
+
+**Success Criteria**:
+- Register AWS account with IAM role
+- Register GCP account with service account
+- Register Azure account with managed identity
+- Health checks return accurate status
+- Credentials stored encrypted
+
+### Week 6: Discovery Collector Framework
+
+**Activities**:
+- Design collector abstraction and collector SDK
+- Implement AWS EC2/VPC discovery collector
+- Implement GCP Compute discovery collector
+- Implement Azure networking discovery collector
+- Build discovery data models and storage
+- Create collector registration and heartbeat system
+- Implement concurrent discovery with rate limiting
+
+**Deliverables**:
+- [ ] Collector interface and SDK
+- [ ] AWS collector (VPCs, subnets, ENIs, EIPs)
+- [ ] GCP collector (networks, subnetworks, IPs)
+- [ ] Azure collector (VNets, subnets, NICs)
+- [ ] Discovery resource storage
+- [ ] Collector registry and heartbeat
+- [ ] Rate limiting per collector
+
+**Success Criteria**:
+- AWS collector discovers resources in test accounts
+- GCP collector discovers resources in test projects
+- Azure collector discovers resources in test subscriptions
+- Discovered resources stored with metadata
+- Collectors send heartbeats every 5 minutes
+- Handles 1000+ resources per discovery cycle
+
+### Week 7: Discovery Sync Engine
+
+**Activities**:
+- Implement sync job scheduling and execution
+- Build incremental sync with change detection
+- Implement resource reconciliation logic
+- Create resource linking to pools
+- Build conflict detection system
+- Implement orphan detection
+- Create sync job monitoring and retry logic
+
+**Deliverables**:
+- [ ] Sync job scheduler (configurable intervals)
+- [ ] Incremental sync engine
+- [ ] Resource reconciliation against existing pools
+- [ ] Conflict detection and reporting
+- [ ] Orphan resource detection
+- [ ] Sync job history and logging
+- [ ] Retry mechanism for failed syncs
+
+**Success Criteria**:
+- Automatic sync runs every 60 minutes (configurable)
+- Detects new, updated, and deleted resources
+- Matches discovered resources to pools
+- Identifies conflicts and orphans
+- Maintains sync history for auditing
+- Sync completes in < 5 minutes for 10k resources
+
+### Week 8: Drift Detection & Cloud Account UI
+
+**Activities**:
+- Implement drift detection logic (discovered vs managed state)
+- Build drift report generation
+- Create cloud account UI scaffolding
+- Implement account discovery status dashboard
+- Build resource sync monitoring views
+- Create reconciliation workflow UI
+
+**Deliverables**:
+- [ ] Drift detection engine
+- [ ] Drift reporting endpoints
+- [ ] Reconciliation suggestions
+- [ ] Cloud account management UI
+- [ ] Sync status dashboard
+- [ ] Resource discovery browser
+
+**Success Criteria**:
+- Drift detection identifies all conflicts
+- Reconciliation suggestions generated automatically
+- UI shows sync status in real-time
+- Historical sync data accessible and queryable
+
+**Phase 2 Success Metrics**:
+- Successfully integrate with all 3 major cloud providers
+- Discover 10,000+ resources per account
+- Sync completes within SLA (5 minutes for typical account)
+- Drift detection accuracy > 99%
+- Zero data loss during sync operations
+
+---
+
+## Phase 3: Smart Planning (Weeks 9-12)
+
+**Objective**: Implement intelligent analysis engine, gap analysis, recommendations, and schema wizard.
+
+### Week 9: Analysis Engine Core
+
+**Activities**:
+- Implement gap analysis algorithm
+- Build fragmentation detection system
+- Create utilization calculation engine
+- Implement compliance rule engine
+- Build analysis report generation
+- Create caching for analysis results
+
+**Deliverables**:
+- [ ] Gap analysis service
+- [ ] Fragmentation scoring algorithm
+- [ ] Compliance rule evaluation
+- [ ] Utilization metrics calculation
+- [ ] Analysis report endpoints: `/api/v1/analysis/*`
+- [ ] Result caching with TTL
+- [ ] Batch analysis for multiple pools
+
+**Success Criteria**:
+- Gap analysis identifies all unused address blocks
+- Fragmentation scoring correlates with inefficiency
+- Compliance checks validate against configurable rules
+- Analysis runs in < 30 seconds for typical org
+- Results cache for 1 hour
+
+**Week 9 Details - Gap Analysis Algorithm**:
+```
+1. For each pool:
+   a. Get all child allocations
+   b. Identify unused ranges between allocations
+   c. Score ranges by size and position
+   d. Return available blocks sorted by suitability
+2. Calculate utilization percentage
+3. Project available runway (time until exhaustion)
+```
+
+### Week 10: Recommendation Generator
+
+**Activities**:
+- Build recommendation engine from analysis results
+- Implement allocation suggestion algorithm
+- Create consolidation recommendations
+- Build compliance remediation suggestions
+- Implement growth projection
+- Create recommendation scoring and ranking
+
+**Deliverables**:
+- [ ] Recommendation generation engine
+- [ ] Allocation suggestion algorithm
+- [ ] Consolidation detection
+- [ ] Compliance fix recommendations
+- [ ] Growth projections (3-12 months)
+- [ ] Recommendation ranking by impact
+- [ ] Auto-applicability detection
+
+**Success Criteria**:
+- Generates 5-20 recommendations per analysis
+- Allocation suggestions ranked by quality
+- Growth projections accurate within 80%
+- Recommendations include rationale and impact
+- Some recommendations auto-applicable
+
+### Week 11: Schema Wizard & Templates
+
+**Activities**:
+- Design schema template system
+- Build schema template library (5 common patterns)
+- Implement schema generator from wizard inputs
+- Create schema validation system
+- Build interactive schema builder
+- Implement schema visualization
+
+**Deliverables**:
+- [ ] Schema template entities and storage
+- [ ] Built-in templates: Regional, Hierarchical, Flat, Cloud-Native, Hybrid
+- [ ] Schema wizard form endpoints
+- [ ] Schema generation from parameters
+- [ ] Schema validation with detailed errors
+- [ ] ASCII art visualization of generated schema
+- [ ] Schema export (JSON, YAML, Terraform)
+
+**Success Criteria**:
+- 5+ built-in templates available
+- Wizard generates valid schemas
+- Validation catches overlaps and issues
+- User can preview before applying
+- Schema applies cleanly to create pool structure
+
+**Week 12: Import/Export Functionality
+
+**Activities**:
+- Implement CSV import system
+- Build Excel import support
+- Create import validation and preview
+- Implement JSON export
+- Build YAML export for infrastructure-as-code
+- Create Terraform provider export
+- Implement bulk update from imports
+
+**Deliverables**:
+- [ ] CSV import with header mapping wizard
+- [ ] Excel import (openpyxl or similar)
+- [ ] Data validation and preview before commit
+- [ ] Dry-run mode for all imports
+- [ ] JSON/YAML/Terraform export endpoints
+- [ ] Error reporting on failed imports
+- [ ] Import history and rollback
+
+**Success Criteria**:
+- Import 1000+ pools from CSV in < 10 seconds
+- Validate data integrity before committing
+- Export generates valid infrastructure-as-code
+- Dry-run mode catches all errors without changes
+
+**Phase 3 Success Metrics**:
+- Analysis engine completes in < 30 seconds
+- Recommendations generated with > 85% actionability
+- Schema wizard handles all 5 template types
+- Import/export format compatibility with industry tools
+- End-to-end planning workflow fully operational
+
+---
+
+## Phase 4: AI Planning (Weeks 13-16)
+
+**Objective**: Implement LLM integration, conversational planning interface, and plan generation.
+
+### Week 13: LLM Provider Abstraction
+
+**Activities**:
+- Design LLM provider interface
+- Implement OpenAI provider
+- Implement Anthropic provider
+- Implement Azure OpenAI provider
+- Implement Ollama (local) provider
+- Create provider configuration system
+- Build context injection system
+
+**Deliverables**:
+- [ ] LLMProvider interface
+- [ ] OpenAI implementation
+- [ ] Anthropic Claude implementation
+- [ ] Azure OpenAI implementation
+- [ ] Ollama implementation
+- [ ] Provider selection and fallback
+- [ ] Configuration validation
+
+**Success Criteria**:
+- Support all 5 LLM providers
+- Seamless provider switching
+- Proper error handling for provider failures
+- Cost tracking for API-based providers
+- Token usage monitoring
+
+**Week 14: Conversational Planning Interface
+
+**Activities**:
+- Build conversation storage (PlanningConversation entity)
+- Implement message handling and history
+- Create system prompts for planning context
+- Build context injection from pool data
+- Implement message streaming responses
+- Create conversation export functionality
+
+**Deliverables**:
+- [ ] Conversation entity and repository
+- [ ] Message storage and retrieval
+- [ ] System prompt library
+- [ ] Context injection system
+- [ ] Streaming response handling
+- [ ] Conversation endpoints: `/api/v1/planning/conversations/*`
+- [ ] WebSocket support for real-time responses
+
+**Success Criteria**:
+- Maintain conversation history
+- System prompts provide sufficient context
+- LLM generates actionable responses
+- Streaming responses feel responsive
+- Conversations persist and retrievable
+
+### Week 15: Plan Generation & Validation
+
+**Activities**:
+- Implement response parsing (extract PoolSpec from LLM output)
+- Build plan generation from conversational context
+- Create plan validation system
+- Implement what-if analysis
+- Build risk assessment for generated plans
+- Create plan application workflow
+
+**Deliverables**:
+- [ ] LLM response parser
+- [ ] GeneratedPlan entity
+- [ ] Plan validation engine
+- [ ] What-if simulation
+- [ ] Risk assessment algorithm
+- [ ] Plan storage and retrieval
+- [ ] Plan application endpoints
+
+**Success Criteria**:
+- LLM generates valid pool specifications
+- Validation catches overlaps and issues
+- What-if analysis completes in < 5 seconds
+- Risk assessment identifies conflicts
+- Plans can be applied or discarded
+
+### Week 16: Advanced Planning Features
+
+**Activities**:
+- Implement multi-turn planning with refinement
+- Build plan comparison (original vs AI-generated)
+- Create cost optimization analysis
+- Implement growth factor consideration
+- Build fallback recommendation system
+- Create plan analytics and success tracking
+
+**Deliverables**:
+- [ ] Multi-turn conversation refinement
+- [ ] Plan comparison reports
+- [ ] Cost impact analysis
+- [ ] Growth headroom calculations
+- [ ] Fallback to rule-based recommendations
+- [ ] Plan success metrics tracking
+- [ ] Analytics endpoints
+
+**Success Criteria**:
+- Users can refine plans through conversation
+- Plan quality improves with iteration
+- Cost analysis accurate and actionable
+- Growth factors properly applied
+- System gracefully falls back when LLM unavailable
+
+**Phase 4 Success Metrics**:
+- LLM integration stable and performant
+- Conversational planning feel natural and intuitive
+- Generated plans 90%+ actionable without modification
+- Support 4+ concurrent planning conversations
+- LLM cost < $0.10 per planning session average
+
+---
+
+## Phase 5: Enterprise Features (Weeks 17-20)
+
+**Objective**: Enable multi-tenancy, enterprise authentication, audit compliance, and rate limiting.
+
+### Week 17: Multi-Tenancy Implementation
+
+**Activities**:
+- Refactor data model for true multi-tenancy
+- Implement organization isolation at database level
+- Create organization management endpoints
+- Build organization settings storage
+- Implement organization-level quotas
+- Create organization API key management
+
+**Deliverables**:
+- [ ] Organization entity enhancements
+- [ ] Row-level security policies (PostgreSQL)
+- [ ] Tenant isolation verification
+- [ ] Organization management UI/API
+- [ ] Settings storage per organization
+- [ ] Quota enforcement system
+- [ ] Organization billing hooks
+
+**Success Criteria**:
+- Complete data isolation between organizations
+- No cross-organization data leakage possible
+- Organization admins can manage users and teams
+- Quotas enforced (pools, syncs, API calls)
+- Audit trail separated by organization
+
+### Week 18: SSO/OIDC & Advanced Auth
+
+**Activities**:
+- Implement SSO configuration management
+- Build OIDC provider discovery
+- Create group mapping to roles
+- Implement JIT (Just-In-Time) user provisioning
+- Build session management UI
+- Implement MFA support
+- Create device management
+
+**Deliverables**:
+- [ ] SSO configuration endpoints
+- [ ] Provider discovery implementation
+- [ ] Group to role mapping UI
+- [ ] Auto-user provisioning system
+- [ ] Session management endpoints
+- [ ] MFA enrollment and verification
+- [ ] Trusted device registration
+
+**Success Criteria**:
+- SSO works with major IdPs (Okta, Azure AD, Google)
+- Groups automatically map to roles
+- New users auto-created on first login
+- MFA support for high-security environments
+- Sessions revocable per-device
+
+### Week 19: Comprehensive Audit Logging & Log Shipping
+
+**Activities**:
+- Enhance audit event tracking for all operations
+- Implement audit log search and filtering
+- Build audit report generation
+- Create compliance-ready exports
+- Implement data retention policies
+- Build audit log encryption for compliance
+- Create audit analysis dashboard
+- Deploy log shipping infrastructure (Vector sidecar)
+- Configure SIEM integrations (Splunk, CloudWatch, Cloud Logging)
+
+**Reference Documentation**:
+- [OBSERVABILITY.md](OBSERVABILITY.md) - Full observability architecture
+- [openapi-observability.yaml](openapi-observability.yaml) - Audit API endpoints
+- [deploy/vector/vector.toml](deploy/vector/vector.toml) - Vector configuration
+- [deploy/k8s/vector-daemonset.yaml](deploy/k8s/vector-daemonset.yaml) - K8s log collection
+- [cloudpam-audit-log.html](cloudpam-audit-log.html) - UI mockup
+
+**Deliverables**:
+- [ ] Comprehensive audit logging for all mutations
+- [ ] Audit search endpoints with filtering (see openapi-observability.yaml)
+- [ ] Audit report generation (JSON, CSV, PDF)
+- [ ] Data retention configuration
+- [ ] Audit trail encryption at rest
+- [ ] Compliance report templates
+- [ ] Audit dashboard with analytics (see cloudpam-audit-log.html)
+- [ ] Vector sidecar deployment for log shipping
+- [ ] SIEM integration (Splunk, CloudWatch, Cloud Logging)
+
+**Success Criteria**:
+- Every mutation logged with before/after state
+- Audit logs searchable and filterable
+- Reports generated on demand
+- Data retention policies enforced
+- Logs encrypted with audit key
+- Logs shipped to configured SIEM in real-time
+
+### Week 20: Rate Limiting, Polish & Launch
+
+**Activities**:
+- Implement API rate limiting (per-user, per-org, per-key)
+- Build rate limit quota management
+- Create usage analytics dashboard
+- Implement cost tracking and billing integration
+- Polish UI/UX for general availability
+- Comprehensive security audit
+- Documentation and runbooks
+
+**Deliverables**:
+- [ ] Rate limiting middleware
+- [ ] Per-user rate limits
+- [ ] Per-API-key configurable limits
+- [ ] Usage dashboard
+- [ ] Cost tracking system
+- [ ] Security audit report
+- [ ] Complete API documentation
+- [ ] Operations runbooks
+
+**Success Criteria**:
+- Rate limits prevent abuse
+- Fair quota system prevents resource starvation
+- Usage tracking accurate
+- System withstands 10k requests/second
+- Zero security issues in audit
+
+**Phase 5 Success Metrics**:
+- Support 100+ organizations independently
+- SSO deployment time < 30 minutes
+- Audit logs queryable and compliant
+- Rate limiting prevents abuse without impacting legitimate users
+- System ready for production enterprise deployment
+
+---
+
+## Technical Dependencies
+
+### Build-Before Dependencies
+
+The following diagram shows which components must be completed before others:
+
+```
+Phase 1
+├── Infrastructure (Weeks 1-2)
+│   └── Required by: All phases
+├── Database & Migrations (Weeks 2-3)
+│   └── Required by: Auth, Pools
+└── Auth (Weeks 3-4)
+    └── Required by: All Phase 2+ features
+    └── Basic Pools (Week 4)
+        └── Required by: Phase 2, 3, 4
+
+Phase 2
+├── Cloud Account Management (Week 5)
+│   └── Required by: Collectors, Sync
+├── Collectors (Week 6)
+│   └── Required by: Sync Engine
+├── Sync Engine (Week 7)
+│   └── Required by: Drift Detection
+└── Drift Detection (Week 8)
+    └── Required by: Analysis (Phase 3)
+
+Phase 3
+├── Analysis Engine (Week 9)
+│   └── Required by: Recommendations, Reports
+├── Recommendations (Week 10)
+│   └── Required by: Planning UI
+├── Schema Wizard (Week 11)
+│   └── Parallel with Recommendations
+└── Import/Export (Week 12)
+    └── Required by: Phase 4 context injection
+
+Phase 4
+└── All depends on Phase 3 completion
+    ├── LLM Abstraction (Week 13)
+    │   └── Required by: Conversational Interface
+    ├── Conversational Interface (Week 14)
+    │   └── Required by: Plan Generation
+    ├── Plan Generation (Week 15)
+    └── Advanced Features (Week 16)
+
+Phase 5
+└── Can proceed in parallel with Phase 4
+    ├── Multi-tenancy (Week 17)
+    ├── SSO/OIDC (Week 18)
+    ├── Audit Logging (Week 19)
+    └── Rate Limiting (Week 20)
+```
+
+### Cross-Phase Dependencies
+
+- **Phase 3 → Phase 4**: Analysis output provides context for AI planning
+- **Phase 2 → Phase 3**: Discovered resources inform gap and fragmentation analysis
+- **Phase 1 → All**: Authentication required by all features
+- **Phase 3 → Phase 5**: Audit logging enhanced with enterprise features
+
+---
+
+## Risk Assessment
+
+### Critical Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|-----------|
+| Cloud provider API changes | Medium | High | Maintain multiple SDK versions, abstract provider interfaces |
+| Database migration failures in production | Low | Critical | Extensive testing, dry-run mode, automated rollback scripts |
+| LLM provider unavailability | Medium | Medium | Multi-provider support, fallback to rule-based recommendations |
+| Performance degradation at scale | Medium | High | Early load testing, caching strategy, database optimization |
+| Security vulnerability in auth | Low | Critical | Regular security audits, penetration testing, bug bounty program |
+
+### High Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|-----------|
+| Integration delays with cloud providers | Medium | Medium | Early prototyping with official SDKs, CloudFormation/Terraform |
+| Data consistency issues across sync | Medium | High | Comprehensive reconciliation logic, audit trails, test harness |
+| LLM output quality variance | Medium | Medium | Extensive prompt engineering, output validation, human review |
+| API design changes | Low | Medium | Versioning strategy, deprecation notices, migration guides |
+
+### Medium Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|-----------|
+| Third-party library vulnerabilities | Medium | Medium | Regular dependency updates, vulnerability scanning |
+| Network latency affecting discovery | Medium | Low | Async operations, progress tracking, graceful degradation |
+| User adoption of new features | Medium | Low | User education, documentation, gradual rollout |
+| Team knowledge gaps on Go/PostgreSQL | Low | Medium | Training, documentation, code reviews, external expertise |
+
+---
+
+## Resource Requirements
+
+### Development Team
+
+**Team Composition** (Full-time equivalent):
+
+| Role | Count | Weeks | Responsibility |
+|------|-------|-------|-----------------|
+| Senior Backend Engineer | 1 | 20 | Lead architecture, core APIs, database design |
+| Backend Engineers | 2 | 20 | Feature implementation, cloud integration, testing |
+| Frontend Engineer | 1 | 15 | UI implementation (Phases 2-5) |
+| DevOps/Infrastructure | 1 | 20 | CI/CD, deployment, monitoring, database setup |
+| QA Engineer | 1 | 15 | Test automation, integration testing (Phases 2-5) |
+| Product Manager | 1 | 20 | Requirements, prioritization, stakeholder management |
+| **Total** | **7** | **20 weeks** | |
+
+**Optional Roles** (Part-time):
+- Security Engineer (2 weeks): Phase 1, Phase 5 security audit
+- Technical Writer (3 weeks): Documentation, API docs, runbooks
+- Solutions Architect (2 weeks): Customer integration, design reviews
+
+### Infrastructure Requirements
+
+**Development Environment**:
+- Cloud credits: ~$500/month (AWS/GCP/Azure for testing)
+- Test databases: PostgreSQL and SQLite
+- Local dev machine: 8GB RAM, 50GB disk minimum
+
+**Staging Environment**:
+- PostgreSQL instance (managed service)
+- Cache layer (Redis) for session/analysis caching
+- Load balancer for testing multi-instance
+- Cloud accounts for each provider (test accounts)
+
+**Production Deployment**:
+- High-availability PostgreSQL (RDS, Cloud SQL, or managed)
+- Kubernetes cluster (optional, for scaling)
+- Cache layer (Redis) for performance
+- API Gateway for rate limiting
+- CDN for static assets
+
+### Technology Stack
+
+**Backend**:
+- Language: Go 1.21+
+- Web Framework: chi router
+- Database: PostgreSQL (primary), SQLite (fallback)
+- Migration Tool: golang-migrate
+- Auth: go-oidc, jwt-go
+- Cloud SDKs: AWS SDK v2, GCP client libraries, Azure SDK
+
+**Frontend** (not detailed in roadmap, assumed separate):
+- Framework: React or Vue
+- HTTP Client: Axios
+- State Management: Redux/Vuex
+- UI Library: Material-UI or Tailwind CSS
+
+**DevOps**:
+- Containerization: Docker
+- Orchestration: Docker Compose (dev), Kubernetes (production optional)
+- CI/CD: GitHub Actions
+- Monitoring: Prometheus + Grafana
+- Logging: ELK Stack or cloud provider logs
+
+---
+
+## Success Metrics
+
+### Phase 1: Foundation
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| API Response Time | < 100ms p95 | APM monitoring |
+| Test Coverage | > 80% | Coverage reports |
+| Authentication Success Rate | > 99.9% | Auth logs |
+| Database Query Performance | < 50ms avg | Query logs |
+| Code Review Quality | > 90% approval rate | GitHub metrics |
+
+### Phase 2: Cloud Integration
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Discovery Accuracy | > 99% of resources found | Manual verification |
+| Sync Performance | < 5 min for 10k resources | Sync job logs |
+| Cloud Provider Support | All 3 major clouds | Manual testing |
+| Reconciliation Accuracy | > 98% | Audit comparison |
+| Collector Uptime | > 99.5% | Heartbeat logs |
+
+### Phase 3: Smart Planning
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Analysis Completion Time | < 30 seconds | Performance monitoring |
+| Recommendation Quality | > 85% actionable | User feedback |
+| Schema Generation | 100% valid schemas | Validation tests |
+| Import Success Rate | > 99% | Import logs |
+| Export Compatibility | Works with Terraform/YAML | Integration tests |
+
+### Phase 4: AI Planning
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| LLM Response Accuracy | > 90% valid plans | Output validation |
+| Conversation Handling | 4+ concurrent conversations | Load testing |
+| Plan Generation Time | < 30 seconds | Performance monitoring |
+| LLM Provider Reliability | 99.5% availability | Provider monitoring |
+| User Satisfaction | > 4/5 stars | User surveys |
+
+### Phase 5: Enterprise Features
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Multi-tenant Isolation | 100% data separation | Security tests |
+| SSO Deployment Time | < 30 minutes | Setup documentation |
+| API Rate Limiting | Prevents abuse | Load tests |
+| Audit Coverage | 100% of mutations | Audit logs |
+| Compliance Readiness | Pass SOC 2 audit | External audit |
+
+### Overall Product Metrics
+
+| Metric | Phase | Target | Measurement |
+|--------|-------|--------|-------------|
+| Supported Pool Count | 3 | 10,000+ | Load testing |
+| Concurrent Users | 5 | 1,000+ | Load testing |
+| API Requests/Second | 2 | 1,000+ sustained | Load testing |
+| System Uptime | 5 | 99.95% | Monitoring |
+| Mean Time to Recovery | 5 | < 5 minutes | Incident response |
+| Security Issues | All | 0 critical | Security audit |
+
+---
+
+## Implementation Timeline
+
+### Gantt Chart Overview
+
+```
+Week   1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
+       |--|----|  Infrastructure & Auth
+          |--|----|  Database & Pools
+                     |--|----|  Cloud Integration (Accounts)
+                        |--|----|  Collectors & Sync
+                           |--|----|  Drift Detection & Analysis
+                              |--|----|  Recommendations
+                                 |--|----|  Schema Wizard
+                                    |--|----|  AI Planning
+                                       |--|----|  Advanced Features
+          |--|--|--|--|--|--|--|--|--|--|--|--|--|--|  Multi-tenancy
+                                       |--|--|--|  SSO
+                                          |--|  Audit
+                                             |--|  Rate Limit
+```
+
+### Key Milestones
+
+- **End of Week 4**: Basic pool management operational, authentication working
+- **End of Week 8**: Cloud discovery and sync fully functional
+- **End of Week 12**: Complete analysis and planning capabilities
+- **End of Week 16**: AI-powered planning conversation interface ready
+- **End of Week 20**: Enterprise-ready product launch
+
+---
+
+## Development Standards & Best Practices
+
+### Code Quality
+
+- **Language**: Go 1.21+ with strict `go vet` and `golangci-lint`
+- **Testing**: Unit tests (>80%), Integration tests, E2E tests
+- **Documentation**: Godoc on all exported functions
+- **Code Review**: All PRs require 2 approvals before merge
+- **Commit Messages**: Conventional commits (feat:, fix:, docs:, etc.)
+
+### Database Design
+
+- **Transactions**: Critical operations wrapped in transactions with proper rollback
+- **Migrations**: All schema changes via versioned migration files
+- **Indexes**: Profile queries before going to production
+- **Soft Deletes**: Use for audit trail preservation
+- **Encryption**: Sensitive data (tokens, secrets) encrypted at rest
+
+### API Design
+
+- **Versioning**: API v1 with deprecation path for v2 features
+- **RESTful**: Standard HTTP methods and status codes
+- **Pagination**: Limit + offset for list endpoints
+- **Validation**: Input validation at handler level
+- **Error Responses**: Consistent error schema with error codes
+
+### Security
+
+- **HTTPS**: All production traffic encrypted
+- **CORS**: Strict origin policy
+- **CSRF**: Token validation on state-changing operations
+- **Rate Limiting**: Prevent abuse
+- **Logging**: No sensitive data in logs (tokens, passwords, credentials)
+- **Dependencies**: Regular updates and vulnerability scanning
+
+### Monitoring & Observability
+
+- **Metrics**: Prometheus metrics for all critical paths
+- **Logging**: Structured JSON logging with request tracing
+- **Alerting**: Alerts for error rates, latency, availability
+- **Tracing**: Distributed tracing for multi-component requests
+- **Health Checks**: /health and /ready endpoints
+
+---
+
+## Post-Launch Roadmap (Months 5-12)
+
+After initial launch, consider these enhancements:
+
+### Month 5-6: Performance & Scale
+- Database query optimization
+- Caching strategy enhancements
+- Horizontal scaling with load balancing
+- CDN integration for static assets
+
+### Month 7-8: Advanced Analytics
+- Cost attribution per pool
+- Historical trend analysis
+- Capacity planning recommendations
+- Chargeback reporting
+
+### Month 9-10: Integration Ecosystem
+- Terraform provider for CloudPAM
+- Ansible inventory plugin
+- CI/CD integrations (Jenkins, GitLab CI)
+- Webhook support for events
+
+### Month 11-12: Machine Learning
+- Predictive growth models
+- Anomaly detection in allocation patterns
+- Cost optimization ML models
+- Usage pattern analysis
+
+---
+
+## Appendix: Reference Architecture Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                         CloudPAM Architecture                         │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐               │
+│  │   Frontend   │  │    Mobile    │  │     CLI      │               │
+│  │   (React)    │  │   (Native)   │  │    (Go)      │               │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘               │
+│         │                 │                  │                       │
+│         └─────────────────┼──────────────────┘                       │
+│                           │                                          │
+│  ┌────────────────────────▼─────────────────────────────────────┐   │
+│  │              API Gateway & Load Balancer                     │   │
+│  │         (Rate Limiting, Auth, Routing)                       │   │
+│  └────────────────────────┬─────────────────────────────────────┘   │
+│                           │                                          │
+│  ┌────────────────────────▼─────────────────────────────────────┐   │
+│  │                    CloudPAM API (Go)                         │   │
+│  ├──────────────────────────────────────────────────────────────┤   │
+│  │  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐         │   │
+│  │  │    Pool      │ │    Cloud     │ │   Analysis   │         │   │
+│  │  │  Management  │ │ Integration  │ │   Engine     │         │   │
+│  │  └──────┬───────┘ └──────┬───────┘ └──────┬───────┘         │   │
+│  │         │                │                │                 │   │
+│  │  ┌──────▼─────────────────▼──────────────▼──────┐           │   │
+│  │  │        Smart Planning & AI Service          │           │   │
+│  │  └──────────────────────────────────────────────┘           │   │
+│  │                                                              │   │
+│  └───────────────────────┬──────────────────────────────────────┘   │
+│                          │                                           │
+│  ┌───────────────────────▼────────────────────────────────────────┐ │
+│  │              Data & Auth Layer                                │ │
+│  ├──────────────────────────────────────────────────────────────┤ │
+│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │ │
+│  │  │ PostgreSQL   │  │   Session    │  │   Audit     │      │ │
+│  │  │   (Primary)  │  │    Store     │  │    Logs     │      │ │
+│  │  └──────────────┘  └──────────────┘  └──────────────┘      │ │
+│  │                                                              │ │
+│  │  ┌──────────────┐  ┌──────────────┐                         │ │
+│  │  │  Redis Cache │  │ OIDC Provider│                         │ │
+│  │  └──────────────┘  └──────────────┘                         │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+│                                                                    │
+│  ┌──────────────────────────────────────────────────────────────┐ │
+│  │              External Integrations                           │ │
+│  ├──────────────────────────────────────────────────────────────┤ │
+│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐   │ │
+│  │  │   AWS    │  │   GCP    │  │  Azure   │  │   LLMs   │   │ │
+│  │  │          │  │          │  │          │  │(OpenAI, │   │ │
+│  │  │VPC/EC2   │  │Compute/  │  │VNet/AKS  │  │ Claude) │   │ │
+│  │  │          │  │Networks  │  │          │  │          │   │ │
+│  │  └──────────┘  └──────────┘  └──────────┘  └──────────┘   │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+│                                                                    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Glossary
+
+**CIDR**: Classless Inter-Domain Routing - notation for IP address ranges (e.g., 10.0.0.0/16)
+
+**IPAM**: IP Address Management - system for managing and tracking IP addresses
+
+**Drift Detection**: Identifying differences between desired state (managed pools) and actual state (cloud resources)
+
+**Fragmentation**: Inefficient use of address space through scattered or oversized allocations
+
+**Gap Analysis**: Identifying unused address blocks available for allocation
+
+**OIDC**: OpenID Connect - authentication protocol
+
+**RBAC**: Role-Based Access Control - authorization model based on user roles
+
+**Soft Delete**: Marking records as deleted without removing from database (preserves audit trail)
+
+**Materialized Path**: Database optimization technique for hierarchical data using path strings
+
+**LLM**: Large Language Model (AI model like ChatGPT, Claude)
+
+**Reconciliation**: Matching discovered resources with managed pools
+
+**Schema**: Hierarchical structure of pools with naming and organization patterns
+
+---
+
+## Document Control
+
+- **Version**: 1.0
+- **Last Updated**: 2024-01-30
+- **Owner**: CloudPAM Product Team
+- **Status**: Approved for Implementation
+

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,514 @@
+# CloudPAM Observability Architecture
+
+## Overview
+
+CloudPAM implements a comprehensive observability stack covering structured logging, metrics collection, distributed tracing, and audit logging. The architecture follows cloud-native best practices with pluggable backends for enterprise integration.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                              CloudPAM Application                                │
+│  ┌─────────────────┐  ┌──────────────────┐  ┌─────────────────────────────────┐ │
+│  │   Structured    │  │   OpenTelemetry  │  │         Audit Events            │ │
+│  │   Logging       │  │   Metrics/Traces │  │         (Database)              │ │
+│  │   (slog/JSON)   │  │                  │  │                                 │ │
+│  └────────┬────────┘  └────────┬─────────┘  └───────────────┬─────────────────┘ │
+└───────────┼─────────────────────┼───────────────────────────┼───────────────────┘
+            │                     │                           │
+            ▼                     ▼                           ▼
+┌───────────────────┐  ┌──────────────────┐       ┌─────────────────────┐
+│   Vector Sidecar  │  │    Prometheus    │       │   Audit Log API     │
+│   (Log Shipping)  │  │    Collector     │       │   (In-App Viewer)   │
+└─────────┬─────────┘  └────────┬─────────┘       └─────────────────────┘
+          │                     │
+          ▼                     ▼
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                           Observability Backends                                 │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────────┐ │
+│  │   Syslog    │  │   Splunk    │  │   AWS       │  │   GCP Cloud Logging     │ │
+│  │             │  │   HEC       │  │   CloudWatch│  │                         │ │
+│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────────────────┘ │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                              │
+│  │  Prometheus │  │   Grafana   │  │   Jaeger    │                              │
+│  │  (Metrics)  │  │   (Viz)     │  │  (Tracing)  │                              │
+│  └─────────────┘  └─────────────┘  └─────────────┘                              │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## 1. Structured Logging
+
+### 1.1 Framework: Go slog (Standard Library)
+
+CloudPAM uses Go's native `slog` package (Go 1.21+) for structured logging:
+
+| Feature | Benefit |
+|---------|---------|
+| Standard library | No external dependencies, future-proof |
+| JSON output | Machine-parseable for log aggregation |
+| Context-aware | Correlation IDs propagate through request lifecycle |
+| Handler composition | Sampling, filtering, multi-output support |
+| High performance | Comparable to zap with better maintainability |
+
+### 1.2 Log Levels
+
+| Level | Usage | Example |
+|-------|-------|---------|
+| `DEBUG` | Development troubleshooting | Variable values, SQL queries |
+| `INFO` | Significant business events | Pool created, sync completed |
+| `WARN` | Recoverable issues | Retry attempt, deprecated API |
+| `ERROR` | Failures requiring attention | Auth failed, database error |
+
+### 1.3 Log Format (JSON)
+
+```json
+{
+  "timestamp": "2025-01-30T14:32:15.123Z",
+  "severity": "INFO",
+  "message": "Pool created successfully",
+  "service": "cloudpam",
+  "version": "1.0.0",
+  "environment": "production",
+  "correlation_id": "req_abc123def456",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "span_id": "00f067aa0ba902b7",
+  "http.method": "POST",
+  "http.path": "/api/v1/pools",
+  "http.status": 201,
+  "user.id": "usr_12345",
+  "pool.id": "pool_67890",
+  "duration_ms": 42.5
+}
+```
+
+### 1.4 Correlation ID Propagation
+
+Every request receives a unique correlation ID that flows through all components:
+
+```
+Client Request
+     │
+     ▼ X-Correlation-ID: req_abc123
+┌─────────────────┐
+│  HTTP Handler   │ ─── logs with correlation_id
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  Service Layer  │ ─── logs with correlation_id
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  Repository     │ ─── logs with correlation_id
+└────────┬────────┘
+         │
+         ▼ Response includes X-Correlation-ID
+     Client
+```
+
+## 2. Log Shipping with Vector
+
+### 2.1 Why Vector?
+
+| Aspect | Vector | Fluentd |
+|--------|--------|---------|
+| Language | Rust (memory-efficient) | Ruby (flexible) |
+| Startup | <100ms | 1-2 seconds |
+| Memory | 20-50 MB | 50-100 MB |
+| Config | TOML (simple) | Ruby/JSON (complex) |
+| Performance | Higher throughput | Proven, solid |
+
+### 2.2 Deployment Pattern: Sidecar
+
+CloudPAM deploys Vector as a sidecar container in Kubernetes:
+
+```yaml
+# Pod structure
+containers:
+  - name: cloudpam        # Main application
+    volumeMounts:
+      - name: logs
+        mountPath: /var/log/cloudpam
+
+  - name: vector          # Log shipping sidecar
+    image: timberio/vector:0.34
+    volumeMounts:
+      - name: logs
+        mountPath: /var/log/cloudpam
+        readOnly: true
+```
+
+Benefits:
+- Decouples log shipping from application
+- Independent updates to shipping config
+- Handles backpressure gracefully
+- Supports multiple destinations simultaneously
+
+### 2.3 Supported Destinations
+
+| Destination | Use Case | Configuration |
+|-------------|----------|---------------|
+| **Syslog** | Enterprise log aggregation | TCP/UDP to syslog server |
+| **Splunk** | SIEM integration | HTTP Event Collector (HEC) |
+| **AWS CloudWatch** | AWS-native logging | IAM role authentication |
+| **GCP Cloud Logging** | GCP-native logging | Service account |
+| **Datadog** | SaaS observability | API key |
+| **Elasticsearch** | Self-hosted search | Bulk API |
+
+### 2.4 Vector Configuration
+
+See `deploy/vector/vector.toml` for full configuration. Key sections:
+
+```toml
+# Collect logs from CloudPAM
+[sources.app_logs]
+type = "file"
+includes = ["/var/log/cloudpam/*.log"]
+
+# Parse JSON and enrich
+[transforms.parse]
+type = "remap"
+inputs = ["app_logs"]
+source = '''
+. = parse_json!(.message)
+.kubernetes.pod_name = get_env_var!("POD_NAME")
+'''
+
+# Ship to multiple destinations
+[sinks.splunk]
+type = "splunk_hec"
+inputs = ["parse"]
+endpoint = "${SPLUNK_HEC_URL}"
+token = "${SPLUNK_HEC_TOKEN}"
+```
+
+## 3. Metrics with OpenTelemetry
+
+### 3.1 Instrumentation Strategy
+
+CloudPAM exports metrics via OpenTelemetry SDK to Prometheus:
+
+```
+┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│  CloudPAM App    │────▶│  OTLP Exporter   │────▶│   Prometheus     │
+│  (OTel SDK)      │     │  :8889/metrics   │     │   Scraper        │
+└──────────────────┘     └──────────────────┘     └──────────────────┘
+                                                           │
+                                                           ▼
+                                                  ┌──────────────────┐
+                                                  │     Grafana      │
+                                                  │   Dashboards     │
+                                                  └──────────────────┘
+```
+
+### 3.2 Metrics Catalog
+
+#### HTTP Metrics (RED Method)
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `http_request_duration_seconds` | Histogram | method, path, status | Request latency |
+| `http_requests_total` | Counter | method, path, status | Request count |
+| `http_request_size_bytes` | Histogram | method, path | Request body size |
+| `http_response_size_bytes` | Histogram | method, path | Response body size |
+| `http_connections_active` | Gauge | - | Active connections |
+
+#### Database Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `db_query_duration_seconds` | Histogram | operation | Query latency |
+| `db_queries_total` | Counter | operation, status | Query count |
+| `db_connections_pool_size` | Gauge | - | Pool size |
+| `db_connections_in_use` | Gauge | - | Connections in use |
+
+#### Business Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cloudpam_pool_count` | Gauge | org_id, type | Total pools |
+| `cloudpam_pool_utilization_percent` | Gauge | pool_id, type | Pool utilization |
+| `cloudpam_allocation_duration_seconds` | Histogram | pool_id | Allocation latency |
+| `cloudpam_allocation_failures_total` | Counter | pool_id, reason | Failed allocations |
+| `cloudpam_discovery_sync_duration_seconds` | Histogram | account_id | Sync duration |
+| `cloudpam_discovery_sync_errors_total` | Counter | account_id, error | Sync errors |
+| `cloudpam_conflicts_detected_total` | Counter | - | IP conflicts found |
+
+#### Authentication Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cloudpam_auth_attempts_total` | Counter | method, success | Auth attempts |
+| `cloudpam_sessions_active` | Gauge | - | Active sessions |
+| `cloudpam_api_token_usage_total` | Counter | token_id | API token usage |
+
+#### Audit Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `cloudpam_audit_events_total` | Counter | action, resource_type | Audit events |
+| `cloudpam_audit_processing_duration_seconds` | Histogram | - | Event processing time |
+
+### 3.3 Prometheus Configuration
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'cloudpam'
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        target_label: __address__
+        regex: (.+)
+        replacement: $1
+```
+
+## 4. Distributed Tracing with Jaeger
+
+### 4.1 Trace Propagation
+
+CloudPAM uses W3C Trace Context for distributed tracing:
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   API Gateway   │────▶│   CloudPAM      │────▶│   PostgreSQL    │
+│                 │     │   Service       │     │                 │
+│  traceparent:   │     │  span: "POST    │     │  span: "INSERT  │
+│  00-abc123...   │     │   /api/pools"   │     │   pools"        │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+         │                      │                      │
+         └──────────────────────┴──────────────────────┘
+                               │
+                               ▼
+                      ┌─────────────────┐
+                      │     Jaeger      │
+                      │   Collector     │
+                      └─────────────────┘
+```
+
+### 4.2 Span Attributes
+
+Each span includes:
+
+| Attribute | Example |
+|-----------|---------|
+| `service.name` | cloudpam |
+| `service.version` | 1.0.0 |
+| `http.method` | POST |
+| `http.url` | /api/v1/pools |
+| `http.status_code` | 201 |
+| `db.system` | postgresql |
+| `db.statement` | INSERT INTO pools... |
+| `user.id` | usr_12345 |
+
+### 4.3 Sampling Strategy
+
+| Environment | Strategy | Rate |
+|-------------|----------|------|
+| Development | Always sample | 100% |
+| Staging | Probabilistic | 10% |
+| Production | Probabilistic | 1% |
+
+## 5. Audit Logging
+
+### 5.1 Architecture
+
+Audit events are stored in the database and exposed via API:
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   HTTP Handler  │────▶│   Audit         │────▶│   audit_events  │
+│   Middleware    │     │   Service       │     │   Table         │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                                                        │
+                                                        ▼
+                                               ┌─────────────────┐
+                                               │   Audit Log     │
+                                               │   API & UI      │
+                                               └─────────────────┘
+```
+
+### 5.2 Audit Event Schema
+
+```json
+{
+  "id": "evt_abc123",
+  "timestamp": "2025-01-30T14:32:15Z",
+  "organization_id": "org_12345",
+  "actor": {
+    "id": "usr_67890",
+    "type": "user",
+    "email": "admin@company.com",
+    "ip_address": "10.20.30.40"
+  },
+  "action": "pool.create",
+  "resource": {
+    "type": "pool",
+    "id": "pool_abc123",
+    "name": "production-vpc"
+  },
+  "changes": {
+    "before": null,
+    "after": {
+      "name": "production-vpc",
+      "cidr": "10.0.0.0/16"
+    }
+  },
+  "metadata": {
+    "source": "web_ui",
+    "request_id": "req_xyz789"
+  }
+}
+```
+
+### 5.3 Tracked Actions
+
+| Category | Actions |
+|----------|---------|
+| **Pools** | create, update, delete, import, allocate |
+| **Accounts** | create, update, delete, sync |
+| **Users** | create, update, delete, invite, deactivate |
+| **Roles** | create, update, delete, assign, revoke |
+| **Authentication** | login, logout, token_create, token_revoke |
+| **Discovery** | sync_start, sync_complete, sync_failed |
+| **Planning** | plan_create, plan_apply, plan_export |
+| **System** | drift_detected, conflict_resolved |
+
+### 5.4 Retention & Export
+
+| Feature | Configuration |
+|---------|---------------|
+| Default retention | 90 days |
+| Configurable per org | Yes (OrganizationSettings.AuditRetentionDays) |
+| Export formats | CSV, JSON, PDF |
+| Real-time export | Syslog, Webhook, S3/GCS |
+
+### 5.5 In-App Audit Log Viewer
+
+The web UI provides a comprehensive audit log viewer with:
+
+- **Timeline view** with color-coded actions
+- **Filtering** by action, resource type, actor, date range
+- **Search** across event data
+- **Detail view** with before/after diff visualization
+- **Export** to CSV, JSON, or PDF
+- **Statistics** dashboard with trends
+
+See mockup: `cloudpam-audit-log.html`
+
+## 6. Configuration
+
+### 6.1 Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLOUDPAM_LOG_LEVEL` | info | Log level (debug, info, warn, error) |
+| `CLOUDPAM_LOG_FORMAT` | json | Log format (json, text) |
+| `CLOUDPAM_LOG_SAMPLING_RATE` | 1.0 | Sampling rate for debug/info logs |
+| `CLOUDPAM_METRICS_ENABLED` | true | Enable Prometheus metrics |
+| `CLOUDPAM_METRICS_PORT` | 8889 | Metrics endpoint port |
+| `CLOUDPAM_TRACING_ENABLED` | true | Enable distributed tracing |
+| `CLOUDPAM_TRACING_ENDPOINT` | localhost:14250 | Jaeger collector endpoint |
+| `CLOUDPAM_TRACING_SAMPLE_RATE` | 0.01 | Trace sampling rate |
+
+### 6.2 Vector Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `SPLUNK_HEC_URL` | Splunk HEC endpoint |
+| `SPLUNK_HEC_TOKEN` | Splunk HEC authentication token |
+| `AWS_REGION` | AWS region for CloudWatch |
+| `GCP_PROJECT_ID` | GCP project for Cloud Logging |
+| `SYSLOG_ADDRESS` | Syslog server address |
+
+## 7. Deployment
+
+### 7.1 Local Development
+
+```bash
+# Start observability stack
+docker-compose -f deploy/docker-compose.observability.yml up -d
+
+# Access dashboards
+# Grafana: http://localhost:3000 (admin/admin)
+# Prometheus: http://localhost:9090
+# Jaeger: http://localhost:16686
+```
+
+### 7.2 Kubernetes
+
+```bash
+# Deploy observability stack
+kubectl apply -f deploy/k8s/observability-stack.yaml
+
+# Deploy Vector DaemonSet
+kubectl apply -f deploy/k8s/vector-daemonset.yaml
+
+# Deploy CloudPAM with sidecar
+kubectl apply -f deploy/k8s/cloudpam-deployment.yaml
+```
+
+### 7.3 Cloud-Specific
+
+| Platform | Logging | Metrics | Tracing |
+|----------|---------|---------|---------|
+| **GCP** | Cloud Logging (auto) | Cloud Monitoring | Cloud Trace |
+| **AWS** | CloudWatch Logs | CloudWatch Metrics | X-Ray |
+| **Azure** | Azure Monitor | Azure Monitor | App Insights |
+
+## 8. Grafana Dashboards
+
+Pre-built dashboards available in `deploy/grafana/dashboards/`:
+
+| Dashboard | Panels |
+|-----------|--------|
+| **CloudPAM Overview** | Request rate, error rate, latency p50/p95/p99 |
+| **Pool Management** | Pool utilization, allocation rate, conflicts |
+| **Discovery** | Sync frequency, success rate, discovered resources |
+| **Authentication** | Login attempts, active sessions, token usage |
+| **Database** | Query latency, connection pool, slow queries |
+
+## 9. Alerting Rules
+
+Example Prometheus alerting rules:
+
+```yaml
+groups:
+  - name: cloudpam
+    rules:
+      - alert: HighErrorRate
+        expr: rate(http_requests_total{status=~"5.."}[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: High error rate detected
+
+      - alert: PoolNearCapacity
+        expr: cloudpam_pool_utilization_percent > 90
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Pool {{ $labels.pool_id }} is above 90% utilization
+
+      - alert: DiscoverySyncFailed
+        expr: increase(cloudpam_discovery_sync_errors_total[1h]) > 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Discovery sync failing repeatedly
+```
+
+## 10. Related Documentation
+
+- [Go Interfaces](internal/observability/interfaces.go) - Logger, Metrics, Tracer interfaces
+- [OpenAPI Spec](openapi-observability.yaml) - Audit log API endpoints
+- [Vector Config](deploy/vector/vector.toml) - Log shipping configuration
+- [K8s Manifests](deploy/k8s/) - Kubernetes deployment files
+- [Audit Log UI](cloudpam-audit-log.html) - In-app audit viewer mockup

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -1,0 +1,739 @@
+# CloudPAM Codebase Review - Comprehensive Analysis
+
+**Review Date:** 2025-10-14
+**Reviewer:** Claude Code (golang-pro agent)
+**Current Version:** Based on commit 102fbf3
+
+## Executive Summary
+
+CloudPAM is a well-architected IPAM system with clean separation of concerns, solid Go idioms, and zero race conditions. Currently at **60% production readiness** with **52.5% test coverage**.
+
+### Strengths
+- Clean architecture (domain/storage/HTTP layers)
+- Innovative build-tag pattern for dual storage backends
+- Good error handling and RESTful API design
+- Zero race conditions detected
+- Comprehensive test coverage for core functionality
+- SQL injection protection (all queries parameterized)
+
+### Critical Gaps
+- Missing observability (structured logging, metrics)
+- No rate limiting or graceful shutdown
+- Resource leak in SQLite store (no Close() method)
+- Missing Kubernetes health endpoints
+- Test coverage below 80% target (currently 52.5%)
+
+---
+
+## Critical Issues (P0/P1)
+
+### P0-1: Resource Leak in SQLite Store
+
+**File:** `internal/storage/sqlite/sqlite.go`
+
+**Issue:** The `Store` struct holds an open `*sql.DB` connection but doesn't implement `Close()` method. This creates resource leaks, especially problematic for:
+- Long-running servers
+- Testing (multiple test runs accumulate connections)
+- Connection pool exhaustion
+
+**Current Code:**
+```go
+type Store struct {
+    db *sql.DB
+}
+// No Close() method defined
+```
+
+**Impact:** High - Connection pool exhaustion in production
+
+**Solution:**
+1. Add `Close() error` to `Store` interface in `internal/storage/store.go`
+2. Implement `Close()` in `internal/storage/sqlite/sqlite.go`
+3. Add no-op `Close()` to `MemoryStore` in `internal/storage/store.go`
+4. Call `defer store.Close()` in `cmd/cloudpam/main.go`
+
+**Estimate:** 30 minutes
+
+---
+
+### P0-2: Missing Graceful Shutdown
+
+**File:** `cmd/cloudpam/main.go:48-55`
+
+**Issue:** Server shutdown logic is unreachable after `ListenAndServe()` blocks. No signal handling for SIGINT/SIGTERM means:
+- In-flight requests interrupted during deployments
+- Database connections not properly closed
+- Kubernetes assumes immediate termination
+
+**Current Code:**
+```go
+if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+    log.Fatalf("server error: %v", err)
+}
+// This code is never reached ↓
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+_ = server.Shutdown(ctx)
+```
+
+**Impact:** Critical - Zero-downtime deployments impossible
+
+**Solution:**
+1. Setup signal handling for SIGINT and SIGTERM
+2. Run server in goroutine
+3. Implement 15-second graceful shutdown timeout
+4. Close database connections on shutdown
+5. Add shutdown logging
+
+**Estimate:** 1 hour
+
+---
+
+### P1-1: Missing Input Validation
+
+**File:** `internal/http/server.go`
+
+**Issues:**
+
+1. **CIDR Validation Incomplete** (Line 829-837):
+   - Validates format but doesn't check for reserved ranges (0.0.0.0/8, 127.0.0.0/8, 240.0.0.0/4)
+   - No broadcast address checks
+   - No maximum prefix length constraints
+
+2. **Account Key Not Validated** (Line 544-549):
+   - No format validation (should match pattern like "aws:123456789012")
+   - No length constraints
+   - No character whitelist
+
+3. **Name Field Length Not Constrained**:
+   - Pool names and account names have no max length
+   - Could lead to storage/display issues
+
+**Impact:** Medium - Could allow invalid data
+
+**Solution:**
+Create `internal/validation` package with:
+- `ValidateCIDR()` - check reserved ranges, format, constraints
+- `ValidateAccountKey()` - format, length, character validation
+- `ValidateName()` - length constraints, non-empty check
+
+**Estimate:** 3 hours
+
+---
+
+### P1-2: Missing Structured Logging
+
+**Files:** All `*.go` files
+
+**Issue:** Using stdlib `log` package with unstructured output:
+```go
+log.Printf("cloudpam listening on %s", addr)
+log.Printf("pools:create ok id=%d name=%q cidr=%q ...", ...)
+```
+
+**Problems:**
+- No log levels (debug, info, warn, error)
+- No structured fields for parsing/filtering
+- No request correlation IDs
+- Hard to query in production log aggregators
+
+**Impact:** High - Poor production debuggability
+
+**Solution:**
+Migrate to `log/slog` (Go 1.21+):
+1. Create logger in `main.go` with JSON handler
+2. Replace all `log.Printf` calls with `slog.Info/Error/Warn/Debug`
+3. Add request ID middleware
+4. Configure log level via `LOG_LEVEL` env var
+
+**Estimate:** 2 hours
+
+---
+
+### P1-3: Missing Rate Limiting
+
+**File:** No implementation exists
+
+**Issue:** API is vulnerable to:
+- Abuse/DoS attacks
+- Resource exhaustion
+- Uncontrolled client behavior
+
+**Impact:** Critical - Production security risk
+
+**Solution:**
+1. Create `internal/http/middleware.go`
+2. Implement token-bucket rate limiter using `golang.org/x/time/rate`
+3. Default: 100 requests/minute per IP address
+4. Configurable via env vars: `RATE_LIMIT_RPS` and `RATE_LIMIT_BURST`
+5. Return 429 Too Many Requests with retry-after
+
+**Estimate:** 4 hours
+
+---
+
+### P1-4: Missing Health/Readiness Endpoints
+
+**File:** `internal/http/server.go:479-481`
+
+**Issue:** Only `/healthz` exists with static response. No `/readyz` for Kubernetes readiness probes.
+
+**Current Code:**
+```go
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+    writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+```
+
+**Impact:** High - Cannot deploy to Kubernetes properly
+
+**Solution:**
+1. Add `handleReadyz()` with database health check
+2. Check database connectivity with 2-second timeout
+3. Return 503 if database unavailable
+4. Register `/readyz` route
+5. Update OpenAPI spec
+
+**Estimate:** 2 hours
+
+---
+
+### P1-5: No Metrics/Observability
+
+**Status:** Missing entirely
+
+**Issue:** No visibility into:
+- Request rates and latency
+- Error rates
+- Resource utilization
+- Pool/account counts
+
+**Impact:** High - Cannot monitor production health
+
+**Solution:**
+1. Add `github.com/prometheus/client_golang` dependency
+2. Create `internal/http/metrics.go`
+3. Instrument key metrics:
+   - `cloudpam_http_requests_total` (counter with method, path, status)
+   - `cloudpam_http_duration_seconds` (histogram)
+   - `cloudpam_pools_total` (gauge)
+   - `cloudpam_accounts_total` (gauge)
+4. Add `/metrics` endpoint
+
+**Estimate:** 3 hours
+
+---
+
+### P1-6: Test Coverage Below Target
+
+**Current:** 52.5% overall (internal/http: 51.6%, internal/storage: 72.2%)
+**Target:** 80%
+
+**Missing Coverage Areas:**
+1. Error paths in HTTP handlers - Many error branches untested
+2. Pagination edge cases - Offset/limit boundary conditions
+3. CIDR computation edge cases - /31, /32 prefixes
+4. Export functionality - CSV generation, field filtering
+5. Migration rollback scenarios
+6. Concurrent access patterns
+
+**Impact:** Medium - Risk of undetected bugs
+
+**Solution:**
+Add test files for:
+- Error scenarios in handlers (`handlers_error_test.go`)
+- Pagination edge cases
+- CIDR /31 and /32 handling
+- CSV export with various field combinations
+- Concurrent pool operations
+
+**Estimate:** 6 hours
+
+---
+
+## Medium Priority (P2/P3)
+
+### P2-1: Large Handler File Needs Refactoring
+
+**File:** `internal/http/server.go` (1171 lines)
+
+**Issue:** Monolithic file with mixed concerns:
+- Route registration
+- Request handling
+- Business logic (CIDR computation)
+- CSV export
+- Error handling
+
+**Impact:** Low - Maintenance difficulty
+
+**Solution:** Split into logical files:
+```
+internal/http/
+├── server.go          (100 lines) - Server struct, RegisterRoutes
+├── middleware.go      (50 lines)  - Middleware functions
+├── handlers_pools.go  (300 lines) - Pool CRUD handlers
+├── handlers_accounts.go (200 lines) - Account CRUD handlers
+├── handlers_blocks.go (300 lines) - Block enumeration
+├── handlers_export.go (200 lines) - Export functionality
+├── handlers_health.go (50 lines)  - Health/ready endpoints
+├── cidr.go           (150 lines) - CIDR validation/computation
+├── helpers.go        (50 lines)  - writeJSON, writeErr
+└── types.go          (50 lines)  - apiError, blockInfo, etc.
+```
+
+**Estimate:** 4 hours
+
+---
+
+### P2-2: Inconsistent Error Handling Pattern
+
+**Files:** Multiple
+
+**Issue:** Some methods in `store.go` return `(T, bool, error)` while others return `(bool, error)` or just `error`:
+
+```go
+// Three different patterns:
+GetPool(ctx, id) (Pool, bool, error)      // found flag + error
+DeletePool(ctx, id) (bool, error)         // success flag + error
+CreatePool(ctx, in) (Pool, error)         // just result + error
+```
+
+**Impact:** Low - Code consistency
+
+**Solution:** Standardize to idiomatic Go:
+- For Get operations: use `(T, error)` with `ErrNotFound` sentinel error
+- For Delete: use `error` only (return `ErrNotFound` if applicable)
+- Define errors in domain package: `ErrNotFound`, `ErrHasChildren`, `ErrInUse`
+
+**Estimate:** 2 hours
+
+---
+
+### P2-3: UpdatePoolMeta Has Confusing Code
+
+**File:** `internal/storage/store.go:104-106`
+
+**Issue:** Suspicious pattern:
+```go
+if accountID != nil || true {  // This condition is always true!
+    p.AccountID = accountID
+}
+```
+
+The `|| true` makes the condition meaningless. This appears to be a workaround for setting `accountID` to `nil`.
+
+**Impact:** Low - Code smell
+
+**Solution:**
+```go
+// Always apply accountID update (including clearing to nil)
+p.AccountID = accountID
+```
+
+Same fix needed in SQLite implementation (line 144).
+
+**Estimate:** 15 minutes
+
+---
+
+### P2-4: Missing Connection Pool Configuration
+
+**File:** `internal/storage/sqlite/sqlite.go`
+
+**Issue:** SQLite uses default connection pool settings. Should expose tunables for production.
+
+**Impact:** Low - Performance tuning
+
+**Solution:**
+```go
+db.SetMaxOpenConns(25)
+db.SetMaxIdleConns(5)
+db.SetConnMaxLifetime(5 * time.Minute)
+```
+
+Make configurable via environment variables:
+- `DB_MAX_OPEN_CONNS`
+- `DB_MAX_IDLE_CONNS`
+- `DB_CONN_MAX_LIFETIME`
+
+**Estimate:** 30 minutes
+
+---
+
+### P2-5: Missing Benchmark Tests
+
+**Status:** No benchmark files found
+
+**Issue:** No performance baselines for:
+- CIDR subnet computation
+- Pool listing with large datasets
+- Concurrent access patterns
+
+**Impact:** Low - Unknown performance characteristics
+
+**Solution:** Add `*_bench_test.go` files with benchmarks for:
+- `BenchmarkComputeSubnets`
+- `BenchmarkListPools` (with 1000+ pools)
+- `BenchmarkConcurrentPoolAccess`
+
+**Estimate:** 2 hours
+
+---
+
+### P2-6: Missing Request ID Middleware
+
+**Status:** No implementation
+
+**Issue:** Cannot correlate logs across distributed systems or trace request flow.
+
+**Impact:** Medium - Debugging difficulty in production
+
+**Solution:**
+1. Add `RequestIDMiddleware` to generate unique IDs (16 hex chars using crypto/rand)
+2. Store request ID in context
+3. Add `X-Request-ID` to response headers
+4. Include request ID in all log entries
+5. Include request ID in error responses
+
+**Estimate:** 1 hour
+
+---
+
+## Low Priority (P3)
+
+### P3-1: API Versioning Strategy Not Documented
+
+**Issue:** Currently using `/api/v1/` but no documentation on versioning approach for breaking changes.
+
+**Solution:** Document in CLAUDE.md:
+- When to bump version
+- Deprecation policy
+- Support timeline for old versions
+
+**Estimate:** 30 minutes
+
+---
+
+### P3-2: OpenAPI Spec Lacks Example Requests
+
+**File:** `docs/openapi.yaml`
+
+**Issue:** The spec exists but lacks example payloads for complex operations like block enumeration.
+
+**Solution:** Add `examples` to OpenAPI spec for:
+- Pool creation with parent
+- Block enumeration with pagination
+- Account creation
+- Export with field filtering
+
+**Estimate:** 1 hour
+
+---
+
+### P3-3: Error Messages Could Be More Descriptive
+
+**Issue:** Some errors are terse:
+```go
+return fmt.Errorf("invalid cidr")
+```
+
+**Solution:** Add more context:
+```go
+return fmt.Errorf("invalid CIDR %q: must be IPv4 in x.x.x.x/y format", in.CIDR)
+```
+
+**Estimate:** 1 hour (audit and improve all error messages)
+
+---
+
+## Quick Wins - High Impact, Low Effort
+
+These can be completed in ~10 hours total:
+
+| Priority | Task | Effort | Impact | Files |
+|----------|------|--------|--------|-------|
+| 1 | Add Store.Close() | 30 min | High | `internal/storage/*.go` |
+| 2 | Graceful shutdown | 1 hour | Critical | `cmd/cloudpam/main.go` |
+| 3 | /healthz + /readyz | 2 hours | High | `internal/http/server.go` |
+| 4 | Fix `\|\| true` bug | 15 min | Low | `internal/storage/store.go:104` |
+| 5 | Connection pool config | 30 min | Medium | `internal/storage/sqlite/sqlite.go` |
+| 6 | Structured logging | 2 hours | High | All `*.go` files |
+| 7 | Bump coverage to 60% | 3 hours | Medium | `*_test.go` files |
+
+---
+
+## Architecture Recommendations
+
+### AR-1: Consider Service Layer (Future)
+
+**Current:** Handlers directly call storage methods.
+
+**Proposal:** Add service layer for business logic:
+```
+internal/
+├── domain/      (types)
+├── storage/     (data access)
+├── service/     (business logic) ← NEW
+└── http/        (handlers)
+```
+
+**Benefits:**
+- Handlers become thin routing layer
+- Business logic testable independently
+- Easier to add caching, validation, authorization
+
+**When:** After P0/P1 issues resolved, if codebase grows beyond 5K LOC.
+
+---
+
+### AR-2: Provider Abstraction (Per PROJECT_PLAN.md)
+
+CloudPAM roadmap mentions AWS/GCP discovery. Design provider interface now:
+
+```go
+package provider
+
+type Provider interface {
+    // Discover finds all VPCs/VNets in the cloud account
+    Discover(ctx context.Context) ([]DiscoveredResource, error)
+
+    // Validate checks if CIDR can be used in this provider
+    Validate(ctx context.Context, cidr string) error
+
+    // Allocate reserves CIDR in the cloud provider
+    Allocate(ctx context.Context, req AllocateRequest) error
+}
+
+type DiscoveredResource struct {
+    ID       string
+    Name     string
+    CIDR     string
+    Region   string
+    Tags     map[string]string
+}
+```
+
+**When:** Phase 2 of roadmap (after core IPAM features stable)
+
+---
+
+### AR-3: Event Sourcing for Audit Log (Future)
+
+**Future Feature:** Track all pool/account mutations for compliance.
+
+**Approach:**
+1. Add `events` table in migrations
+2. Emit event on every Create/Update/Delete
+3. Build audit log view from events
+4. Support event replay for debugging
+
+**Benefits:**
+- Full audit trail
+- Time-travel debugging
+- Compliance reporting
+
+**When:** If compliance/audit requirements emerge
+
+---
+
+## Code Quality Observations
+
+### What's Working Well ✅
+
+1. **Build Tag Pattern** - The `//go:build` approach for storage backends is elegant and well-documented
+2. **Interface Design** - Clean separation between storage implementations
+3. **CIDR Logic** - IPv4 subnet computation is solid and well-tested
+4. **Zero Race Conditions** - Mutex usage in MemoryStore is correct
+5. **SQL Injection Protection** - All queries use parameterized statements
+6. **Context Usage** - Proper context.Context in all storage methods
+7. **Error Wrapping** - Good use of `fmt.Errorf("%w", err)`
+8. **Table-Driven Tests** - Comprehensive test structure
+
+### Areas for Improvement 🟡
+
+1. **Error Handling Consistency** - Mix of `(T, bool, error)` and `(T, error)` patterns
+2. **Large Files** - `server.go` at 1171 lines needs splitting
+3. **Missing Observability** - No metrics, structured logging, or tracing
+4. **Test Coverage** - Below 80% target (currently 52.5%)
+5. **Input Validation** - Some edge cases not validated
+6. **Resource Management** - Missing Close() methods
+
+---
+
+## Security Assessment
+
+### Strengths ✅
+- SQL injection protection (parameterized queries)
+- No hardcoded credentials
+- Context propagation for timeouts
+- Proper mutex usage (no race conditions)
+
+### Concerns ⚠️
+- No authentication/authorization
+- No rate limiting (DoS vulnerability)
+- No input sanitization for reserved CIDR ranges
+- No audit logging
+- No TLS configuration guidance
+
+### Recommendations
+1. Add rate limiting (P1-3)
+2. Document auth integration points
+3. Add audit logging for all mutations
+4. Create security.md with deployment best practices
+
+---
+
+## Performance Considerations
+
+### Current State
+- No identified bottlenecks
+- In-memory store: O(1) for get, O(n) for list
+- SQLite store: Indexed on primary keys
+- CIDR computation: Efficient uint32 arithmetic
+
+### Potential Issues
+- Large pool counts (>10,000) may slow list operations
+- Block enumeration can generate huge result sets
+- Export function loads all data into memory
+
+### Recommendations
+1. Add pagination to all list endpoints (partially done)
+2. Add database indexes on commonly filtered fields (account_id, parent_id)
+3. Stream CSV export for large datasets
+4. Add benchmark tests to track performance
+5. Consider connection pooling configuration
+
+---
+
+## Testing Strategy
+
+### Current Coverage
+- Overall: 52.5%
+- internal/http: 51.6%
+- internal/storage: 72.2%
+
+### Missing Test Scenarios
+- [ ] Error paths in all handlers
+- [ ] Pagination with edge cases (negative offset, huge limit)
+- [ ] CIDR computation for /31 and /32
+- [ ] CSV export with all field combinations
+- [ ] Concurrent pool mutations
+- [ ] Migration rollback safety
+- [ ] Database connection failures
+- [ ] Context cancellation handling
+
+### Recommendations
+1. Target 80% coverage before production
+2. Add integration tests with real SQLite database
+3. Add property-based tests for CIDR logic (fuzzing)
+4. Test with production-like data volumes (10K+ pools)
+
+---
+
+## Deployment Readiness
+
+### Production Checklist
+
+#### ✅ Ready
+- [x] Linter passing (golangci-lint)
+- [x] Tests passing with -race flag
+- [x] No known race conditions
+- [x] SQL injection protected
+- [x] Build process documented
+- [x] Migration system in place
+
+#### ⚠️ Needs Work
+- [ ] Graceful shutdown (P0-2)
+- [ ] Resource leak fixed (P0-1)
+- [ ] Health/readiness endpoints (P1-4)
+- [ ] Structured logging (P1-2)
+- [ ] Rate limiting (P1-3)
+- [ ] Metrics/monitoring (P1-5)
+- [ ] Test coverage >80% (P1-6)
+
+#### 🔮 Future
+- [ ] Authentication/authorization
+- [ ] Audit logging
+- [ ] TLS configuration
+- [ ] Multi-region support
+- [ ] Backup/restore tooling
+
+---
+
+## Metrics Dashboard
+
+| Metric | Current | Target | Status |
+|--------|---------|--------|--------|
+| Test Coverage | 52.5% | 80% | 🟡 |
+| Race Conditions | 0 | 0 | ✅ |
+| Linter Issues | 0 | 0 | ✅ |
+| Critical Bugs | 2 | 0 | 🔴 |
+| High Priority Issues | 6 | 0 | 🟡 |
+| Medium Priority Issues | 6 | <5 | 🟡 |
+| Production Readiness | 60% | 90% | 🟡 |
+| Lines of Code | ~3,500 | - | ✅ |
+| API Endpoints | 13 | - | ✅ |
+
+---
+
+## Implementation Roadmap
+
+### Sprint 1: Critical Fixes (Week 1)
+1. Fix resource leak - Add Close() method
+2. Implement graceful shutdown
+3. Add /healthz and /readyz endpoints
+4. Fix `|| true` bug in UpdatePoolMeta
+
+**Goal:** 70% production ready
+
+### Sprint 2: Observability (Week 2)
+5. Add structured logging with slog
+6. Implement rate limiting
+7. Add Prometheus metrics
+8. Add request ID middleware
+
+**Goal:** 80% production ready
+
+### Sprint 3: Quality & Testing (Week 3)
+9. Increase test coverage to 65%+
+10. Add input validation package
+11. Add benchmark tests
+12. Fix error handling consistency
+
+**Goal:** 85% production ready
+
+### Sprint 4: Refactoring (Week 4)
+13. Split large handler file
+14. Add connection pool configuration
+15. Improve error messages
+16. Update documentation
+
+**Goal:** 90% production ready
+
+---
+
+## Conclusion
+
+CloudPAM is a **solid, well-architected project** with clean code and good engineering practices. The codebase is production-ready for internal use, but needs the following before external deployment:
+
+**Must Fix (Next 2 weeks):**
+1. Resource leak (Close method)
+2. Graceful shutdown
+3. Health/readiness endpoints
+4. Structured logging
+5. Rate limiting
+
+**Should Fix (Next month):**
+6. Test coverage to 65%+
+7. Input validation hardening
+8. Metrics/observability
+9. Code refactoring
+
+**Nice to Have (Next quarter):**
+10. Enhanced error messages
+11. OpenAPI examples
+12. Benchmark tests
+
+The architecture using build tags for storage backends is innovative and shows thoughtful design. The dual-backend testing strategy ensures portability. With the critical issues addressed, this will be a production-grade IPAM system.
+
+**Recommended Next Step:** Start with Quick Wins (QW-1 through QW-7) which can be completed in ~10 hours total and provide immediate production readiness improvements.

--- a/docs/SMART_PLANNING.md
+++ b/docs/SMART_PLANNING.md
@@ -1,0 +1,186 @@
+# CloudPAM Smart Planning Architecture
+
+## Overview
+
+Smart Planning is CloudPAM's intelligent network planning system that analyzes existing infrastructure, understands user intent, and generates optimized IP address allocation recommendations. It combines rule-based analysis with optional AI/LLM integration for natural language planning.
+
+## Core Components
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           Smart Planning Engine                              │
+│  ┌─────────────────┐  ┌──────────────────┐  ┌─────────────────────────────┐│
+│  │   Discovery     │  │    Analysis      │  │    Recommendation           ││
+│  │   Aggregator    │──│    Engine        │──│    Generator                ││
+│  └─────────────────┘  └──────────────────┘  └─────────────────────────────┘│
+│          │                    │                         │                   │
+│          ▼                    ▼                         ▼                   │
+│  ┌─────────────────┐  ┌──────────────────┐  ┌─────────────────────────────┐│
+│  │ • Cloud APIs    │  │ • Gap Analysis   │  │ • Schema Templates          ││
+│  │ • CSV Import    │  │ • Fragmentation  │  │ • Allocation Plans          ││
+│  │ • Manual Entry  │  │ • Utilization    │  │ • Growth Projections        ││
+│  │ • Network Scan  │  │ • Compliance     │  │ • Migration Paths           ││
+│  └─────────────────┘  └──────────────────┘  └─────────────────────────────┘│
+│                                                                             │
+│  ┌─────────────────────────────────────────────────────────────────────────┐│
+│  │                        AI Planning Assistant (Optional)                  ││
+│  │   • Natural Language Intent → Structured Requirements                    ││
+│  │   • Pattern Recognition → Best Practice Recommendations                  ││
+│  │   • What-If Analysis → Risk Assessment                                   ││
+│  └─────────────────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## 1. Discovery Aggregator
+
+### 1.1 Data Sources
+
+| Source | Method | Data Captured |
+|--------|--------|---------------|
+| **AWS** | EC2/VPC API via Collector | VPCs, Subnets, ENIs, EIPs, CIDR blocks |
+| **GCP** | Compute API via Collector | Networks, Subnetworks, IP addresses |
+| **Azure** | ARM API via Collector | VNets, Subnets, NICs, Public IPs |
+| **On-Prem** | SNMP/SSH Scanner | Switch VLANs, Router interfaces, DHCP scopes |
+| **DNS** | Zone Transfer/API | Forward/reverse zones, A/AAAA records |
+| **CSV/Excel** | File Import | Legacy IPAM data, spreadsheet inventories |
+| **CMDB** | API Integration | ServiceNow, Device42, etc. |
+
+### 1.2 Import Formats
+
+**CSV Import Schema:**
+```csv
+cidr,name,environment,region,type,notes
+10.0.0.0/16,Production VPC,production,us-east-1,vpc,Main production network
+10.0.1.0/24,Web Tier,production,us-east-1,subnet,Public-facing web servers
+```
+
+**Excel Import:** Multi-sheet support with header mapping wizard and data validation preview.
+
+## 2. Analysis Engine
+
+### 2.1 Gap Analysis
+
+Identifies unused address space within allocated ranges:
+
+```
+Parent: 10.0.0.0/16 (65,536 addresses)
+├── Allocated: 10.0.0.0/24 (256) - Web Tier
+├── Allocated: 10.0.1.0/24 (256) - App Tier
+├── [AVAILABLE] 10.0.3.0/24 (256 addresses)
+├── [AVAILABLE] 10.0.4.0/22 (1,024 addresses)
+└── [AVAILABLE] 10.0.8.0/21 (2,048 addresses)
+
+Utilization: 1.2% (768 / 65,536)
+```
+
+### 2.2 Fragmentation Analysis
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Scattered** | Small allocations spread across large space | /28s scattered in a /16 |
+| **Oversized** | Allocation much larger than actual usage | /22 with 10 hosts |
+| **Undersized** | Allocation approaching capacity | /24 at 90% utilization |
+| **Misaligned** | CIDR boundaries don't follow best practices | 10.0.3.0/23 instead of 10.0.2.0/23 |
+
+### 2.3 Compliance Analysis
+
+Configurable rules including: minimum/maximum subnet sizes, reserved IP range protection, RFC1918 enforcement, environment isolation, and naming conventions.
+
+### 2.4 Growth Projection
+
+Predicts future address needs using linear regression, seasonal adjustment, and event-based factors.
+
+## 3. Recommendation Generator
+
+### 3.1 Recommendation Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `allocation` | Recommends specific CIDR | "Allocate 10.0.4.0/22 for new workload" |
+| `consolidation` | Suggests merging ranges | "Merge fragmented /25s into /24" |
+| `resize` | Recommends resizing | "Expand staging /24 to /23" |
+| `reclaim` | Identifies reclaimable space | "10.0.5.0/24 has no active hosts" |
+| `compliance` | Fixes compliance issues | "Rename pool to follow convention" |
+
+### 3.2 Intelligent Allocation Algorithm
+
+1. **Find candidate blocks** matching size requirements
+2. **Score each candidate** based on contiguity, alignment, and growth runway
+3. **Apply constraints** (region, environment isolation, etc.)
+4. **Rank and return** top suggestions with rationale
+
+## 4. AI Planning Assistant
+
+### 4.1 LLM Integration Options
+
+| Provider | Configuration | Use Case |
+|----------|--------------|----------|
+| **OpenAI** | API key + model selection | Cloud-hosted, GPT-4 quality |
+| **Anthropic** | API key + model selection | Cloud-hosted, Claude quality |
+| **Azure OpenAI** | Endpoint + deployment | Enterprise compliance |
+| **Ollama** | Local endpoint | Air-gapped, self-hosted |
+| **vLLM** | OpenAI-compatible endpoint | Self-hosted, GPU acceleration |
+
+### 4.2 Context Injection
+
+The AI assistant receives structured context about your infrastructure including pools, available space, compliance rules, recent allocations, and organization preferences.
+
+### 4.3 Example Conversation
+
+**Kubernetes Cluster Planning**
+
+```
+User: "I need to plan networking for a new Kubernetes cluster in production.
+       We'll have about 100 nodes and use Calico for pod networking."
+Assistant: "Based on your current production infrastructure (10.1.0.0/16),
+           I recommend:
+
+           **Node Network**: 10.1.8.0/22 (1,024 addresses)
+           **Pod CIDR**: 10.1.64.0/18 (16,384 addresses)
+           **Service CIDR**: 10.1.128.0/20 (4,096 addresses)
+
+           Shall I create a schema plan with these allocations?"
+
+User: "Yes, and also reserve space for a DR cluster in us-west-2"
+
+Assistant: "I will extend the plan to include DR in us-west-2:
+
+           prod-us-east-1 (10.1.0.0/16)
+           +-- k8s-cluster-01 [NEW]
+               +-- nodes     10.1.8.0/22
+               +-- pods      10.1.64.0/18
+               +-- services  10.1.128.0/20
+
+           prod-us-west-2 (10.2.0.0/16) [NEW REGION]
+           +-- k8s-cluster-dr [NEW]
+               +-- nodes     10.2.8.0/22
+               +-- pods      10.2.64.0/18
+               +-- services  10.2.128.0/20
+
+           Ready to apply?"
+```
+
+## 5. API Reference
+
+Smart Planning endpoints are documented in `openapi-smart-planning.yaml`:
+
+| Category | Endpoints |
+|----------|----------|
+| **Discovery** | POST /planning/import, GET /planning/discovered, POST /planning/sync |
+| **Analysis** | POST /planning/analyze, POST /planning/analyze/gaps, /fragmentation, /compliance, /growth |
+| **Recommendations** | GET /planning/recommendations, POST .../apply, POST .../dismiss |
+| **AI Planning** | POST /planning/ai/conversations, GET .../messages, POST .../plans/{id}/apply |
+| **Schema Wizard** | GET /planning/schema/templates, POST /planning/schema/generate, /validate, /apply |
+| **LLM Config** | GET/PUT /settings/llm, POST /settings/llm/test, GET/PUT /settings/llm/prompts |
+
+See [openapi-smart-planning.yaml](openapi-smart-planning.yaml) for full specification.
+
+## 6. Go Interfaces
+
+Service interfaces are defined in `internal/planning/interfaces.go`. See that file for:
+- DiscoveryService
+- AnalysisService
+- RecommendationService
+- AIPlanningService
+- SchemaWizardService
+- LLMProvider


### PR DESCRIPTION
## Summary
- Moved 8 documentation files from `.planning/docs/` to `docs/` so all README links resolve to existing files
- Rewrote README.md to accurately reflect current project state: implemented features only, correct Go version (1.24), real API endpoints, actual project structure, sprint progress through 16b
- Updated CLAUDE.md planning docs table to reference new `docs/` paths

## Test plan
- [x] All 12 README documentation links verified as resolving to existing files
- [x] `just test` passes (docs-only change, no code modifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)