### PR TITLE
UI: fix discovery agent connection status

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.5] - 2026-05-27
+
 ### Fixed
 - Plan Discovery now recognizes newly connected agents by their provisioned API key ID, so the deployment step leaves the waiting state even when agent names are reused or differ from the provisioning prompt.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Plan Discovery now recognizes newly connected agents by their provisioned API key ID, so the deployment step leaves the waiting state even when agent names are reused or differ from the provisioning prompt.
+
 ## [0.13.4] - 2026-05-27
 
 ### Fixed

--- a/ui/src/components/DiscoveryWizard.tsx
+++ b/ui/src/components/DiscoveryWizard.tsx
@@ -80,7 +80,9 @@ export default function DiscoveryWizard({ accounts, onAccountCreated, onClose, o
   // Check if the provisioned agent has connected
   useEffect(() => {
     if (provisionResult && agents.length > 0) {
-      const match = agents.find(a => a.name === provisionResult.agent_name)
+      const match =
+        agents.find(a => a.api_key_id === provisionResult.api_key_id) ??
+        agents.find(a => a.name === provisionResult.agent_name && a.status === 'healthy')
       if (match) {
         setConnectedAgent(match)
         if (pollRef.current) {


### PR DESCRIPTION
## Summary
- Match the Plan Discovery connected-agent state by the provisioned API key ID before falling back to a healthy name match
- Add an Unreleased changelog entry for the wizard waiting-state fix

## Tests
- npm test -- --run