### PR TITLE
Discovery: stabilize agent identity

### DIFF
--- a/cmd/cloudpam-agent/config.go
+++ b/cmd/cloudpam-agent/config.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 
 	"cloudpam/internal/domain"
 
@@ -29,6 +33,8 @@ type Config struct {
 	ServerURL         string        `yaml:"server_url"`
 	APIKey            string        `yaml:"api_key"`
 	AgentName         string        `yaml:"agent_name"`
+	AgentID           string        `yaml:"agent_id"`
+	AgentIDFile       string        `yaml:"agent_id_file"`
 	AccountID         int64         `yaml:"account_id"`
 	SyncInterval      time.Duration `yaml:"sync_interval"`
 	HeartbeatInterval time.Duration `yaml:"heartbeat_interval"`
@@ -76,10 +82,18 @@ func LoadConfig(path string) (*Config, error) {
 	if v := os.Getenv("CLOUDPAM_AGENT_NAME"); v != "" {
 		cfg.AgentName = v
 	}
+	if v := os.Getenv("CLOUDPAM_AGENT_ID"); v != "" {
+		cfg.AgentID = v
+	}
+	if v := os.Getenv("CLOUDPAM_AGENT_ID_FILE"); v != "" {
+		cfg.AgentIDFile = v
+	}
 	if v := os.Getenv("CLOUDPAM_ACCOUNT_ID"); v != "" {
-		if id, err := strconv.ParseInt(v, 10, 64); err == nil {
-			cfg.AccountID = id
+		id, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CLOUDPAM_ACCOUNT_ID: %w", err)
 		}
+		cfg.AccountID = id
 	}
 	if v := os.Getenv("CLOUDPAM_SYNC_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
@@ -121,6 +135,61 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func (c *Config) ResolveAgentID() (uuid.UUID, error) {
+	if strings.TrimSpace(c.AgentID) != "" {
+		id, err := uuid.Parse(strings.TrimSpace(c.AgentID))
+		if err != nil {
+			return uuid.Nil, fmt.Errorf("invalid agent_id: %w", err)
+		}
+		return id, nil
+	}
+
+	if strings.TrimSpace(c.AgentIDFile) != "" {
+		id, err := readOrCreateAgentIDFile(strings.TrimSpace(c.AgentIDFile))
+		if err != nil {
+			return uuid.Nil, err
+		}
+		return id, nil
+	}
+
+	return deterministicAgentID(c), nil
+}
+
+func readOrCreateAgentIDFile(path string) (uuid.UUID, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		id, parseErr := uuid.Parse(strings.TrimSpace(string(data)))
+		if parseErr != nil {
+			return uuid.Nil, fmt.Errorf("parse agent_id_file %s: %w", path, parseErr)
+		}
+		return id, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return uuid.Nil, fmt.Errorf("read agent_id_file %s: %w", path, err)
+	}
+
+	id := uuid.New()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return uuid.Nil, fmt.Errorf("create agent_id_file directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(id.String()+"\n"), 0o600); err != nil {
+		return uuid.Nil, fmt.Errorf("write agent_id_file %s: %w", path, err)
+	}
+	return id, nil
+}
+
+func deterministicAgentID(c *Config) uuid.UUID {
+	seed := strings.Join([]string{c.ServerURL, c.AgentName, strconv.FormatInt(c.AccountID, 10)}, "\x00")
+	sum := sha256.Sum256([]byte(seed))
+	sum[6] = (sum[6] & 0x0f) | 0x40
+	sum[8] = (sum[8] & 0x3f) | 0x80
+	id, err := uuid.FromBytes(sum[:16])
+	if err != nil {
+		return uuid.New()
+	}
+	return id
 }
 
 // Validate checks that required configuration fields are set.

--- a/cmd/cloudpam-agent/config_test.go
+++ b/cmd/cloudpam-agent/config_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestResolveAgentIDUsesExplicitID(t *testing.T) {
+	want := uuid.New()
+	cfg := &Config{AgentID: "  " + want.String() + "  "}
+
+	got, err := cfg.ResolveAgentID()
+	if err != nil {
+		t.Fatalf("ResolveAgentID: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}
+
+func TestResolveAgentIDUsesExistingFile(t *testing.T) {
+	want := uuid.New()
+	path := filepath.Join(t.TempDir(), "agent-id")
+	if err := os.WriteFile(path, []byte(want.String()+"\n"), 0o600); err != nil {
+		t.Fatalf("write agent id file: %v", err)
+	}
+
+	got, err := (&Config{AgentIDFile: path}).ResolveAgentID()
+	if err != nil {
+		t.Fatalf("ResolveAgentID: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}
+
+func TestResolveAgentIDCreatesStableFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "agent-id")
+	cfg := &Config{AgentIDFile: path}
+
+	first, err := cfg.ResolveAgentID()
+	if err != nil {
+		t.Fatalf("first ResolveAgentID: %v", err)
+	}
+	if first == uuid.Nil {
+		t.Fatal("expected generated agent id")
+	}
+
+	second, err := cfg.ResolveAgentID()
+	if err != nil {
+		t.Fatalf("second ResolveAgentID: %v", err)
+	}
+	if second != first {
+		t.Fatalf("expected stable id %s, got %s", first, second)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated id file: %v", err)
+	}
+	if string(data) != first.String()+"\n" {
+		t.Fatalf("unexpected id file contents %q", string(data))
+	}
+}
+
+func TestResolveAgentIDDeterministicFallback(t *testing.T) {
+	cfg := &Config{
+		ServerURL: "https://cloudpam.example.com",
+		APIKey:    "cpk_test",
+		AgentName: "aws-prod",
+		AccountID: 125672604241,
+	}
+
+	first, err := cfg.ResolveAgentID()
+	if err != nil {
+		t.Fatalf("first ResolveAgentID: %v", err)
+	}
+	second, err := cfg.ResolveAgentID()
+	if err != nil {
+		t.Fatalf("second ResolveAgentID: %v", err)
+	}
+	if first != second {
+		t.Fatalf("expected deterministic id %s, got %s", first, second)
+	}
+
+	cfg.APIKey = "cpk_rotated"
+	rotatedKeyID, err := cfg.ResolveAgentID()
+	if err != nil {
+		t.Fatalf("rotated-key ResolveAgentID: %v", err)
+	}
+	if rotatedKeyID != first {
+		t.Fatalf("fallback id should not depend on API key: expected %s, got %s", first, rotatedKeyID)
+	}
+}

--- a/cmd/cloudpam-agent/main.go
+++ b/cmd/cloudpam-agent/main.go
@@ -43,9 +43,12 @@ func main() {
 		"heartbeat_interval", cfg.HeartbeatInterval,
 	)
 
-	// Generate agent ID
-	agentID := uuid.New()
-	logger.Info("agent id generated", "agent_id", agentID)
+	agentID, err := cfg.ResolveAgentID()
+	if err != nil {
+		logger.Error("failed to resolve agent id", "error", err)
+		os.Exit(1)
+	}
+	logger.Info("agent id resolved", "agent_id", agentID)
 
 	// Get hostname
 	hostname, _ := os.Hostname()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to CloudPAM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-05-28
+
+### Added
+- Discovery agents can now be deleted from the Agents tab or via `DELETE /api/v1/discovery/agents/{id}` for cleaning up retired or duplicate agent records.
+
+### Changed
+- Discovery agents now resolve a stable identity from explicit config/env, a host-side `agent_id_file`, or a deterministic fallback so process restarts reuse the same server-side agent record.
+- Generated agent examples now include `CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id`, with Docker examples mounting `/var/lib/cloudpam-agent`, so host deployments persist agent identity across restarts.
+
+### Fixed
+- Discovery agents no longer create a new server-side agent record each time the process restarts with the same persisted or deterministic identity inputs.
+
+### Security
+- Deterministic fallback agent IDs now derive only from non-secret identity fields and no longer hash API key material.
+
 ## [0.14.0] - 2026-05-28
 
 ### Added

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -161,6 +161,7 @@ Save the `token` value — it's shown only once.
 
 ```bash
 CLOUDPAM_BOOTSTRAP_TOKEN=eyJhZ2VudF9uYW1lIjoi... \
+CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id \
 CLOUDPAM_ACCOUNT_ID=1 \
 ./cloudpam-agent
 ```
@@ -181,6 +182,7 @@ You can also configure the agent explicitly using environment variables or a YAM
 CLOUDPAM_SERVER_URL=https://cloudpam.example.com \
 CLOUDPAM_API_KEY=cpk_abc123... \
 CLOUDPAM_AGENT_NAME=prod-us-east-1 \
+CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id \
 CLOUDPAM_ACCOUNT_ID=1 \
 CLOUDPAM_AWS_REGIONS=us-east-1,us-west-2 \
 ./cloudpam-agent
@@ -193,6 +195,7 @@ CLOUDPAM_AWS_REGIONS=us-east-1,us-west-2 \
 server_url: https://cloudpam.example.com
 api_key: cpk_abc123...
 agent_name: prod-us-east-1
+agent_id_file: /var/lib/cloudpam-agent/agent-id
 account_id: 1
 aws_regions:
   - us-east-1
@@ -212,6 +215,8 @@ heartbeat_interval: 1m
 | `server_url` | `CLOUDPAM_SERVER_URL` | (required) | CloudPAM server URL |
 | `api_key` | `CLOUDPAM_API_KEY` | (required) | API key with `discovery:write` scope |
 | `agent_name` | `CLOUDPAM_AGENT_NAME` | (required) | Human-readable agent name |
+| `agent_id` | `CLOUDPAM_AGENT_ID` | | Explicit discovery agent UUID |
+| `agent_id_file` | `CLOUDPAM_AGENT_ID_FILE` | deterministic fallback | Host-side file used to persist a generated discovery agent UUID |
 | `account_id` | `CLOUDPAM_ACCOUNT_ID` | (required) | CloudPAM account ID to discover for |
 | `bootstrap_token` | `CLOUDPAM_BOOTSTRAP_TOKEN` | | Base64 provisioning bundle (replaces server_url, api_key, agent_name) |
 | `aws_regions` | `CLOUDPAM_AWS_REGIONS` | SDK default | Comma-separated AWS regions |
@@ -229,6 +234,8 @@ When `bootstrap_token` is set and `api_key` is not, the token is decoded and its
 docker build -f deploy/docker/Dockerfile.agent -t cloudpam-agent .
 
 docker run -e CLOUDPAM_BOOTSTRAP_TOKEN=eyJhZ2VudF9uYW1lIjoi... \
+           -v /var/lib/cloudpam-agent:/var/lib/cloudpam-agent \
+           -e CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id \
            -e CLOUDPAM_ACCOUNT_ID=1 \
            -e AWS_REGION=us-east-1 \
            cloudpam-agent

--- a/internal/api/bootstrap_handlers.go
+++ b/internal/api/bootstrap_handlers.go
@@ -267,6 +267,32 @@ func (d *DiscoveryServer) handleRejectAgent(w http.ResponseWriter, r *http.Reque
 	})
 }
 
+func (d *DiscoveryServer) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		w.Header().Set("Allow", http.MethodDelete)
+		d.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	idStr := strings.TrimPrefix(r.URL.Path, "/api/v1/discovery/agents/")
+	agentID, err := uuid.Parse(strings.TrimRight(idStr, "/"))
+	if err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid agent id", "")
+		return
+	}
+
+	if err := d.store.DeleteAgent(r.Context(), agentID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			d.srv.writeErr(r.Context(), w, http.StatusNotFound, "agent not found", "")
+			return
+		}
+		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "delete agent failed", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
 // handleAgentsSubroutes dispatches /api/v1/discovery/agents/ subroutes.
 // Handles: /{id}, /{id}/approve, /{id}/reject, /register, /provision, /heartbeat
 func (d *DiscoveryServer) handleAgentsSubroutes(w http.ResponseWriter, r *http.Request) {
@@ -284,6 +310,8 @@ func (d *DiscoveryServer) handleAgentsSubroutes(w http.ResponseWriter, r *http.R
 		d.handleApproveAgent(w, r)
 	case strings.HasSuffix(path, "/reject"):
 		d.handleRejectAgent(w, r)
+	case r.Method == http.MethodDelete:
+		d.handleDeleteAgent(w, r)
 	default:
 		d.handleGetAgent(w, r)
 	}

--- a/internal/api/bootstrap_handlers_test.go
+++ b/internal/api/bootstrap_handlers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	stdhttp "net/http"
 	"net/http/httptest"
 	"strings"
@@ -281,5 +282,30 @@ func TestAgentApproveReject(t *testing.T) {
 	// Non-existent agent
 	doJSON(t, discSrv.srv.mux, stdhttp.MethodPost,
 		"/api/v1/discovery/agents/"+uuid.New().String()+"/approve", "",
+		stdhttp.StatusNotFound)
+}
+
+func TestDeleteAgent(t *testing.T) {
+	discSrv, _, ds, _ := setupDiscoveryTestServer()
+
+	agentID := uuid.New()
+	if err := ds.UpsertAgent(t.Context(), domain.DiscoveryAgent{
+		ID:        agentID,
+		Name:      "old-agent",
+		AccountID: 1,
+	}); err != nil {
+		t.Fatalf("upsert agent: %v", err)
+	}
+
+	doJSON(t, discSrv.srv.mux, stdhttp.MethodDelete,
+		"/api/v1/discovery/agents/"+agentID.String(), "",
+		stdhttp.StatusOK)
+
+	if _, err := ds.GetAgent(t.Context(), agentID); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after delete, got %v", err)
+	}
+
+	doJSON(t, discSrv.srv.mux, stdhttp.MethodDelete,
+		"/api/v1/discovery/agents/"+agentID.String(), "",
 		stdhttp.StatusNotFound)
 }

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -70,6 +70,7 @@ func (d *DiscoveryServer) protectedAgentsSubroutes(logger *slog.Logger) http.Han
 	readMW := RequirePermissionMiddleware(auth.ResourceDiscovery, auth.ActionRead, logger)
 	createMW := RequirePermissionMiddleware(auth.ResourceDiscovery, auth.ActionCreate, logger)
 	updateMW := RequirePermissionMiddleware(auth.ResourceDiscovery, auth.ActionUpdate, logger)
+	deleteMW := RequirePermissionMiddleware(auth.ResourceDiscovery, auth.ActionDelete, logger)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/api/v1/discovery/agents/")
@@ -86,6 +87,8 @@ func (d *DiscoveryServer) protectedAgentsSubroutes(logger *slog.Logger) http.Han
 			createMW(http.HandlerFunc(d.handleAgentHeartbeat)).ServeHTTP(w, r)
 		case strings.HasSuffix(path, "/approve"), strings.HasSuffix(path, "/reject"):
 			updateMW(http.HandlerFunc(d.handleAgentsSubroutes)).ServeHTTP(w, r)
+		case r.Method == http.MethodDelete:
+			deleteMW(http.HandlerFunc(d.handleDeleteAgent)).ServeHTTP(w, r)
 		default:
 			readMW(http.HandlerFunc(d.handleGetAgent)).ServeHTTP(w, r)
 		}
@@ -800,8 +803,8 @@ func (d *DiscoveryServer) handleAgentHeartbeat(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if req.Name == "" || req.AccountID < 1 {
-		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "name and account_id are required", "")
+	if req.AgentID == uuid.Nil || req.Name == "" || req.AccountID < 1 {
+		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "agent_id, name, and account_id are required", "")
 		return
 	}
 

--- a/internal/storage/discovery.go
+++ b/internal/storage/discovery.go
@@ -54,6 +54,9 @@ type DiscoveryStore interface {
 	// GetAgent returns a discovery agent by ID.
 	GetAgent(ctx context.Context, id uuid.UUID) (*domain.DiscoveryAgent, error)
 
+	// DeleteAgent deletes a discovery agent by ID.
+	DeleteAgent(ctx context.Context, id uuid.UUID) error
+
 	// ListAgents returns all discovery agents, optionally filtered by account ID.
 	ListAgents(ctx context.Context, accountID int64) ([]domain.DiscoveryAgent, error)
 }

--- a/internal/storage/discovery_memory.go
+++ b/internal/storage/discovery_memory.go
@@ -289,6 +289,23 @@ func (m *MemoryDiscoveryStore) GetAgent(_ context.Context, id uuid.UUID) (*domai
 	return &a, nil
 }
 
+func (m *MemoryDiscoveryStore) DeleteAgent(_ context.Context, id uuid.UUID) error {
+	m.store.mu.Lock()
+	defer m.store.mu.Unlock()
+
+	if _, ok := m.agents[id]; !ok {
+		return ErrNotFound
+	}
+	delete(m.agents, id)
+	for jobID, job := range m.syncJobs {
+		if job.AgentID != nil && *job.AgentID == id {
+			job.AgentID = nil
+			m.syncJobs[jobID] = job
+		}
+	}
+	return nil
+}
+
 func (m *MemoryDiscoveryStore) ListAgents(_ context.Context, accountID int64) ([]domain.DiscoveryAgent, error) {
 	m.store.mu.RLock()
 	defer m.store.mu.RUnlock()

--- a/internal/storage/sqlite/discovery.go
+++ b/internal/storage/sqlite/discovery.go
@@ -487,6 +487,18 @@ func (s *Store) GetAgent(ctx context.Context, id uuid.UUID) (*domain.DiscoveryAg
 	return &a, nil
 }
 
+func (s *Store) DeleteAgent(ctx context.Context, id uuid.UUID) error {
+	res, err := s.db.ExecContext(ctx, "DELETE FROM discovery_agents WHERE id = ?", id.String())
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
+}
+
 // ListAgents returns all discovery agents, optionally filtered by account ID.
 func (s *Store) ListAgents(ctx context.Context, accountID int64) ([]domain.DiscoveryAgent, error) {
 	query := "SELECT id, name, account_id, api_key_id, version, hostname, last_seen_at, created_at FROM discovery_agents"

--- a/ui/src/components/DiscoveryWizard.tsx
+++ b/ui/src/components/DiscoveryWizard.tsx
@@ -179,12 +179,14 @@ export default function DiscoveryWizard({ accounts, onAccountCreated, onClose, o
   // Single-account configs
   const shellConfigSingle = `#!/bin/bash
 export CLOUDPAM_BOOTSTRAP_TOKEN="${token}"
+export CLOUDPAM_AGENT_ID_FILE="/var/lib/cloudpam-agent/agent-id"
 export CLOUDPAM_ACCOUNT_ID=${accountId}
 export CLOUDPAM_AWS_REGIONS="${accountRegions.join(',')}"
 ./cloudpam-agent`
 
   const yamlConfigSingle = `server_url: "${serverUrl}"
 bootstrap_token: "${token}"
+agent_id_file: "/var/lib/cloudpam-agent/agent-id"
 account_id: ${accountId}
 agent_name: "${agentNameFinal}"
 sync_interval: "15m"
@@ -194,6 +196,7 @@ aws_regions: [${accountRegions.map(r => `"${r}"`).join(', ')}]`
   // Org-mode configs
   const shellConfigOrg = `#!/bin/bash
 export CLOUDPAM_BOOTSTRAP_TOKEN="${token}"
+export CLOUDPAM_AGENT_ID_FILE="/var/lib/cloudpam-agent/agent-id"
 export CLOUDPAM_ACCOUNT_ID=${accountId}
 export AWS_REGION="${orgRegions[0] ?? 'us-east-1'}"
 export AWS_DEFAULT_REGION="${orgRegions[0] ?? 'us-east-1'}"
@@ -206,6 +209,7 @@ export CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS="${orgExclude.join(',')}"` : ''}
 
   const yamlConfigOrg = `server_url: "${serverUrl}"
 bootstrap_token: "${token}"
+agent_id_file: "/var/lib/cloudpam-agent/agent-id"
 account_id: ${accountId}
 agent_name: "${agentNameFinal}"
 sync_interval: "15m"
@@ -226,6 +230,7 @@ resource "null_resource" "cloudpam_agent" {
   provisioner "local-exec" {
     command = <<-EOT
       CLOUDPAM_BOOTSTRAP_TOKEN=\${var.cloudpam_bootstrap_token} \\
+      CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id \\
       CLOUDPAM_ACCOUNT_ID=${accountId} \\
       CLOUDPAM_AWS_REGIONS=${accountRegions.join(',')} \\
       ./cloudpam-agent
@@ -242,6 +247,7 @@ resource "null_resource" "cloudpam_agent" {
   provisioner "local-exec" {
     command = <<-EOT
       CLOUDPAM_BOOTSTRAP_TOKEN=\${var.cloudpam_bootstrap_token} \\
+      CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id \\
       CLOUDPAM_ACCOUNT_ID=${accountId} \\
       AWS_REGION=${orgRegions[0] ?? 'us-east-1'} \\
       AWS_DEFAULT_REGION=${orgRegions[0] ?? 'us-east-1'} \\
@@ -257,14 +263,18 @@ resource "null_resource" "cloudpam_agent" {
 
   const dockerConfigSingle = `docker run -d \\
   --name cloudpam-agent \\
+  -v /var/lib/cloudpam-agent:/var/lib/cloudpam-agent \\
   -e CLOUDPAM_BOOTSTRAP_TOKEN="${token}" \\
+  -e CLOUDPAM_AGENT_ID_FILE="/var/lib/cloudpam-agent/agent-id" \\
   -e CLOUDPAM_ACCOUNT_ID=${accountId} \\
   -e CLOUDPAM_AWS_REGIONS="${accountRegions.join(',')}" \\
   ghcr.io/badgerops/cloudpam/agent:latest`
 
   const dockerConfigOrg = `docker run -d \\
   --name cloudpam-agent \\
+  -v /var/lib/cloudpam-agent:/var/lib/cloudpam-agent \\
   -e CLOUDPAM_BOOTSTRAP_TOKEN="${token}" \\
+  -e CLOUDPAM_AGENT_ID_FILE="/var/lib/cloudpam-agent/agent-id" \\
   -e CLOUDPAM_ACCOUNT_ID=${accountId} \\
   -e AWS_REGION="${orgRegions[0] ?? 'us-east-1'}" \\
   -e AWS_DEFAULT_REGION="${orgRegions[0] ?? 'us-east-1'}" \\

--- a/ui/src/hooks/useDiscovery.ts
+++ b/ui/src/hooks/useDiscovery.ts
@@ -168,5 +168,9 @@ export function useDiscoveryAgents() {
     }
   }, [])
 
-  return { agents, loading, error, fetch }
+  const deleteAgent = useCallback(async (agentId: string) => {
+    await del(`/api/v1/discovery/agents/${agentId}`)
+  }, [])
+
+  return { agents, loading, error, fetch, deleteAgent }
 }

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -12,6 +12,7 @@ import {
   Wand2,
   Loader2,
   UploadCloud,
+  Trash2,
 } from 'lucide-react'
 import {
   useDiscoveryResources,
@@ -74,6 +75,7 @@ export default function DiscoveryPage() {
     loading: agentsLoading,
     error: agentsError,
     fetch: fetchAgents,
+    deleteAgent,
   } = useDiscoveryAgents()
   const { showToast } = useToast()
   const agentsRefreshInterval = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -246,6 +248,19 @@ export default function DiscoveryPage() {
       showToast(err instanceof Error ? err.message : 'Import failed', 'error')
     } finally {
       setImportLoading(false)
+    }
+  }
+
+  async function handleDeleteAgent(agent: DiscoveryAgent) {
+    if (!confirm(`Delete discovery agent "${agent.name}"? The agent will reappear if it is still running and heartbeating.`)) {
+      return
+    }
+    try {
+      await deleteAgent(agent.id)
+      showToast('Agent deleted', 'success')
+      fetchAgents()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Delete agent failed', 'error')
     }
   }
 
@@ -472,6 +487,7 @@ export default function DiscoveryPage() {
             setSelectedScanAgentId(agentId)
             void handleSync(agentId)
           }}
+          onDelete={(agent) => void handleDeleteAgent(agent)}
         />
       )}
 
