### PR TITLE
fix: add password reset CLI

### DIFF
--- a/cmd/cloudpam/main.go
+++ b/cmd/cloudpam/main.go
@@ -80,14 +80,14 @@ func main() {
 		userStore := selectUserStore(logger)
 		sessionStore := selectSessionStore(logger)
 		if err := resetUserPassword(context.Background(), userStore, sessionStore, *resetPasswordUsername, password); err != nil {
-			logger.Error("password reset failed", "username", *resetPasswordUsername, "error", err)
+			logger.Error("password reset failed", "error", err)
 			closeIfPossible(logger, sessionStore, "session store")
 			closeIfPossible(logger, userStore, "user store")
 			os.Exit(1)
 		}
 		closeIfPossible(logger, sessionStore, "session store")
 		closeIfPossible(logger, userStore, "user store")
-		logger.Info("password reset complete", "username", *resetPasswordUsername)
+		logger.Info("password reset complete")
 		return
 	}
 

--- a/cmd/cloudpam/main.go
+++ b/cmd/cloudpam/main.go
@@ -387,7 +387,7 @@ func resetUserPassword(ctx context.Context, userStore auth.UserStore, sessionSto
 		return fmt.Errorf("lookup user: %w", err)
 	}
 	if user == nil {
-		return fmt.Errorf("user %q not found", username)
+		return fmt.Errorf("user not found")
 	}
 
 	hash, err := auth.HashPassword(password)

--- a/cmd/cloudpam/main.go
+++ b/cmd/cloudpam/main.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"flag"
+	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -38,6 +40,7 @@ func main() {
 	}
 	flag.StringVar(&addr, "addr", addr, "listen address (host:port)")
 	migrate := flag.String("migrate", "", "run migrations: 'up' to apply, 'status' to show status")
+	resetPasswordUsername := flag.String("reset-password", "", "reset a local user's password and exit; set CLOUDPAM_RESET_PASSWORD or pipe the password on stdin")
 	flag.Parse()
 
 	// Initialize Sentry if DSN is provided
@@ -65,6 +68,26 @@ func main() {
 	// Handle migrations CLI before starting server
 	if *migrate != "" {
 		runMigrationsCLI(logger, *migrate)
+		return
+	}
+
+	if *resetPasswordUsername != "" {
+		password, err := resetPasswordInput()
+		if err != nil {
+			logger.Error("password reset failed", "error", err)
+			os.Exit(1)
+		}
+		userStore := selectUserStore(logger)
+		sessionStore := selectSessionStore(logger)
+		if err := resetUserPassword(context.Background(), userStore, sessionStore, *resetPasswordUsername, password); err != nil {
+			logger.Error("password reset failed", "username", *resetPasswordUsername, "error", err)
+			closeIfPossible(logger, sessionStore, "session store")
+			closeIfPossible(logger, userStore, "user store")
+			os.Exit(1)
+		}
+		closeIfPossible(logger, sessionStore, "session store")
+		closeIfPossible(logger, userStore, "user store")
+		logger.Info("password reset complete", "username", *resetPasswordUsername)
 		return
 	}
 
@@ -324,6 +347,80 @@ func envOr(k, def string) string {
 		return v
 	}
 	return def
+}
+
+func resetPasswordInput() (string, error) {
+	if password := os.Getenv("CLOUDPAM_RESET_PASSWORD"); password != "" {
+		return password, nil
+	}
+
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat stdin: %w", err)
+	}
+	if stat.Mode()&os.ModeCharDevice != 0 {
+		return "", fmt.Errorf("set CLOUDPAM_RESET_PASSWORD or pipe the new password on stdin")
+	}
+
+	raw, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", fmt.Errorf("read password from stdin: %w", err)
+	}
+	password := strings.TrimRight(string(raw), "\r\n")
+	if password == "" {
+		return "", fmt.Errorf("password is empty")
+	}
+	return password, nil
+}
+
+func resetUserPassword(ctx context.Context, userStore auth.UserStore, sessionStore auth.SessionStore, username, password string) error {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+	if err := auth.ValidatePassword(password, 0); err != nil {
+		return err
+	}
+
+	user, err := userStore.GetByUsername(ctx, username)
+	if err != nil {
+		return fmt.Errorf("lookup user: %w", err)
+	}
+	if user == nil {
+		return fmt.Errorf("user %q not found", username)
+	}
+
+	hash, err := auth.HashPassword(password)
+	if err != nil {
+		return fmt.Errorf("hash password: %w", err)
+	}
+
+	now := time.Now().UTC()
+	user.PasswordHash = hash
+	user.IsActive = true
+	user.FailedLoginAttempts = 0
+	user.LastFailedLoginAt = nil
+	user.LockedAt = nil
+	user.LockoutUntil = nil
+	user.UpdatedAt = now
+
+	if err := userStore.Update(ctx, user); err != nil {
+		return fmt.Errorf("update user: %w", err)
+	}
+	if err := sessionStore.DeleteByUserID(ctx, user.ID); err != nil {
+		return fmt.Errorf("revoke sessions: %w", err)
+	}
+	return nil
+}
+
+func closeIfPossible(logger observability.Logger, v any, name string) {
+	closer, ok := v.(interface{ Close() error })
+	if !ok {
+		return
+	}
+	if err := closer.Close(); err != nil {
+		logger.Warn("close failed", "component", name, "error", err)
+	}
 }
 
 // bootstrapAdmin creates the initial admin user if it doesn't already exist.

