### PR TITLE
deps: bump go-jose to v4.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/getsentry/sentry-go v0.43.0
-	github.com/go-jose/go-jose/v4 v4.1.3
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/testcontainers/testcontainers-go v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxI
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Summary
- bump `github.com/go-jose/go-jose/v4` from `v4.1.3` to `v4.1.4`
- address Dependabot alert `GHSA-78h2-9frx-2jm8` / `CVE-2026-34986`
- keep the change scoped to the runtime OIDC dependency path

## Testing
- `GOCACHE=/tmp/cloudpam-go-build GOMODCACHE=/tmp/cloudpam-go-mod go test -c -o /tmp/cloudpam-internal-auth-oidc.test ./internal/auth/oidc`
- `GOCACHE=/tmp/cloudpam-go-build GOMODCACHE=/tmp/cloudpam-go-mod go test -c -o /tmp/cloudpam-internal-api.test ./internal/api`

## Notes
- full test execution is sandbox-limited locally because `httptest.NewServer` cannot open listeners here; GitHub Actions should run the full suite