### PR TITLE
Discovery: improve agent scanning and schema import

### DIFF
--- a/cmd/cloudpam-agent/config.go
+++ b/cmd/cloudpam-agent/config.go
@@ -148,13 +148,13 @@ func (c *Config) Validate() error {
 	if c.AgentName == "" {
 		return errors.New("agent_name is required (set CLOUDPAM_AGENT_NAME or yaml)")
 	}
+	if c.AccountID < 1 {
+		return errors.New("account_id must be a positive integer (set CLOUDPAM_ACCOUNT_ID or yaml)")
+	}
 	if c.AWSOrg.Enabled {
-		// In org mode, account_id is not required (accounts are discovered dynamically)
 		if c.AWSOrg.RoleName == "" {
 			c.AWSOrg.RoleName = "CloudPAMDiscoveryRole"
 		}
-	} else if c.AccountID < 1 {
-		return errors.New("account_id must be a positive integer (set CLOUDPAM_ACCOUNT_ID or yaml)")
 	}
 	if c.SyncInterval < 1*time.Minute {
 		return errors.New("sync_interval must be at least 1 minute")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,10 +5,28 @@ All notable changes to CloudPAM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.0] - 2026-05-28
+
+### Added
+- Discovery now supports importing scanned VPC and subnet resources directly into the managed IP schema, creating discovered-source pools and linking the originating discovered resources back to the new or matching pools.
+- Added a discovery import API at `POST /api/v1/discovery/import` for turning active discovered resources into CloudPAM pools without going through CSV/block import workflows.
+- Discovery scans can now be requested for every healthy connected agent in one action, with each agent receiving its own tracked sync job.
+- Discovery scans can also target a single selected agent for account-specific or cloud-specific troubleshooting.
+- The Agents tab now exposes a per-agent scan action so operators can start discovery from the agent inventory view.
+- Added API coverage for all-agent scan queueing and discovered schema import/link behavior.
 
 ### Changed
 - Container image releases now cross-compile Linux binaries on the Actions runner and package them with thin runtime Dockerfiles, avoiding slow arm64 builds under QEMU emulation.
+- The Cloud Discovery primary action is now `Scan Now`; it defaults to all healthy connected agents and falls back to the selected-account server scan when no healthy agent is available.
+- Sync History now shows locally tracked queued agent jobs immediately, polls queued/running agent scans until completion, and displays whether each scan came from the server or a specific agent.
+- The discovery setup wizard is now labeled `Set Up Discovery`/`Add Agent` instead of `Plan Discovery`, requires a management account for AWS Organization agents, and sends users back to the Agents view when setup completes.
+- Generated Docker examples for discovery agents now use the published `ghcr.io/badgerops/cloudpam/agent:latest` image.
+- Organization-mode agent configuration now requires a positive `CLOUDPAM_ACCOUNT_ID` so bootstrap registration and heartbeat status work consistently while org ingest continues to auto-create member accounts from scan data.
+
+### Fixed
+- Clicking the scan button no longer appears to do nothing when a connected agent is selected: agent scans are queued, surfaced in Sync History, and polled until the agent completes ingest.
+- Scan job responses with `pending` or `running` status are now treated as successful queued work instead of error toasts.
+- Discovery UI now refreshes accounts after scans so accounts imported from AWS Organization ingest become visible without a manual page refresh.
 
 ## [0.13.5] - 2026-05-27
 

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"net/netip"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -35,6 +38,7 @@ func NewDiscoveryServer(srv *Server, store storage.DiscoveryStore, syncService *
 func (d *DiscoveryServer) RegisterDiscoveryRoutes() {
 	d.srv.mux.HandleFunc("/api/v1/discovery/resources", d.handleResources)
 	d.srv.mux.HandleFunc("/api/v1/discovery/resources/", d.handleResourcesSubroutes)
+	d.srv.mux.HandleFunc("/api/v1/discovery/import", d.handleImportDiscoveredSchema)
 	d.srv.mux.HandleFunc("/api/v1/discovery/sync", d.handleSync)
 	d.srv.mux.HandleFunc("/api/v1/discovery/sync/", d.handleSyncSubroutes)
 	d.srv.mux.HandleFunc("/api/v1/discovery/ingest", d.handleIngest)
@@ -50,6 +54,7 @@ func (d *DiscoveryServer) RegisterProtectedDiscoveryRoutes(dualMW Middleware, lo
 
 	d.srv.mux.Handle("/api/v1/discovery/resources", dualMW(readMW(http.HandlerFunc(d.handleResources))))
 	d.srv.mux.Handle("/api/v1/discovery/resources/", dualMW(d.protectedResourcesSubroutes(logger)))
+	d.srv.mux.Handle("/api/v1/discovery/import", dualMW(createMW(http.HandlerFunc(d.handleImportDiscoveredSchema))))
 	d.srv.mux.Handle("/api/v1/discovery/sync", dualMW(d.protectedSyncHandler(logger)))
 	d.srv.mux.Handle("/api/v1/discovery/sync/", dualMW(readMW(http.HandlerFunc(d.handleSyncSubroutes))))
 
@@ -234,6 +239,183 @@ func (d *DiscoveryServer) handleLink(w http.ResponseWriter, r *http.Request, id 
 	}
 }
 
+type discoveryImportResponse struct {
+	AccountsImported int      `json:"accounts_imported"`
+	PoolsCreated     int      `json:"pools_created"`
+	ResourcesLinked  int      `json:"resources_linked"`
+	Skipped          int      `json:"skipped"`
+	Errors           []string `json:"errors"`
+}
+
+// handleImportDiscoveredSchema imports active discovered VPC/subnet resources as pools.
+func (d *DiscoveryServer) handleImportDiscoveredSchema(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		d.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	var body struct {
+		AccountID int64 `json:"account_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.AccountID < 1 {
+		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "account_id is required and must be a positive integer", "")
+		return
+	}
+
+	if _, found, err := d.srv.store.GetAccount(r.Context(), body.AccountID); err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "account lookup failed", err.Error())
+		return
+	} else if !found {
+		d.srv.writeErr(r.Context(), w, http.StatusNotFound, "account not found", "")
+		return
+	}
+
+	resources, _, err := d.store.ListDiscoveredResources(r.Context(), body.AccountID, domain.DiscoveryFilters{
+		Status:   string(domain.DiscoveryStatusActive),
+		Page:     1,
+		PageSize: 10000,
+	})
+	if err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "list resources failed", err.Error())
+		return
+	}
+
+	resp := d.importDiscoveredPools(r.Context(), body.AccountID, resources)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (d *DiscoveryServer) importDiscoveredPools(ctx context.Context, accountID int64, resources []domain.DiscoveredResource) discoveryImportResponse {
+	resp := discoveryImportResponse{Errors: []string{}}
+	sort.SliceStable(resources, func(i, j int) bool {
+		if resources[i].ResourceType == resources[j].ResourceType {
+			return resources[i].ResourceID < resources[j].ResourceID
+		}
+		if resources[i].ResourceType == domain.ResourceTypeVPC {
+			return true
+		}
+		if resources[j].ResourceType == domain.ResourceTypeVPC {
+			return false
+		}
+		return resources[i].ResourceType < resources[j].ResourceType
+	})
+
+	existingPools, err := d.srv.store.ListPools(ctx)
+	if err != nil {
+		resp.Errors = append(resp.Errors, "list pools: "+err.Error())
+		return resp
+	}
+	poolByDiscoveryID := make(map[string]int64)
+	poolByShape := make(map[string]int64)
+	for _, pool := range existingPools {
+		if pool.Tags != nil {
+			if id := pool.Tags["discovery_resource_id"]; id != "" {
+				poolByDiscoveryID[id] = pool.ID
+			}
+		}
+		poolByShape[poolShapeKey(pool.AccountID, pool.ParentID, string(pool.Type), pool.CIDR)] = pool.ID
+	}
+
+	resourceToPool := make(map[string]int64)
+	for _, res := range resources {
+		if res.PoolID != nil {
+			resourceToPool[res.ResourceID] = *res.PoolID
+			resp.Skipped++
+			continue
+		}
+		if res.CIDR == "" || (res.ResourceType != domain.ResourceTypeVPC && res.ResourceType != domain.ResourceTypeSubnet) {
+			resp.Skipped++
+			continue
+		}
+		if _, err := netip.ParsePrefix(res.CIDR); err != nil {
+			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: invalid CIDR %q", res.ResourceID, res.CIDR))
+			resp.Skipped++
+			continue
+		}
+
+		poolType := domain.PoolTypeSubnet
+		if res.ResourceType == domain.ResourceTypeVPC {
+			poolType = domain.PoolTypeVPC
+		}
+
+		var parentID *int64
+		if res.ParentResourceID != nil {
+			if id, ok := resourceToPool[*res.ParentResourceID]; ok {
+				parentID = &id
+			}
+		}
+
+		if id, ok := poolByDiscoveryID[res.ResourceID]; ok {
+			if err := d.store.LinkResourceToPool(ctx, res.ID, id); err != nil {
+				resp.Errors = append(resp.Errors, fmt.Sprintf("%s: link existing pool: %v", res.ResourceID, err))
+			} else {
+				resourceToPool[res.ResourceID] = id
+				resp.ResourcesLinked++
+			}
+			continue
+		}
+		if id, ok := poolByShape[poolShapeKey(&accountID, parentID, string(poolType), res.CIDR)]; ok {
+			if err := d.store.LinkResourceToPool(ctx, res.ID, id); err != nil {
+				resp.Errors = append(resp.Errors, fmt.Sprintf("%s: link matching pool: %v", res.ResourceID, err))
+			} else {
+				resourceToPool[res.ResourceID] = id
+				resp.ResourcesLinked++
+			}
+			continue
+		}
+
+		name := strings.TrimSpace(res.Name)
+		if name == "" {
+			name = res.ResourceID
+		}
+		pool, err := d.srv.store.CreatePool(ctx, domain.CreatePool{
+			Name:      name,
+			CIDR:      res.CIDR,
+			ParentID:  parentID,
+			AccountID: &accountID,
+			Type:      poolType,
+			Status:    domain.PoolStatusActive,
+			Source:    domain.PoolSourceDiscovered,
+			Description: fmt.Sprintf("Imported from %s discovery resource %s in %s",
+				res.Provider, res.ResourceID, res.Region),
+			Tags: map[string]string{
+				"discovery_resource_id": res.ResourceID,
+				"discovery_provider":    res.Provider,
+				"discovery_region":      res.Region,
+				"discovery_type":        string(res.ResourceType),
+			},
+		})
+		if err != nil {
+			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: create pool: %v", res.ResourceID, err))
+			resp.Skipped++
+			continue
+		}
+		if err := d.store.LinkResourceToPool(ctx, res.ID, pool.ID); err != nil {
+			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: link new pool: %v", res.ResourceID, err))
+		} else {
+			resp.ResourcesLinked++
+		}
+		resourceToPool[res.ResourceID] = pool.ID
+		poolByDiscoveryID[res.ResourceID] = pool.ID
+		poolByShape[poolShapeKey(pool.AccountID, pool.ParentID, string(pool.Type), pool.CIDR)] = pool.ID
+		resp.PoolsCreated++
+	}
+
+	return resp
+}
+
+func poolShapeKey(accountID *int64, parentID *int64, poolType string, cidr string) string {
+	account := int64(0)
+	parent := int64(0)
+	if accountID != nil {
+		account = *accountID
+	}
+	if parentID != nil {
+		parent = *parentID
+	}
+	return fmt.Sprintf("%d|%d|%s|%s", account, parent, poolType, cidr)
+}
+
 // handleSync handles POST /api/v1/discovery/sync (trigger) and GET (list jobs)
 func (d *DiscoveryServer) handleSync(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
@@ -249,9 +431,74 @@ func (d *DiscoveryServer) handleSync(w http.ResponseWriter, r *http.Request) {
 
 func (d *DiscoveryServer) triggerSync(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		AccountID int64 `json:"account_id"`
+		AccountID int64  `json:"account_id"`
+		AgentID   string `json:"agent_id"`
+		AllAgents bool   `json:"all_agents"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.AccountID < 1 {
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+
+	if d.syncService == nil {
+		d.srv.writeErr(r.Context(), w, http.StatusServiceUnavailable, "sync service not available", "")
+		return
+	}
+
+	if body.AllAgents {
+		jobs, err := d.queueAllHealthyAgentSyncs(r.Context())
+		if err != nil {
+			d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "queue agent syncs failed", err.Error())
+			return
+		}
+		if len(jobs) == 0 {
+			d.srv.writeErr(r.Context(), w, http.StatusConflict, "no healthy discovery agents are connected", "")
+			return
+		}
+		writeJSON(w, http.StatusOK, domain.SyncJobsResponse{Items: jobs})
+		return
+	}
+
+	if body.AgentID != "" {
+		agentID, err := uuid.Parse(body.AgentID)
+		if err != nil {
+			d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid agent_id", "")
+			return
+		}
+		agent, err := d.store.GetAgent(r.Context(), agentID)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				d.srv.writeErr(r.Context(), w, http.StatusNotFound, "agent not found", "")
+				return
+			}
+			d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "get agent failed", err.Error())
+			return
+		}
+		if computeAgentStatus(agent.LastSeenAt, time.Now().UTC()) != domain.AgentStatusHealthy {
+			d.srv.writeErr(r.Context(), w, http.StatusConflict, "agent is not healthy", "")
+			return
+		}
+		accountID := agent.AccountID
+		if body.AccountID > 0 {
+			accountID = body.AccountID
+		}
+		if _, found, err := d.srv.store.GetAccount(r.Context(), accountID); err != nil {
+			d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "account lookup failed", err.Error())
+			return
+		} else if !found {
+			d.srv.writeErr(r.Context(), w, http.StatusNotFound, "account not found", "")
+			return
+		}
+		job, err := d.createAgentSyncJob(r.Context(), accountID, agent.ID)
+		if err != nil {
+			d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "create agent sync job failed", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, job)
+		return
+	}
+
+	if body.AccountID < 1 {
 		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "account_id is required and must be a positive integer", "")
 		return
 	}