--- a/cmd/cloudpam/main_test.go
+++ b/cmd/cloudpam/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloudpam/internal/auth"
+)
+
+func TestResetUserPassword(t *testing.T) {
+	ctx := context.Background()
+	userStore := auth.NewMemoryUserStore()
+	sessionStore := auth.NewMemorySessionStore()
+
+	oldHash, err := auth.HashPassword("OldPassword123!")
+	if err != nil {
+		t.Fatalf("hash old password: %v", err)
+	}
+	lastFailed := time.Now().UTC().Add(-time.Hour)
+	lockedAt := time.Now().UTC().Add(-30 * time.Minute)
+	lockoutUntil := time.Now().UTC().Add(30 * time.Minute)
+	user := &auth.User{
+		ID:                  "user-1",
+		Username:            "admin",
+		Role:                auth.RoleAdmin,
+		PasswordHash:        oldHash,
+		IsActive:            false,
+		FailedLoginAttempts: 4,
+		LastFailedLoginAt:   &lastFailed,
+		LockedAt:            &lockedAt,
+		LockoutUntil:        &lockoutUntil,
+		CreatedAt:           time.Now().UTC(),
+		UpdatedAt:           time.Now().UTC(),
+	}
+	if err := userStore.Create(ctx, user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	session, err := auth.NewSession(user.ID, user.Role, time.Hour, nil)
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	if err := sessionStore.Create(ctx, session); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if err := resetUserPassword(ctx, userStore, sessionStore, "admin", "NewPassword123!"); err != nil {
+		t.Fatalf("reset password: %v", err)
+	}
+
+	got, err := userStore.GetByUsername(ctx, "admin")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if got == nil {
+		t.Fatal("user not found after reset")
+	}
+	if err := auth.VerifyPassword("NewPassword123!", got.PasswordHash); err != nil {
+		t.Fatalf("new password did not verify: %v", err)
+	}
+	if !got.IsActive {
+		t.Error("reset should reactivate user")
+	}
+	if got.FailedLoginAttempts != 0 || got.LastFailedLoginAt != nil || got.LockedAt != nil || got.LockoutUntil != nil {
+		t.Fatalf("lockout state not cleared: %+v", got)
+	}
+	sessions, err := sessionStore.ListByUserID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("expected sessions to be revoked, got %d", len(sessions))
+	}
+}
+
+func TestResetUserPasswordNotFound(t *testing.T) {
+	err := resetUserPassword(context.Background(), auth.NewMemoryUserStore(), auth.NewMemorySessionStore(), "missing", "NewPassword123!")
+	if err == nil {
+		t.Fatal("expected missing user error")
+	}
+}

--- a/docs/AUTH_FLOWS.md
+++ b/docs/AUTH_FLOWS.md
@@ -36,6 +36,72 @@ POST /api/v1/auth/setup
 
 Local auth can be disabled from security settings when OIDC is configured, leaving SSO as the primary interactive login path.
 
+#### Password Reset Recovery
+
+Operators can reset a local user's password without starting a second HTTP server. The command uses the same configured user/session stores as normal startup, so PostgreSQL-backed deployments use `DATABASE_URL` and SQLite-backed deployments use `SQLITE_DSN`. Use a binary or container image built with the storage backend tags required by that deployment.
+
+The reset command:
+- validates the new password against the default password policy
+- updates the user's bcrypt password hash
+- reactivates the user account
+- clears failed-login and lockout state
+- revokes existing sessions for that user
+
+Local binary with PostgreSQL:
+
+```bash
+DATABASE_URL='postgres://cloudpam:secret@db.example.com:5432/cloudpam?sslmode=require' \
+  CLOUDPAM_RESET_PASSWORD='<new-password>' \
+  ./cloudpam -reset-password <username>
+```
+
+Local binary with SQLite:
+
+```bash
+SQLITE_DSN='file:cloudpam.db?cache=shared&_fk=1' \
+  CLOUDPAM_RESET_PASSWORD='<new-password>' \
+  ./cloudpam -reset-password <username>
+```
+
+Kubernetes pod:
+
+```bash
+kubectl exec -n <namespace> deploy/<cloudpam-deployment> -- \
+  env CLOUDPAM_RESET_PASSWORD='<new-password>' \
+  cloudpam -reset-password <username>
+```
+
+Podman container:
+
+```bash
+podman exec \
+  -e CLOUDPAM_RESET_PASSWORD='<new-password>' \
+  <cloudpam-container> \
+  cloudpam -reset-password <username>
+```
+
+Stdin form, which avoids placing the password in the shell history, works with local binaries, Kubernetes, and Podman:
+
+```bash
+printf '%s\n' '<new-password>' | \
+  DATABASE_URL='postgres://cloudpam:secret@db.example.com:5432/cloudpam?sslmode=require' \
+  ./cloudpam -reset-password <username>
+```
+
+```bash
+printf '%s\n' '<new-password>' | \
+  kubectl exec -i -n <namespace> deploy/<cloudpam-deployment> -- \
+  cloudpam -reset-password <username>
+```
+
+```bash
+printf '%s\n' '<new-password>' | \
+  podman exec -i <cloudpam-container> \
+  cloudpam -reset-password <username>
+```
+
+The command exits non-zero if the user does not exist, the password fails policy validation, or the configured backing store cannot be reached. For PostgreSQL deployments, verify the process has the same `DATABASE_URL` environment that the server uses.
+
 ### 2. OAuth 2.0 / OIDC Flow (User Sessions)
 
 CloudPAM acts as an OIDC Relying Party, supporting any OIDC-compliant Identity Provider.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-05-05
