### PR TITLE
feat: config section, user dropdown & sidebar restructure (v0.5.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,10 @@ The HTTP server (`internal/http/server.go`) implements IPv4 CIDR logic:
 - Handles migration CLI commands before starting server
 - Implements graceful shutdown with signal handling
 
+## Nix Development Environment
+
+This project has a Nix flake (`flake.nix`). **Always use `nix develop`** to enter the dev shell before running commands (Go, Node, npm, npx, etc.). This ensures the correct toolchain versions are available. For running shell commands, prefix with `nix develop --command` or enter the shell first.
+
 ## Development Guidelines
 
 ### Code Style

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to CloudPAM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - Configuration Section & User Menu
+
+### Changed
+- Sidebar nav restructured into labeled sections: IPAM, Operations, Planning, Configuration
+- Sidebar "Settings" section renamed to "Configuration"; routes updated from `/settings/*` to `/config/*`
+- Theme toggle moved from sidebar footer to header as a Sun/Moon icon button (simple light/dark toggle)
+- User info badge and logout button removed from sidebar footer (now handled by header dropdown)
+
+### Added
+- Header user dropdown menu: shows authenticated user info (username, role badge), with links to Profile, My API Keys, and Log out
+- Profile page (`/profile`): view user info (username, email, role) and change password
+- Log Destinations stub page (`/config/log-destinations`): placeholder for future syslog, webhook, S3, and SIEM integrations
+
 ## [0.4.1] - First-Boot Setup & Auth Bugfixes
 
 ### Added

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,6 +16,8 @@ import ApiKeysPage from './pages/ApiKeysPage'
 import UsersPage from './pages/UsersPage'
 import RecommendationsPage from './pages/RecommendationsPage'
 import AIPlannerPage from './pages/AIPlannerPage'
+import ProfilePage from './pages/ProfilePage'
+import LogDestinationsPage from './pages/LogDestinationsPage'
 
 export default function App() {
   const toastState = useToastState()
@@ -39,8 +41,10 @@ export default function App() {
                 <Route path="schema" element={<SchemaPage />} />
                 <Route path="recommendations" element={<RecommendationsPage />} />
                 <Route path="ai-planner" element={<AIPlannerPage />} />
-                <Route path="settings/api-keys" element={<ApiKeysPage />} />
-                <Route path="settings/users" element={<UsersPage />} />
+                <Route path="profile" element={<ProfilePage />} />
+                <Route path="config/api-keys" element={<ApiKeysPage />} />
+                <Route path="config/users" element={<UsersPage />} />
+                <Route path="config/log-destinations" element={<LogDestinationsPage />} />
               </Route>
             </Route>
           </Routes>

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -1,10 +1,40 @@
-import { Search, Bell, User } from 'lucide-react'
+import { useState, useRef, useEffect } from 'react'
+import { Search, Bell, User, LogOut, Key, UserCircle, Sun, Moon } from 'lucide-react'
+import { useAuth } from '../hooks/useAuth'
+import { useTheme } from '../hooks/useTheme'
+import { useNavigate } from 'react-router-dom'
 
 interface HeaderProps {
   onSearchClick: () => void
 }
 
 export default function Header({ onSearchClick }: HeaderProps) {
+  const { isAuthenticated, currentUser, role, logout } = useAuth()
+  const { resolvedTheme, toggle: toggleTheme } = useTheme()
+  const navigate = useNavigate()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  const displayName = currentUser?.display_name || currentUser?.username || 'User'
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    if (menuOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [menuOpen])
+
+  function handleLogout() {
+    setMenuOpen(false)
+    logout()
+    navigate('/login')
+  }
+
   return (
     <header className="h-16 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between px-6 flex-shrink-0">
       <div className="flex items-center gap-4 flex-1">
@@ -27,11 +57,70 @@ export default function Header({ onSearchClick }: HeaderProps) {
         <button className="relative p-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
           <Bell className="w-5 h-5" />
         </button>
-        <div className="flex items-center gap-2 pl-4 border-l border-gray-200 dark:border-gray-700">
-          <div className="w-8 h-8 bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center">
-            <User className="w-4 h-4" />
-          </div>
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Admin</span>
+        <button
+          onClick={toggleTheme}
+          aria-label={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          className="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+        >
+          {resolvedTheme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+        </button>
+        <div className="relative pl-4 border-l border-gray-200 dark:border-gray-700" ref={menuRef}>
+          <button
+            onClick={() => setMenuOpen((v) => !v)}
+            className="flex items-center gap-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg px-2 py-1 transition-colors"
+          >
+            <div className="w-8 h-8 bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center">
+              <User className="w-4 h-4" />
+            </div>
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              {isAuthenticated ? displayName : 'Guest'}
+            </span>
+          </button>
+
+          {menuOpen && (
+            <div className="absolute right-0 top-full mt-2 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50">
+              {isAuthenticated && currentUser && (
+                <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{displayName}</p>
+                  {role && (
+                    <span className="inline-block mt-1 px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 rounded text-[10px] font-medium uppercase">
+                      {role}
+                    </span>
+                  )}
+                </div>
+              )}
+              <div className="py-1">
+                <button
+                  onClick={() => { setMenuOpen(false); navigate('/profile') }}
+                  className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  <UserCircle className="w-4 h-4" />
+                  Profile
+                </button>
+                <button
+                  onClick={() => { setMenuOpen(false); navigate('/config/api-keys') }}
+                  className="w-full flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  <Key className="w-4 h-4" />
+                  My API Keys
+                </button>
+              </div>
+              {isAuthenticated && (
+                <>
+                  <div className="border-t border-gray-200 dark:border-gray-700" />
+                  <div className="py-1">
+                    <button
+                      onClick={handleLogout}
+                      className="w-full flex items-center gap-3 px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    >
+                      <LogOut className="w-4 h-4" />
+                      Log out
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </header>

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -10,46 +10,27 @@ import {
   Key,
   Map,
   Settings,
-  Sun,
-  Moon,
-  Monitor,
-  LogOut,
-  Shield,
   Users,
-  User,
   Lightbulb,
   Bot,
+  Radio,
 } from 'lucide-react'
-import { useTheme } from '../hooks/useTheme'
 import { useAuth } from '../hooks/useAuth'
 
-const navItems = [
-  { to: '/', icon: LayoutDashboard, label: 'Dashboard', end: true },
-  { to: '/pools', icon: Server, label: 'Address Pools' },
-  { to: '/blocks', icon: LayoutGrid, label: 'Allocated Blocks' },
-  { to: '/accounts', icon: Cloud, label: 'Cloud Accounts' },
-  { to: '/discovery', icon: RefreshCw, label: 'Discovery' },
-  { to: '/audit', icon: Clock, label: 'Audit Log' },
-  { to: '/schema', icon: Map, label: 'Schema Planner' },
-  { to: '/recommendations', icon: Lightbulb, label: 'Recommendations' },
-  { to: '/ai-planner', icon: Bot, label: 'AI Planner' },
-]
+const linkClass = ({ isActive }: { isActive: boolean }) =>
+  `w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
+    isActive ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-gray-800'
+  }`
+
+const sectionHeader = 'px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-gray-500'
 
 interface SidebarProps {
   onImportExport: () => void
 }
 
 export default function Sidebar({ onImportExport }: SidebarProps) {
-  const { mode, cycle } = useTheme()
-  const { isAuthenticated, keyName, role, authType, currentUser, logout } = useAuth()
+  const { isAuthenticated, role } = useAuth()
   const navigate = useNavigate()
-  const ThemeIcon = mode === 'dark' ? Moon : mode === 'light' ? Sun : Monitor
-  const themeLabel = mode === 'system' ? 'System' : mode === 'dark' ? 'Dark' : 'Light'
-
-  function handleLogout() {
-    logout()
-    navigate('/login')
-  }
 
   return (
     <aside className="w-64 bg-gray-900 dark:bg-gray-950 text-white flex flex-col flex-shrink-0">
@@ -65,79 +46,80 @@ export default function Sidebar({ onImportExport }: SidebarProps) {
         </div>
       </div>
 
-      <nav aria-label="Main navigation" className="flex-1 p-4 space-y-1">
-        {navItems.map((item) => (
-          <NavLink
-            key={item.to}
-            to={item.to}
-            end={item.end}
-            className={({ isActive }) =>
-              `w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
-                isActive ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-gray-800'
-              }`
-            }
-          >
-            <item.icon className="w-5 h-5" />
-            <span>{item.label}</span>
-          </NavLink>
-        ))}
+      <nav aria-label="Main navigation" className="flex-1 p-4 space-y-1 overflow-y-auto">
+        <NavLink to="/" end className={linkClass}>
+          <LayoutDashboard className="w-5 h-5" />
+          <span>Dashboard</span>
+        </NavLink>
 
-        {/* Settings section */}
+        {/* IPAM section */}
         <div className="pt-3 mt-3 border-t border-gray-800">
-          <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
-            Settings
-          </p>
-          <NavLink
-            to="/settings/api-keys"
-            className={({ isActive }) =>
-              `w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
-                isActive ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-gray-800'
-              }`
-            }
-          >
+          <p className={sectionHeader}>IPAM</p>
+          <NavLink to="/pools" className={linkClass}>
+            <Server className="w-5 h-5" />
+            <span>Address Pools</span>
+          </NavLink>
+          <NavLink to="/blocks" className={linkClass}>
+            <LayoutGrid className="w-5 h-5" />
+            <span>Allocated Blocks</span>
+          </NavLink>
+          <NavLink to="/accounts" className={linkClass}>
+            <Cloud className="w-5 h-5" />
+            <span>Cloud Accounts</span>
+          </NavLink>
+        </div>
+
+        {/* Operations section */}
+        <div className="pt-3 mt-3 border-t border-gray-800">
+          <p className={sectionHeader}>Operations</p>
+          <NavLink to="/discovery" className={linkClass}>
+            <RefreshCw className="w-5 h-5" />
+            <span>Discovery</span>
+          </NavLink>
+          <NavLink to="/audit" className={linkClass}>
+            <Clock className="w-5 h-5" />
+            <span>Audit Log</span>
+          </NavLink>
+        </div>
+
+        {/* Planning section */}
+        <div className="pt-3 mt-3 border-t border-gray-800">
+          <p className={sectionHeader}>Planning</p>
+          <NavLink to="/schema" className={linkClass}>
+            <Map className="w-5 h-5" />
+            <span>Schema Planner</span>
+          </NavLink>
+          <NavLink to="/recommendations" className={linkClass}>
+            <Lightbulb className="w-5 h-5" />
+            <span>Recommendations</span>
+          </NavLink>
+          <NavLink to="/ai-planner" className={linkClass}>
+            <Bot className="w-5 h-5" />
+            <span>AI Planner</span>
+          </NavLink>
+        </div>
+
+        {/* Configuration section */}
+        <div className="pt-3 mt-3 border-t border-gray-800">
+          <p className={sectionHeader}>Configuration</p>
+          <NavLink to="/config/api-keys" className={linkClass}>
             <Key className="w-5 h-5" />
             <span>API Keys</span>
           </NavLink>
           {role === 'admin' && (
-            <NavLink
-              to="/settings/users"
-              className={({ isActive }) =>
-                `w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
-                  isActive ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-gray-800'
-                }`
-              }
-            >
+            <NavLink to="/config/users" className={linkClass}>
               <Users className="w-5 h-5" />
               <span>Users</span>
             </NavLink>
           )}
+          <NavLink to="/config/log-destinations" className={linkClass}>
+            <Radio className="w-5 h-5" />
+            <span>Log Destinations</span>
+          </NavLink>
         </div>
       </nav>
 
       <div className="p-4 border-t border-gray-800 space-y-1">
-        {/* Auth info — show whenever user is logged in */}
-        {isAuthenticated && (
-          <div className="px-3 py-2 mb-2">
-            <div className="flex items-center gap-2">
-              {authType === 'session' ? (
-                <User className="w-4 h-4 text-gray-400" />
-              ) : (
-                <Shield className="w-4 h-4 text-gray-400" />
-              )}
-              <span className="text-xs text-gray-400 truncate" title={keyName ?? undefined}>
-                {authType === 'session' && currentUser
-                  ? currentUser.display_name || currentUser.username
-                  : keyName ?? 'API Key'}
-              </span>
-              {role && (
-                <span className="ml-auto px-1.5 py-0.5 bg-blue-600/30 text-blue-300 rounded text-[10px] font-medium uppercase">
-                  {role}
-                </span>
-              )}
-            </div>
-          </div>
-        )}
-
         <button
           onClick={onImportExport}
           className="w-full flex items-center gap-3 px-3 py-2 text-gray-300 hover:bg-gray-800 rounded-lg"
@@ -146,27 +128,6 @@ export default function Sidebar({ onImportExport }: SidebarProps) {
           <span>Import/Export</span>
         </button>
 
-        <button
-          onClick={cycle}
-          aria-label={`Theme: ${themeLabel}. Click to cycle.`}
-          className="w-full flex items-center gap-3 px-3 py-2 text-gray-300 hover:bg-gray-800 rounded-lg"
-        >
-          <ThemeIcon className="w-5 h-5" />
-          <span>{themeLabel}</span>
-        </button>
-
-        {/* Logout button — show when user has an active session */}
-        {isAuthenticated && (
-          <button
-            onClick={handleLogout}
-            className="w-full flex items-center gap-3 px-3 py-2 text-gray-300 hover:bg-gray-800 rounded-lg"
-          >
-            <LogOut className="w-5 h-5" />
-            <span>Logout</span>
-          </button>
-        )}
-
-        {/* Login link — show when not authenticated */}
         {!isAuthenticated && (
           <button
             onClick={() => navigate('/login')}

--- a/ui/src/hooks/useTheme.ts
+++ b/ui/src/hooks/useTheme.ts
@@ -4,12 +4,16 @@ export type ThemeMode = 'light' | 'dark' | 'system'
 
 interface ThemeContextValue {
   mode: ThemeMode
+  resolvedTheme: 'light' | 'dark'
   cycle: () => void
+  toggle: () => void
 }
 
 export const ThemeContext = createContext<ThemeContextValue>({
   mode: 'system',
+  resolvedTheme: 'light',
   cycle: () => {},
+  toggle: () => {},
 })
 
 export function useTheme() {
@@ -53,5 +57,22 @@ export function useThemeState(): ThemeContextValue {
     return () => mq.removeEventListener('change', handler)
   }, [mode, apply])
 
-  return { mode, cycle }
+  const resolvedTheme: 'light' | 'dark' =
+    mode === 'system'
+      ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+      : mode
+
+  const toggle = useCallback(() => {
+    setMode((prev) => {
+      const resolved = prev === 'system'
+        ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        : prev
+      const next: ThemeMode = resolved === 'dark' ? 'light' : 'dark'
+      localStorage.setItem('theme', next)
+      apply(next)
+      return next
+    })
+  }, [apply])
+
+  return { mode, resolvedTheme, cycle, toggle }
 }

--- a/ui/src/pages/LogDestinationsPage.tsx
+++ b/ui/src/pages/LogDestinationsPage.tsx
@@ -1,0 +1,23 @@
+import { Radio } from 'lucide-react'
+
+export default function LogDestinationsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Log Destinations</h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
+          Configure where to push audit and system logs
+        </p>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-8 text-center">
+        <Radio className="w-12 h-12 text-gray-400 dark:text-gray-500 mx-auto mb-4" />
+        <h2 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">Coming Soon</h2>
+        <p className="text-gray-500 dark:text-gray-400 max-w-md mx-auto">
+          Log destination configuration will allow you to forward audit events and system logs to
+          external services including syslog, webhooks, S3 buckets, and SIEM integrations.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import { User } from 'lucide-react'
+import { useAuth } from '../hooks/useAuth'
+import { useUsers } from '../hooks/useUsers'
+import { useToast } from '../hooks/useToast'
+
+export default function ProfilePage() {
+  const { currentUser } = useAuth()
+  const { changePassword } = useUsers()
+  const { showToast } = useToast()
+
+  const [currentPw, setCurrentPw] = useState('')
+  const [newPw, setNewPw] = useState('')
+  const [confirmPw, setConfirmPw] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  async function handleChangePassword(e: React.FormEvent) {
+    e.preventDefault()
+    if (newPw !== confirmPw) {
+      showToast('New passwords do not match', 'error')
+      return
+    }
+    if (!currentUser) return
+
+    setSaving(true)
+    try {
+      await changePassword(currentUser.id, {
+        current_password: currentPw,
+        new_password: newPw,
+      })
+      showToast('Password changed successfully', 'success')
+      setCurrentPw('')
+      setNewPw('')
+      setConfirmPw('')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to change password', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Profile</h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
+          Your account information and settings
+        </p>
+      </div>
+
+      {/* User Info */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center gap-4 mb-6">
+          <div className="w-12 h-12 bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center">
+            <User className="w-6 h-6" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              {currentUser?.display_name || currentUser?.username || 'Unknown'}
+            </h2>
+            {currentUser?.role && (
+              <span className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 rounded text-xs font-medium uppercase">
+                {currentUser.role}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">Username</dt>
+            <dd className="mt-1 text-sm text-gray-900 dark:text-white">{currentUser?.username ?? '-'}</dd>
+          </div>
+          <div>
+            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">Email</dt>
+            <dd className="mt-1 text-sm text-gray-900 dark:text-white">{currentUser?.email ?? '-'}</dd>
+          </div>
+          <div>
+            <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">Role</dt>
+            <dd className="mt-1 text-sm text-gray-900 dark:text-white">{currentUser?.role ?? '-'}</dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* Change Password */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Change Password</h3>
+        <form onSubmit={handleChangePassword} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Current Password
+            </label>
+            <input
+              type="password"
+              required
+              value={currentPw}
+              onChange={(e) => setCurrentPw(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              New Password
+            </label>
+            <input
+              type="password"
+              required
+              value={newPw}
+              onChange={(e) => setNewPw(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Confirm New Password
+            </label>
+            <input
+              type="password"
+              required
+              value={confirmPw}
+              onChange={(e) => setConfirmPw(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Saving...' : 'Change Password'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,10 +12,10 @@
         }
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-CmLoUyEl.js"></script>
+    <script type="module" crossorigin src="/assets/index-5YK-1qVF.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-ljeQdaFM.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-Pni0vzxC.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-Bb1n5A2D.css">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-BWmw_XE8.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-BkSdtf5z.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Restructure sidebar navigation into labeled sections: **IPAM**, **Operations**, **Planning**, **Configuration**
- Add header user dropdown menu with user info, Profile link, My API Keys link, and Log out
- Move theme toggle from sidebar footer to header as a Sun/Moon icon button (light/dark toggle)
- Add Profile page (`/profile`) with user info display and change password form
- Add Log Destinations stub page (`/config/log-destinations`)
- Rename routes from `/settings/*` to `/config/*`
- Add Nix development environment note to CLAUDE.md

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 39/39 tests pass
- [x] `npm run build` — production build succeeds
- [ ] Manual: verify sidebar shows grouped sections (IPAM, Operations, Planning, Configuration)
- [ ] Manual: verify header dropdown shows user info, profile/API keys links, and logout
- [ ] Manual: verify Sun/Moon theme toggle in header switches light/dark
- [ ] Manual: verify `/profile` page renders user info and password change form
- [ ] Manual: verify `/config/log-destinations` renders stub page

🤖 Generated with [Claude Code](https://claude.com/claude-code)