### PR TITLE
feat: soft-deletes, SQLite connection pooling, utilization snapshots (v0.6.0)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to CloudPAM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - Soft-Deletes, Connection Pooling & Utilization Snapshots
+
+### Added
+- Soft-delete support for pools and accounts — records are marked with `deleted_at` instead of being permanently removed, enabling future restore/audit capabilities (#18)
+- SQLite connection pool configuration via environment variables: `SQLITE_MAX_OPEN_CONNS`, `SQLITE_MAX_IDLE_CONNS`, `SQLITE_CONN_MAX_LIFETIME_SECS`, `SQLITE_CONN_MAX_IDLE_SECS` (#71)
+- Utilization snapshot table (`utilization_snapshots`) for tracking pool usage over time, enabling growth projections and capacity planning (#117)
+- `UtilizationStore` interface with in-memory and SQLite implementations (`RecordSnapshot`, `ListSnapshots`, `LatestSnapshot`)
+- `UtilizationSnapshot` domain type capturing pool utilization at a point in time
+- SQLite migrations: `0014_soft_deletes.sql` (adds `deleted_at` column + indexes), `0015_utilization_snapshots.sql` (snapshot table)
+
+### Changed
+- All pool and account queries now filter on `deleted_at IS NULL` across MemoryStore, SQLite, and PostgreSQL backends
+- Delete operations (`DeletePool`, `DeleteAccount`, `DeletePoolCascade`, `DeleteAccountCascade`) now perform soft-deletes (SET `deleted_at`) instead of hard deletes
+- Search queries filter out soft-deleted records in all storage backends
+
+### Noted
+- Test coverage is at 53.4% overall — below the 80% target tracked in #67; coverage improvement deferred to a dedicated sprint
+
 ## [0.5.0] - Configuration Section & User Menu
 
 ### Changed
@@ -604,6 +622,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IPv4 only (IPv6 planned)
 - Block detection marks exact CIDR matches as used
 
+[0.6.0]: https://github.com/BadgerOps/cloudpam/compare/v0.5.0...v0.6.0
 [Unreleased]: https://github.com/BadgerOps/cloudpam/compare/v0.3.2...HEAD
 [0.3.2]: https://github.com/BadgerOps/cloudpam/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/BadgerOps/cloudpam/compare/v0.3.0...v0.3.1

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -98,6 +98,7 @@ type Pool struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 	CreatedAt   time.Time         `json:"created_at"`
 	UpdatedAt   time.Time         `json:"updated_at"`
+	DeletedAt   *time.Time        `json:"deleted_at,omitempty"`
 }
 
 // PoolStats contains computed statistics for a pool.
@@ -143,18 +144,19 @@ type UpdatePool struct {
 // Account represents a cloud account or project to which pools can be assigned.
 // It uses a generic shape to support AWS accounts, GCP projects, etc.
 type Account struct {
-	ID          int64     `json:"id"`
-	Key         string    `json:"key"` // unique key like "aws:123456789012" or "gcp:my-project"
-	Name        string    `json:"name"`
-	Provider    string    `json:"provider,omitempty"`
-	ExternalID  string    `json:"external_id,omitempty"`
-	Description string    `json:"description,omitempty"`
-	Platform    string    `json:"platform,omitempty"`
-	Tier        string    `json:"tier,omitempty"`
-	Environment string    `json:"environment,omitempty"`
-	Regions     []string  `json:"regions,omitempty"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID          int64      `json:"id"`
+	Key         string     `json:"key"` // unique key like "aws:123456789012" or "gcp:my-project"
+	Name        string     `json:"name"`
+	Provider    string     `json:"provider,omitempty"`
+	ExternalID  string     `json:"external_id,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Platform    string     `json:"platform,omitempty"`
+	Tier        string     `json:"tier,omitempty"`
+	Environment string     `json:"environment,omitempty"`
+	Regions     []string   `json:"regions,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
 }
 
 // CreateAccount is the input for creating an account.
@@ -168,4 +170,17 @@ type CreateAccount struct {
 	Tier        string   `json:"tier,omitempty"`
 	Environment string   `json:"environment,omitempty"`
 	Regions     []string `json:"regions,omitempty"`
+}
+
+// UtilizationSnapshot captures pool utilization at a point in time
+// for historical tracking and growth projections.
+type UtilizationSnapshot struct {
+	ID           int64     `json:"id"`
+	PoolID       int64     `json:"pool_id"`
+	TotalIPs     int64     `json:"total_ips"`
+	UsedIPs      int64     `json:"used_ips"`
+	AvailableIPs int64     `json:"available_ips"`
+	Utilization  float64   `json:"utilization"` // 0-100 percentage
+	ChildCount   int       `json:"child_count"`
+	CapturedAt   time.Time `json:"captured_at"`
 }

--- a/internal/storage/sqlite/utilization.go
+++ b/internal/storage/sqlite/utilization.go
@@ -1,0 +1,73 @@
+//go:build sqlite
+
+package sqlite
+
+import (
+	"context"
+	"time"
+
+	"cloudpam/internal/domain"
+	"cloudpam/internal/storage"
+)
+
+var _ storage.UtilizationStore = (*Store)(nil)
+
+func (s *Store) RecordSnapshot(ctx context.Context, snap domain.UtilizationSnapshot) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO utilization_snapshots (pool_id, total_ips, used_ips, available_ips, utilization, child_count, captured_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		snap.PoolID, snap.TotalIPs, snap.UsedIPs, snap.AvailableIPs,
+		snap.Utilization, snap.ChildCount, snap.CapturedAt.Format(time.RFC3339))
+	return err
+}
+
+func (s *Store) ListSnapshots(ctx context.Context, poolID int64, from, to time.Time) ([]domain.UtilizationSnapshot, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, pool_id, total_ips, used_ips, available_ips, utilization, child_count, captured_at
+		FROM utilization_snapshots
+		WHERE pool_id = ? AND captured_at >= ? AND captured_at <= ?
+		ORDER BY captured_at ASC`,
+		poolID, from.Format(time.RFC3339), to.Format(time.RFC3339))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []domain.UtilizationSnapshot
+	for rows.Next() {
+		var snap domain.UtilizationSnapshot
+		var capturedAt string
+		if err := rows.Scan(&snap.ID, &snap.PoolID, &snap.TotalIPs, &snap.UsedIPs,
+			&snap.AvailableIPs, &snap.Utilization, &snap.ChildCount, &capturedAt); err != nil {
+			return nil, err
+		}
+		if t, e := time.Parse(time.RFC3339, capturedAt); e == nil {
+			snap.CapturedAt = t
+		}
+		out = append(out, snap)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) LatestSnapshot(ctx context.Context, poolID int64) (*domain.UtilizationSnapshot, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, pool_id, total_ips, used_ips, available_ips, utilization, child_count, captured_at
+		FROM utilization_snapshots
+		WHERE pool_id = ?
+		ORDER BY captured_at DESC
+		LIMIT 1`, poolID)
+
+	var snap domain.UtilizationSnapshot
+	var capturedAt string
+	if err := row.Scan(&snap.ID, &snap.PoolID, &snap.TotalIPs, &snap.UsedIPs,
+		&snap.AvailableIPs, &snap.Utilization, &snap.ChildCount, &capturedAt); err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if t, e := time.Parse(time.RFC3339, capturedAt); e == nil {
+		snap.CapturedAt = t
+	}
+	return &snap, nil
+}

--- a/internal/storage/utilization.go
+++ b/internal/storage/utilization.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"cloudpam/internal/domain"
+)
+
+// UtilizationStore provides storage operations for pool utilization snapshots.
+type UtilizationStore interface {
+	// RecordSnapshot captures the current utilization of a pool.
+	RecordSnapshot(ctx context.Context, snap domain.UtilizationSnapshot) error
+
+	// ListSnapshots returns snapshots for a pool within a time range, ordered by captured_at ASC.
+	ListSnapshots(ctx context.Context, poolID int64, from, to time.Time) ([]domain.UtilizationSnapshot, error)
+
+	// LatestSnapshot returns the most recent snapshot for a pool, or nil if none exist.
+	LatestSnapshot(ctx context.Context, poolID int64) (*domain.UtilizationSnapshot, error)
+}

--- a/internal/storage/utilization_memory.go
+++ b/internal/storage/utilization_memory.go
@@ -1,0 +1,64 @@
+package storage
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"cloudpam/internal/domain"
+)
+
+// MemoryUtilizationStore is an in-memory implementation of UtilizationStore.
+type MemoryUtilizationStore struct {
+	mu        sync.RWMutex
+	snapshots []domain.UtilizationSnapshot
+	nextID    int64
+}
+
+func NewMemoryUtilizationStore() *MemoryUtilizationStore {
+	return &MemoryUtilizationStore{nextID: 1}
+}
+
+var _ UtilizationStore = (*MemoryUtilizationStore)(nil)
+
+func (s *MemoryUtilizationStore) RecordSnapshot(_ context.Context, snap domain.UtilizationSnapshot) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snap.ID = s.nextID
+	s.nextID++
+	s.snapshots = append(s.snapshots, snap)
+	return nil
+}
+
+func (s *MemoryUtilizationStore) ListSnapshots(_ context.Context, poolID int64, from, to time.Time) ([]domain.UtilizationSnapshot, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []domain.UtilizationSnapshot
+	for _, snap := range s.snapshots {
+		if snap.PoolID == poolID &&
+			!snap.CapturedAt.Before(from) &&
+			!snap.CapturedAt.After(to) {
+			out = append(out, snap)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CapturedAt.Before(out[j].CapturedAt)
+	})
+	return out, nil
+}
+
+func (s *MemoryUtilizationStore) LatestSnapshot(_ context.Context, poolID int64) (*domain.UtilizationSnapshot, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var latest *domain.UtilizationSnapshot
+	for i := range s.snapshots {
+		snap := &s.snapshots[i]
+		if snap.PoolID == poolID {
+			if latest == nil || snap.CapturedAt.After(latest.CapturedAt) {
+				latest = snap
+			}
+		}
+	}
+	return latest, nil
+}

--- a/migrations/0014_soft_deletes.sql
+++ b/migrations/0014_soft_deletes.sql
@@ -1,0 +1,10 @@
+-- Add soft-delete support to pools and accounts.
+-- Rows with deleted_at IS NOT NULL are treated as deleted;
+-- all existing queries filter on deleted_at IS NULL.
+
+ALTER TABLE pools ADD COLUMN deleted_at TEXT;
+ALTER TABLE accounts ADD COLUMN deleted_at TEXT;
+
+-- Index for efficient filtering of non-deleted rows.
+CREATE INDEX IF NOT EXISTS idx_pools_deleted_at ON pools(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_accounts_deleted_at ON accounts(deleted_at);

--- a/migrations/0015_utilization_snapshots.sql
+++ b/migrations/0015_utilization_snapshots.sql
@@ -1,0 +1,16 @@
+-- Utilization snapshots for tracking pool usage over time.
+-- Enables growth projections and capacity planning.
+CREATE TABLE IF NOT EXISTS utilization_snapshots (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    pool_id     INTEGER NOT NULL REFERENCES pools(id),
+    total_ips   INTEGER NOT NULL,
+    used_ips    INTEGER NOT NULL,
+    available_ips INTEGER NOT NULL,
+    utilization REAL NOT NULL,          -- 0-100 percentage
+    child_count INTEGER NOT NULL DEFAULT 0,
+    captured_at TEXT NOT NULL,           -- RFC3339 timestamp
+    UNIQUE(pool_id, captured_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_utilization_snapshots_pool_id ON utilization_snapshots(pool_id);
+CREATE INDEX IF NOT EXISTS idx_utilization_snapshots_captured_at ON utilization_snapshots(captured_at);


### PR DESCRIPTION
## Summary

- **Soft-deletes for pools and accounts (#18)**: Records are now marked with `deleted_at` instead of permanently removed. All List/Get/Search/Delete operations filter on `deleted_at IS NULL` across MemoryStore, SQLite, and PostgreSQL backends. Migration `0014_soft_deletes.sql` adds column + indexes.
- **SQLite connection pool configuration (#71)**: Adds `SetMaxOpenConns`, `SetMaxIdleConns`, `SetConnMaxLifetime`, `SetConnMaxIdleTime` with env var overrides (`SQLITE_MAX_OPEN_CONNS`, `SQLITE_MAX_IDLE_CONNS`, `SQLITE_CONN_MAX_LIFETIME_SECS`, `SQLITE_CONN_MAX_IDLE_SECS`).
- **Utilization snapshot table (#117)**: New `utilization_snapshots` table (migration `0015`) with `UtilizationStore` interface and implementations (memory + SQLite) for tracking pool usage over time.
- **Coverage validation (#67)**: Overall coverage is 53.4% — below 80% target. Documented in changelog; improvement deferred to dedicated sprint.
- **Version bump**: 0.5.0 → 0.6.0 with changelog entry.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` — default build compiles
- [x] `go build -tags sqlite ./...` — SQLite build compiles
- [x] Pre-commit hook passes (golangci-lint)

Closes #18, #71, #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)