+
+### Fixed
+- Added password reset CLI recovery for local binaries, Kubernetes pods, and Podman containers without starting the HTTP server
+
 ## [0.11.0] - 2026-05-05
 
 ### Added

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -142,6 +142,51 @@ docker compose logs -f cloudpam
 # Access at http://localhost:8080
 ```
 
+### Password Reset Operations
+
+Use the reset CLI when an operator needs to recover a local user password without starting another HTTP server. The command validates the new password, updates the stored hash, reactivates the user, clears failed-login and lockout state, and revokes that user's sessions. Use a binary or container image built with the storage backend tags required by the deployment.
+
+Local PostgreSQL-backed binary:
+
+```bash
+DATABASE_URL='postgres://cloudpam:secret@localhost:5432/cloudpam?sslmode=disable' \
+  CLOUDPAM_RESET_PASSWORD='<new-password>' \
+  ./cloudpam -reset-password <username>
+```
+
+Local SQLite-backed binary:
+
+```bash
+SQLITE_DSN='file:cloudpam.db?cache=shared&_fk=1' \
+  CLOUDPAM_RESET_PASSWORD='<new-password>' \
+  ./cloudpam -reset-password <username>
+```
+
+Podman container using the container's existing database environment:
+
+```bash
+podman exec \
+  -e CLOUDPAM_RESET_PASSWORD='<new-password>' \
+  <cloudpam-container> \
+  cloudpam -reset-password <username>
+```
+
+Stdin avoids putting the new password in shell history:
+
+```bash
+printf '%s\n' '<new-password>' | \
+  DATABASE_URL='postgres://cloudpam:secret@localhost:5432/cloudpam?sslmode=disable' \
+  ./cloudpam -reset-password <username>
+```
+
+```bash
+printf '%s\n' '<new-password>' | \
+  podman exec -i <cloudpam-container> \
+  cloudpam -reset-password <username>
+```
+
+For PostgreSQL-backed deployments, confirm the local process or container has the same `DATABASE_URL` value that the server uses. For SQLite-backed deployments, confirm `SQLITE_DSN` points at the active database file.
+
 ### Development with Hot Reload
 
 ```yaml
@@ -1139,6 +1184,26 @@ spec:
               drop:
                 - ALL
 ```
+
+### Kubernetes Password Reset
+
+Reset a local user's password from inside a running CloudPAM pod so the command uses the same database environment as the server:
+
+```bash
+kubectl exec -n <namespace> deploy/<cloudpam-deployment> -- \
+  env CLOUDPAM_RESET_PASSWORD='<new-password>' \
+  cloudpam -reset-password <username>
+```
+
+To avoid shell history, pass the new password on stdin:
+
+```bash
+printf '%s\n' '<new-password>' | \
+  kubectl exec -i -n <namespace> deploy/<cloudpam-deployment> -- \
+  cloudpam -reset-password <username>
+```
+
+The command exits non-zero if the user does not exist, the password fails policy validation, or the pod cannot reach the configured backing store.
 
 ### GKE-specific Values
 


### PR DESCRIPTION
## Summary
- add a local-user password reset CLI that exits without starting the HTTP server
- clear failed-login/lockout state and revoke existing sessions after reset
- document local binary, Kubernetes, and Podman reset flows
- add changelog entry for 0.11.1 bugfix release

## Tests
- env XDG_CACHE_HOME=/tmp/nix-cache nix develop -c scripts/pre-commit
- env XDG_CACHE_HOME=/tmp/nix-cache nix develop -c go test ./cmd/cloudpam