@@ -823,11 +839,13 @@ function AgentsTab({
   loading,
   error,
   onScan,
+  onDelete,
 }: {
   agents: DiscoveryAgent[]
   loading: boolean
   error: string | null
   onScan: (agentId: string) => void
+  onDelete: (agent: DiscoveryAgent) => void
 }) {
   if (error) {
     return (
@@ -879,6 +897,7 @@ function AgentsTab({
                 Deploy the agent with the token:
                 <pre className="mt-1 bg-gray-100 dark:bg-gray-800 rounded px-2 py-1.5 text-xs font-mono overflow-x-auto whitespace-pre">
 {`CLOUDPAM_BOOTSTRAP_TOKEN=<token> \\
+CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id \\
 CLOUDPAM_ACCOUNT_ID=1 \\
 ./cloudpam-agent`}
                 </pre>
@@ -938,14 +957,24 @@ CLOUDPAM_ACCOUNT_ID=1 \\
                 {formatTimeAgo(agent.last_seen_at)}
               </td>
               <td className="px-4 py-2 text-right">
-                <button
-                  onClick={() => onScan(agent.id)}
-                  disabled={agent.status !== 'healthy'}
-                  className="inline-flex items-center gap-1.5 rounded bg-blue-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300 dark:disabled:bg-blue-900"
-                >
-                  <RefreshCw className="w-3.5 h-3.5" />
-                  Scan
-                </button>
+                <div className="inline-flex items-center gap-2">
+                  <button
+                    onClick={() => onScan(agent.id)}
+                    disabled={agent.status !== 'healthy'}
+                    className="inline-flex items-center gap-1.5 rounded bg-blue-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300 dark:disabled:bg-blue-900"
+                  >
+                    <RefreshCw className="w-3.5 h-3.5" />
+                    Scan
+                  </button>
+                  <button
+                    onClick={() => onDelete(agent)}
+                    className="inline-flex h-7 w-7 items-center justify-center rounded border border-red-200 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20"
+                    title="Delete agent"
+                    aria-label={`Delete ${agent.name}`}
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                </div>
               </td>
             </tr>
           ))}

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,10 +12,10 @@
         }
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-bwr02AJv.js"></script>
+    <script type="module" crossorigin src="/assets/index-D5LJH4g0.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-cLTP9fnK.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-icons-em_AXDBH.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BUxQ_jbM.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-BtBYY6is.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

This follow-up fixes discovery agent lifecycle cleanup after PR #175:

- agents now keep a stable server identity across host/process restarts
- old/offline duplicate agents can be deleted from the Agents tab
- `DELETE /api/v1/discovery/agents/{id}` is available for API cleanup
- generated agent setup snippets now persist identity with `CLOUDPAM_AGENT_ID_FILE`

The changelog now has its own patch release section, `0.14.1 - 2026-05-28`; no `Unreleased` section was added.

## Detailed Changes

### Stable Agent Identity

- Added `agent_id` / `CLOUDPAM_AGENT_ID` for explicit UUID configuration.
- Added `agent_id_file` / `CLOUDPAM_AGENT_ID_FILE` for host-side generated UUID persistence.
- The agent now resolves identity in this priority order:
  - explicit configured UUID
  - persisted UUID file, creating it with `0600` mode if missing
  - deterministic UUID fallback from non-secret identity fields: server URL, agent name, and account ID
- Replaced the previous startup behavior that generated a fresh UUID on every process start.
- Heartbeat now rejects missing/nil agent IDs so accidental empty identities cannot create new records.
- `CLOUDPAM_ACCOUNT_ID` parsing now trims whitespace and reports invalid values directly instead of silently falling through to the generic missing-account validation.
- The deterministic fallback no longer includes API key material in the hash seed, resolving the CodeQL sensitive-data hashing finding.

### Agent Cleanup API

- Added `DeleteAgent` to the discovery storage interface.
- Added in-memory and SQLite implementations.
- SQLite deletes from `discovery_agents`; existing sync job rows keep history through the existing `ON DELETE SET NULL` relationship.
- In-memory storage mirrors that behavior by clearing matching sync job `agent_id` pointers.
- Added `DELETE /api/v1/discovery/agents/{id}` with RBAC `discovery:delete` enforcement in protected mode.

### UI/UX

- Added a delete action to each row in the Agents tab.
- The delete action confirms before removal and explains that still-running agents will reappear when they heartbeat.
- The existing scan action remains available for healthy agents.

### Generated Config And Docs

- Updated generated shell, YAML, Terraform, and Docker snippets to include:
  - `CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id`
  - `agent_id_file: "/var/lib/cloudpam-agent/agent-id"`
- Docker snippets now mount `/var/lib/cloudpam-agent` so container replacement does not create a new identity.
- Updated `docs/DISCOVERY.md` configuration reference and examples.

### Changelog

- Added `0.14.1` entries for:
  - delete-agent UI/API support
  - stable agent identity resolution
  - generated persistent identity config examples
  - preventing duplicate agent records on restart
  - removal of API key material from deterministic fallback hashing

## Verification

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./...`
- `(cd ui && npx tsc -b)`
- `(cd ui && npm run build)`