@@ -267,21 +514,8 @@ func (d *DiscoveryServer) triggerSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if d.syncService == nil {
-		d.srv.writeErr(r.Context(), w, http.StatusServiceUnavailable, "sync service not available", "")
-		return
-	}
-
 	if agent := d.selectConnectedAgent(r.Context(), body.AccountID); agent != nil {
-		now := time.Now().UTC()
-		job, err := d.store.CreateSyncJob(r.Context(), domain.SyncJob{
-			ID:        uuid.New(),
-			AccountID: account.ID,
-			Status:    domain.SyncJobStatusPending,
-			Source:    "agent",
-			AgentID:   &agent.ID,
-			CreatedAt: now,
-		})
+		job, err := d.createAgentSyncJob(r.Context(), account.ID, agent.ID)
 		if err != nil {
 			d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "create agent sync job failed", err.Error())
 			return
@@ -302,6 +536,46 @@ func (d *DiscoveryServer) triggerSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, job)
+}
+
+func (d *DiscoveryServer) createAgentSyncJob(ctx context.Context, accountID int64, agentID uuid.UUID) (domain.SyncJob, error) {
+	now := time.Now().UTC()
+	return d.store.CreateSyncJob(ctx, domain.SyncJob{
+		ID:        uuid.New(),
+		AccountID: accountID,
+		Status:    domain.SyncJobStatusPending,
+		Source:    "agent",
+		AgentID:   &agentID,
+		CreatedAt: now,
+	})
+}
+
+func (d *DiscoveryServer) queueAllHealthyAgentSyncs(ctx context.Context) ([]domain.SyncJob, error) {
+	agents, err := d.store.ListAgents(ctx, 0)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	jobs := make([]domain.SyncJob, 0, len(agents))
+	seen := make(map[uuid.UUID]bool)
+	for i := range agents {
+		agent := agents[i]
+		if seen[agent.ID] || computeAgentStatus(agent.LastSeenAt, now) != domain.AgentStatusHealthy {
+			continue
+		}
+		if _, found, err := d.srv.store.GetAccount(ctx, agent.AccountID); err != nil {
+			return nil, err
+		} else if !found {
+			continue
+		}
+		job, err := d.createAgentSyncJob(ctx, agent.AccountID, agent.ID)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+		seen[agent.ID] = true
+	}
+	return jobs, nil
 }
 
 func (d *DiscoveryServer) selectConnectedAgent(ctx context.Context, accountID int64) *domain.DiscoveryAgent {

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"cloudpam/internal/domain"
+)
+
+func TestTriggerSyncAllHealthyAgents(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	a1, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:111111111111", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account 1: %v", err)
+	}
+	a2, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:222222222222", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account 2: %v", err)
+	}
+
+	now := time.Now().UTC()
+	for _, account := range []domain.Account{a1, a2} {
+		if err := ds.UpsertAgent(t.Context(), domain.DiscoveryAgent{
+			ID:         uuid.New(),
+			Name:       account.Name + "-agent",
+			AccountID:  account.ID,
+			APIKeyID:   "key-" + account.Key,
+			LastSeenAt: now,
+			CreatedAt:  now,
+		}); err != nil {
+			t.Fatalf("upsert agent: %v", err)
+		}
+	}
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/sync", `{"all_agents":true}`, http.StatusOK)
+	var resp domain.SyncJobsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(resp.Items))
+	}
+	for _, job := range resp.Items {
+		if job.Status != domain.SyncJobStatusPending || job.Source != "agent" || job.AgentID == nil {
+			t.Fatalf("unexpected job: %+v", job)
+		}
+	}
+}
+
+func TestImportDiscoveredSchemaCreatesAndLinksPools(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	subnetID := uuid.New()
+	parent := "vpc-1"
+	if err := ds.UpsertDiscoveredResource(t.Context(), domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-1",
+		Name:         "prod-vpc",
+		CIDR:         "10.0.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	}); err != nil {
+		t.Fatalf("upsert vpc: %v", err)
+	}
+	if err := ds.UpsertDiscoveredResource(t.Context(), domain.DiscoveredResource{
+		ID:               subnetID,
+		AccountID:        account.ID,
+		Provider:         "aws",
+		Region:           "us-east-1",
+		ResourceType:     domain.ResourceTypeSubnet,
+		ResourceID:       "subnet-1",
+		Name:             "prod-subnet",
+		CIDR:             "10.0.1.0/24",
+		ParentResourceID: &parent,
+		Status:           domain.DiscoveryStatusActive,
+		DiscoveredAt:     now,
+		LastSeenAt:       now,
+	}); err != nil {
+		t.Fatalf("upsert subnet: %v", err)
+	}
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import", `{"account_id":1}`, http.StatusOK)
+	var resp discoveryImportResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.PoolsCreated != 2 || resp.ResourcesLinked != 2 {
+		t.Fatalf("unexpected import response: %+v", resp)
+	}
+
+	pools, err := st.ListPools(t.Context())
+	if err != nil {
+		t.Fatalf("list pools: %v", err)
+	}
+	if len(pools) != 2 {
+		t.Fatalf("len(pools) = %d, want 2", len(pools))
+	}
+
+	vpc, err := ds.GetDiscoveredResource(t.Context(), vpcID)
+	if err != nil {
+		t.Fatalf("get vpc: %v", err)
+	}
+	subnet, err := ds.GetDiscoveredResource(t.Context(), subnetID)
+	if err != nil {
+		t.Fatalf("get subnet: %v", err)
+	}
+	if vpc.PoolID == nil || subnet.PoolID == nil {
+		t.Fatalf("resources were not linked: vpc=%v subnet=%v", vpc.PoolID, subnet.PoolID)
+	}
+}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -434,6 +434,8 @@ export interface SyncJob {
   id: string
   account_id: number
   status: SyncJobStatus
+  source?: 'local' | 'agent'
+  agent_id?: string | null
   started_at?: string | null
   completed_at?: string | null
   resources_found: number
@@ -447,6 +449,8 @@ export interface SyncJob {
 export interface SyncJobsResponse {
   items: SyncJob[]
 }
+
+export type SyncTriggerResponse = SyncJob | SyncJobsResponse
 
 export type AgentStatus = 'healthy' | 'stale' | 'offline'
 
@@ -464,6 +468,14 @@ export interface DiscoveryAgent {
 
 export interface DiscoveryAgentsResponse {
   items: DiscoveryAgent[]
+}
+
+export interface DiscoveryImportResponse {
+  accounts_imported: number
+  pools_created: number
+  resources_linked: number
+  skipped: number
+  errors: string[]
 }
 
 // --- Recommendation types ---

--- a/ui/src/components/DiscoveryWizard.tsx
+++ b/ui/src/components/DiscoveryWizard.tsx
@@ -28,6 +28,7 @@ export default function DiscoveryWizard({ accounts, onAccountCreated, onClose, o
     provider: 'aws',
     regions: [],
   })
+  const [createdAccount, setCreatedAccount] = useState<Account | null>(null)
   const [regionsInput, setRegionsInput] = useState('')
   const [agentName, setAgentName] = useState('')
   const [provisionResult, setProvisionResult] = useState<AgentProvisionResponse | null>(null)
@@ -50,7 +51,7 @@ export default function DiscoveryWizard({ accounts, onAccountCreated, onClose, o
   const { agents, fetch: fetchAgents } = useDiscoveryAgents()
   const { showToast } = useToast()
 
-  const selectedAccount = accounts.find(a => a.id === selectedAccountId) ?? null
+  const selectedAccount = accounts.find(a => a.id === selectedAccountId) ?? createdAccount
 
   // Poll for agent connection when on step 3 with a provisioned agent
   useEffect(() => {
@@ -117,6 +118,7 @@ export default function DiscoveryWizard({ accounts, onAccountCreated, onClose, o
     try {
       const regions = regionsInput.split(',').map(r => r.trim()).filter(Boolean)
       const account = await createAccount({ ...newAccount, regions })
+      setCreatedAccount(account)
       setSelectedAccountId(account.id)
       setShowNewAccount(false)
       onAccountCreated()
@@ -258,7 +260,7 @@ resource "null_resource" "cloudpam_agent" {
   -e CLOUDPAM_BOOTSTRAP_TOKEN="${token}" \\
   -e CLOUDPAM_ACCOUNT_ID=${accountId} \\
   -e CLOUDPAM_AWS_REGIONS="${accountRegions.join(',')}" \\
-  cloudpam/agent:latest`
+  ghcr.io/badgerops/cloudpam/agent:latest`
 
   const dockerConfigOrg = `docker run -d \\
   --name cloudpam-agent \\
@@ -271,7 +273,7 @@ resource "null_resource" "cloudpam_agent" {
   -e CLOUDPAM_AWS_ORG_EXTERNAL_ID="${orgExternalId}" \\` : ''}
   -e CLOUDPAM_AWS_ORG_REGIONS="${orgRegions.join(',')}" \\${orgExclude.length > 0 ? `
   -e CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS="${orgExclude.join(',')}" \\` : ''}
-  cloudpam/agent:latest`
+  ghcr.io/badgerops/cloudpam/agent:latest`
 
   const iamSetupContent = `# IAM Setup for AWS Organizations Discovery
 #
@@ -353,7 +355,7 @@ resource "aws_iam_policy" "cloudpam_org" {
     iam: { content: iamSetupContent, filename: `${agentNameFinal}-iam.tf`, label: 'IAM Setup' },
   }
 
-  const canGoNext = (step === 1 && (discoveryMode === 'organization' || selectedAccountId !== null)) ||
+  const canGoNext = (step === 1 && selectedAccountId !== null) ||
     (step === 2 && provisionResult !== null)
 
   return (
@@ -362,7 +364,7 @@ resource "aws_iam_policy" "cloudpam_org" {
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b dark:border-gray-700">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Plan Discovery</h2>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Set Up Discovery</h2>
             <div className="flex items-center gap-2 mt-1">
               {[1, 2, 3].map(s => (
                 <div key={s} className="flex items-center gap-1">
@@ -430,10 +432,12 @@ resource "aws_iam_policy" "cloudpam_org" {
                 </label>
               </div>
 
-              {/* Single account mode */}
-              {discoveryMode === 'single' && (
+              {/* Account selection */}
+              {(discoveryMode === 'single' || discoveryMode === 'organization') && (
                 <div className="space-y-3">
-                  <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">Select Cloud Account</h4>
+                  <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {discoveryMode === 'organization' ? 'Select Management Account' : 'Select Cloud Account'}
+                  </h4>
                   {!showNewAccount ? (
                     <>
                       <select

--- a/ui/src/hooks/useDiscovery.ts
+++ b/ui/src/hooks/useDiscovery.ts
@@ -6,7 +6,9 @@ import type {
   DiscoveryAgentsResponse,
   SyncJob,
   SyncJobsResponse,
+  SyncTriggerResponse,
   AgentProvisionResponse,
+  DiscoveryImportResponse,
 } from '../api/types'
 
 export function useDiscoveryResources() {
@@ -90,14 +92,30 @@ export function useSyncJobs() {
     }
   }, [])
 
-  const triggerSync = useCallback(async (accountId: number) => {
-    const job = await post<SyncJob>('/api/v1/discovery/sync', {
-      account_id: accountId,
+  const triggerSync = useCallback(async (options: {
+    accountId?: number
+    agentId?: string
+    allAgents?: boolean
+  }) => {
+    const job = await post<SyncTriggerResponse>('/api/v1/discovery/sync', {
+      account_id: options.accountId,
+      agent_id: options.agentId,
+      all_agents: options.allAgents,
     })
     return job
   }, [])
 
-  return { jobs, loading, error, fetch, triggerSync }
+  const getJob = useCallback(async (jobId: string) => {
+    return get<SyncJob>(`/api/v1/discovery/sync/${jobId}`)
+  }, [])
+
+  const importDiscoveredSchema = useCallback(async (accountId: number) => {
+    return post<DiscoveryImportResponse>('/api/v1/discovery/import', {
+      account_id: accountId,
+    })
+  }, [])
+
+  return { jobs, loading, error, fetch, triggerSync, getJob, importDiscoveredSchema }
 }
 
 export function useAgentProvisioning() {

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -10,6 +10,8 @@ import {
   ChevronRight,
   Activity,
   Wand2,
+  Loader2,
+  UploadCloud,
 } from 'lucide-react'
 import {
   useDiscoveryResources,
@@ -30,6 +32,14 @@ import type {
 } from '../api/types'
 
 type Tab = 'resources' | 'sync' | 'agents'
+
+function mergeJobs(current: SyncJob[], updates: SyncJob[]) {
+  const byID = new Map(current.map((job) => [job.id, job]))
+  updates.forEach((job) => byID.set(job.id, job))
+  return Array.from(byID.values()).sort((a, b) =>
+    new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  )
+}
 
 export default function DiscoveryPage() {
   const [tab, setTab] = useState<Tab>('resources')
@@ -56,6 +66,8 @@ export default function DiscoveryPage() {
     error: jobsError,
     fetch: fetchJobs,
     triggerSync,
+    getJob,
+    importDiscoveredSchema,
   } = useSyncJobs()
   const {
     agents,
@@ -65,10 +77,19 @@ export default function DiscoveryPage() {
   } = useDiscoveryAgents()
   const { showToast } = useToast()
   const agentsRefreshInterval = useRef<ReturnType<typeof setInterval> | null>(null)
+  const scanPollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [selectedScanAgentId, setSelectedScanAgentId] = useState('all')
+  const [scanLoading, setScanLoading] = useState(false)
+  const [importLoading, setImportLoading] = useState(false)
+  const [trackedScanJobs, setTrackedScanJobs] = useState<SyncJob[]>([])
 
   useEffect(() => {
     fetchAccounts()
   }, [fetchAccounts])
+
+  useEffect(() => {
+    fetchAgents()
+  }, [fetchAgents])
 
   // Auto-select first account
   useEffect(() => {
@@ -93,6 +114,14 @@ export default function DiscoveryPage() {
   }, [loadResources])
 
   useEffect(() => {
+    return () => {
+      if (scanPollRef.current) {
+        clearInterval(scanPollRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
     if (selectedAccountId && tab === 'sync') {
       fetchJobs(selectedAccountId)
     }
@@ -101,9 +130,9 @@ export default function DiscoveryPage() {
   // Auto-refresh agents every 30 seconds when on agents tab
   useEffect(() => {
     if (tab === 'agents') {
-      fetchAgents(selectedAccountId ?? undefined)
+      fetchAgents()
       agentsRefreshInterval.current = setInterval(() => {
-        fetchAgents(selectedAccountId ?? undefined)
+        fetchAgents()
       }, 30000)
     } else {
       if (agentsRefreshInterval.current) {
@@ -116,22 +145,107 @@ export default function DiscoveryPage() {
         clearInterval(agentsRefreshInterval.current)
       }
     }
-  }, [tab, selectedAccountId, fetchAgents])
+  }, [tab, fetchAgents])
 
-  async function handleSync() {
+  const healthyAgents = agents.filter((agent) => agent.status === 'healthy')
+
+  function pollScanJobs(jobIds: string[]) {
+    if (scanPollRef.current) {
+      clearInterval(scanPollRef.current)
+    }
+    const pending = new Set(jobIds)
+    let attempts = 0
+    scanPollRef.current = setInterval(async () => {
+      attempts += 1
+      const results = await Promise.allSettled(Array.from(pending).map((id) => getJob(id)))
+      const updatedJobs: SyncJob[] = []
+      results.forEach((result) => {
+        if (result.status === 'fulfilled') {
+          const job = result.value
+          updatedJobs.push(job)
+          if (job.status === 'completed' || job.status === 'failed') {
+            pending.delete(job.id)
+          }
+        }
+      })
+      if (updatedJobs.length > 0) {
+        setTrackedScanJobs((current) => mergeJobs(current, updatedJobs))
+      }
+      if (selectedAccountId) {
+        fetchJobs(selectedAccountId)
+      }
+      if (pending.size === 0 || attempts >= 40) {
+        if (scanPollRef.current) {
+          clearInterval(scanPollRef.current)
+          scanPollRef.current = null
+        }
+        fetchAccounts()
+        loadResources()
+        if (selectedAccountId) {
+          fetchJobs(selectedAccountId)
+        }
+      }
+    }, 3000)
+  }
+
+  async function handleSync(agentIdOverride?: string) {
     if (!selectedAccountId) return
+    setScanLoading(true)
     try {
-      const job = await triggerSync(selectedAccountId)
-      showToast(
-        job.status === 'completed'
-          ? `Sync complete: ${job.resources_found} resources found`
-          : `Sync ${job.status}${job.error_message ? ': ' + job.error_message : ''}`,
-        job.status === 'completed' ? 'success' : 'error',
-      )
+      const targetAgentId = agentIdOverride ?? selectedScanAgentId
+      const response =
+        targetAgentId === 'all' && healthyAgents.length > 0
+          ? await triggerSync({ allAgents: true })
+          : targetAgentId !== 'all'
+            ? await triggerSync({ agentId: targetAgentId })
+            : await triggerSync({ accountId: selectedAccountId })
+
+      const queuedJobs = 'items' in response ? response.items : [response]
+      setTrackedScanJobs((current) => mergeJobs(current, queuedJobs))
+      const activeJobs = queuedJobs.filter((job) => job.status === 'pending' || job.status === 'running')
+      if (activeJobs.length > 0) {
+        showToast(
+          activeJobs.length === 1
+            ? 'Scan queued for connected agent'
+            : `Scans queued for ${activeJobs.length} connected agents`,
+          'success',
+        )
+        setTab('sync')
+        pollScanJobs(activeJobs.map((job) => job.id))
+      } else {
+        const job = queuedJobs[0]
+        showToast(
+          job?.status === 'completed'
+            ? `Scan complete: ${job.resources_found} resources found`
+            : `Scan ${job?.status ?? 'requested'}${job?.error_message ? ': ' + job.error_message : ''}`,
+          job?.status === 'failed' ? 'error' : 'success',
+        )
+      }
+      fetchAccounts()
       loadResources()
       fetchJobs(selectedAccountId)
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Sync failed', 'error')
+    } finally {
+      setScanLoading(false)
+    }
+  }
+
+  async function handleImportSchema() {
+    if (!selectedAccountId) return
+    setImportLoading(true)
+    try {
+      const result = await importDiscoveredSchema(selectedAccountId)
+      const detail = result.errors.length > 0 ? ` (${result.errors.length} warning${result.errors.length === 1 ? '' : 's'})` : ''
+      showToast(
+        `Imported ${result.pools_created} pools and linked ${result.resources_linked} resources${detail}`,
+        result.errors.length > 0 ? 'info' : 'success',
+      )
+      loadResources()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Import failed', 'error')
+    } finally {
+      setImportLoading(false)
     }
   }
 
@@ -189,7 +303,7 @@ export default function DiscoveryPage() {
               className="inline-flex items-center gap-2 rounded bg-green-600 hover:bg-green-700 text-white px-4 py-2 text-sm"
             >
               <Wand2 className="w-4 h-4" />
-              Plan Discovery
+              Set Up Discovery
             </button>
           </div>
           <SetupGuide defaultOpen />
@@ -242,14 +356,37 @@ export default function DiscoveryPage() {
             className="flex items-center gap-2 rounded bg-green-600 hover:bg-green-700 text-white px-4 py-1.5 text-sm"
           >
             <Wand2 className="w-4 h-4" />
-            Plan Discovery
+            Add Agent
           </button>
           <button
-            onClick={handleSync}
-            className="flex items-center gap-2 rounded bg-blue-600 hover:bg-blue-700 text-white px-4 py-1.5 text-sm"
+            onClick={handleImportSchema}
+            disabled={importLoading}
+            className="flex items-center gap-2 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-1.5 text-sm disabled:opacity-50"
           >
-            <RefreshCw className="w-4 h-4" />
-            Sync Now
+            {importLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <UploadCloud className="w-4 h-4" />}
+            Import Schema
+          </button>
+          <select
+            value={selectedScanAgentId}
+            onChange={(e) => setSelectedScanAgentId(e.target.value)}
+            className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-1.5 text-sm"
+          >
+            <option value="all">
+              {healthyAgents.length > 0 ? `All connected agents (${healthyAgents.length})` : 'Selected account'}
+            </option>
+            {agents.map((agent) => (
+              <option key={agent.id} value={agent.id} disabled={agent.status !== 'healthy'}>
+                {agent.name} ({agent.status})
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={() => void handleSync()}
+            disabled={scanLoading}
+            className="flex items-center gap-2 rounded bg-blue-600 hover:bg-blue-700 text-white px-4 py-1.5 text-sm disabled:opacity-50"
+          >
+            {scanLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
+            Scan Now
           </button>
         </div>
       </div>
@@ -323,7 +460,7 @@ export default function DiscoveryPage() {
       )}
 
       {tab === 'sync' && (
-        <SyncTab jobs={jobs} loading={jobsLoading} error={jobsError} />
+        <SyncTab jobs={mergeJobs(jobs, trackedScanJobs)} agents={agents} loading={jobsLoading} error={jobsError} />
       )}
 
       {tab === 'agents' && (
@@ -331,6 +468,10 @@ export default function DiscoveryPage() {
           agents={agents}
           loading={agentsLoading}
           error={agentsError}
+          onScan={(agentId) => {
+            setSelectedScanAgentId(agentId)
+            void handleSync(agentId)
+          }}
         />
       )}
 
@@ -339,6 +480,10 @@ export default function DiscoveryPage() {
           accounts={accounts}
           onAccountCreated={fetchAccounts}
           onClose={() => setShowWizard(false)}
+          onComplete={() => {
+            setTab('agents')
+            fetchAgents()
+          }}
         />
       )}
     </div>
@@ -542,10 +687,12 @@ function ResourcesTab({
 
 function SyncTab({
   jobs,
+  agents,
   loading,
   error,
 }: {
   jobs: SyncJob[]
+  agents: DiscoveryAgent[]
   loading: boolean
   error: string | null
 }) {
@@ -585,6 +732,9 @@ function SyncTab({
               Started
             </th>
             <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
+              Source
+            </th>
+            <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
               Found
             </th>
             <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
@@ -612,6 +762,13 @@ function SyncTab({
               </td>
               <td className="px-4 py-2 text-gray-600 dark:text-gray-400">
                 {j.started_at ? formatTimeAgo(j.started_at) : '-'}
+              </td>
+              <td className="px-4 py-2 text-gray-600 dark:text-gray-400">
+                {j.source === 'agent' ? (
+                  agents.find((agent) => agent.id === j.agent_id)?.name || 'agent'
+                ) : (
+                  'server'
+                )}
               </td>
               <td className="px-4 py-2 text-gray-900 dark:text-gray-100">
                 {j.resources_found}
@@ -665,10 +822,12 @@ function AgentsTab({
   agents,
   loading,
   error,
+  onScan,
 }: {
   agents: DiscoveryAgent[]
   loading: boolean
   error: string | null
+  onScan: (agentId: string) => void
 }) {
   if (error) {
     return (
@@ -752,6 +911,9 @@ CLOUDPAM_ACCOUNT_ID=1 \\
             <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
               Last Seen
             </th>
+            <th className="px-4 py-2 text-right text-gray-600 dark:text-gray-400 font-medium">
+              Actions
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -774,6 +936,16 @@ CLOUDPAM_ACCOUNT_ID=1 \\
               </td>
               <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
                 {formatTimeAgo(agent.last_seen_at)}
+              </td>
+              <td className="px-4 py-2 text-right">
+                <button
+                  onClick={() => onScan(agent.id)}
+                  disabled={agent.status !== 'healthy'}
+                  className="inline-flex items-center gap-1.5 rounded bg-blue-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300 dark:disabled:bg-blue-900"
+                >
+                  <RefreshCw className="w-3.5 h-3.5" />
+                  Scan
+                </button>
               </td>
             </tr>
           ))}

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,10 +12,10 @@
         }
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-CS6LBAas.js"></script>
+    <script type="module" crossorigin src="/assets/index-bwr02AJv.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-cLTP9fnK.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-T9A-j9BC.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-UTkvOfIH.css">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-em_AXDBH.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-BUxQ_jbM.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

This PR tightens the Discovery UI and agent scan workflow so operators can move through the full lifecycle from agent setup to scanning to importing discovered address space into CloudPAM.

This is tracked as the minor release changelog entry `0.14.0 - 2026-05-28`.

The main behavior changes are:

- `Scan Now` now initiates work instead of appearing inert when agents are connected.
- The scan action defaults to all healthy connected agents.
- Operators can select a specific healthy agent and scan only that agent.
- If no healthy agent is available, the selected-account server-side scan path still works as the fallback.
- Queued/running agent scans are surfaced immediately in Sync History and polled until completion.
- Discovered VPC and subnet resources can now be imported into the managed IP schema as discovered-source pools.

## Detailed Changes

### Discovery scan orchestration

- Extended `POST /api/v1/discovery/sync` to support:
  - selected account scan via the existing `account_id` request shape
  - single-agent scan via `agent_id`
  - all-agent scan via `all_agents: true`
- Added backend queueing for all healthy agents, creating one pending sync job per agent.
- Preserved the existing server-local fallback when no healthy agent is available for the selected account.
- Kept sync job records compatible with the existing heartbeat claim flow.

### Discovery schema import

- Added `POST /api/v1/discovery/import`.
- Imports active discovered VPC and subnet resources into `pools`.
- Creates pools with `source: discovered`, active status, account assignment, discovery metadata tags, and VPC/subnet hierarchy where parent discovery data is available.
- Links discovered resources back to newly created or matching existing pools.
- Skips already-linked, non-CIDR, unsupported, or invalid resources and reports warnings in the response.

### UI/UX

- Renamed the wizard surface from `Plan Discovery` to `Set Up Discovery` / `Add Agent`.
- Added `Scan Now` with loading state.
- Added an agent selector:
  - all connected agents
  - individual healthy agent
  - selected account/server fallback when no healthy agent is connected
- Added `Import Schema` to import scanned VPC/subnet resources into managed pools.
- Added polling for queued/running agent scan jobs.
- Added optimistic local tracking so queued jobs show immediately in Sync History.
- Added scan source display in Sync History, showing `server` or the agent name.
- Added a per-agent `Scan` action in the Agents tab.
- Refreshes accounts after scans so AWS Organization ingest-created accounts appear without a manual refresh.

### Agent setup/config

- Org-mode setup now requires a management account so bootstrap registration and heartbeat state have a valid CloudPAM account.
- Agent config validation now requires a positive `account_id` for all modes.
- Generated Docker examples now use `ghcr.io/badgerops/cloudpam/agent:latest`.

### Changelog

- Added detailed `0.14.0` minor release entries under `Added`, `Changed`, and `Fixed`.
- Removed the `Unreleased` section in line with the repo convention that every changelog touch is a semver update.

## Verification

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./...`
- `npx tsc -b`
- `npm run build`

Note: the production UI build required write access to `web/dist/assets`, so it was run with elevated write permission after the sandbox reported that directory as read-only to Vite.
