### PR TITLE
Discovery: fix per-agent scan account resolution

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to CloudPAM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.2] - 2026-05-28
+
+### Fixed
+- Per-agent scans no longer fail with `account not found` when the agent was registered with an AWS account number instead of an internal CloudPAM account ID; scans now use the selected CloudPAM account and can resolve matching `aws:<account-id>` account keys.
+
 ## [0.14.1] - 2026-05-28
 
 ### Added

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -481,15 +481,13 @@ func (d *DiscoveryServer) triggerSync(w http.ResponseWriter, r *http.Request) {
 			d.srv.writeErr(r.Context(), w, http.StatusConflict, "agent is not healthy", "")
 			return
 		}
-		accountID := agent.AccountID
-		if body.AccountID > 0 {
-			accountID = body.AccountID
-		}
-		if _, found, err := d.srv.store.GetAccount(r.Context(), accountID); err != nil {
+		accountID, err := d.resolveAgentSyncAccountID(r.Context(), *agent, body.AccountID)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				d.srv.writeErr(r.Context(), w, http.StatusNotFound, "agent account not found", "")
+				return
+			}
 			d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "account lookup failed", err.Error())
-			return
-		} else if !found {
-			d.srv.writeErr(r.Context(), w, http.StatusNotFound, "account not found", "")
 			return
 		}
 		job, err := d.createAgentSyncJob(r.Context(), accountID, agent.ID)
@@ -566,12 +564,14 @@ func (d *DiscoveryServer) queueAllHealthyAgentSyncs(ctx context.Context) ([]doma
 		if seen[agent.ID] || computeAgentStatus(agent.LastSeenAt, now) != domain.AgentStatusHealthy {
 			continue
 		}
-		if _, found, err := d.srv.store.GetAccount(ctx, agent.AccountID); err != nil {
-			return nil, err
-		} else if !found {
+		accountID, err := d.resolveAgentSyncAccountID(ctx, agent, 0)
+		if errors.Is(err, storage.ErrNotFound) {
 			continue
 		}
-		job, err := d.createAgentSyncJob(ctx, agent.AccountID, agent.ID)
+		if err != nil {
+			return nil, err
+		}
+		job, err := d.createAgentSyncJob(ctx, accountID, agent.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -579,6 +579,35 @@ func (d *DiscoveryServer) queueAllHealthyAgentSyncs(ctx context.Context) ([]doma
 		seen[agent.ID] = true
 	}
 	return jobs, nil
+}
+
+func (d *DiscoveryServer) resolveAgentSyncAccountID(ctx context.Context, agent domain.DiscoveryAgent, requestedAccountID int64) (int64, error) {
+	if requestedAccountID > 0 {
+		if _, found, err := d.srv.store.GetAccount(ctx, requestedAccountID); err != nil {
+			return 0, err
+		} else if !found {
+			return 0, storage.ErrNotFound
+		}
+		return requestedAccountID, nil
+	}
+
+	if agent.AccountID > 0 {
+		if _, found, err := d.srv.store.GetAccount(ctx, agent.AccountID); err != nil {
+			return 0, err
+		} else if found {
+			return agent.AccountID, nil
+		}
+
+		account, err := d.srv.store.GetAccountByKey(ctx, "aws:"+strconv.FormatInt(agent.AccountID, 10))
+		if err == nil {
+			return account.ID, nil
+		}
+		if !errors.Is(err, storage.ErrNotFound) {
+			return 0, err
+		}
+	}
+
+	return 0, storage.ErrNotFound
 }
 
 func (d *DiscoveryServer) selectConnectedAgent(ctx context.Context, accountID int64) *domain.DiscoveryAgent {

--- a/internal/api/org_ingest_test.go
+++ b/internal/api/org_ingest_test.go
@@ -65,6 +65,79 @@ func TestTriggerSyncQueuesHealthyAgent(t *testing.T) {
 	}
 }
 
+func TestTriggerSyncAgentUsesRequestedAccountWhenStoredAccountMissing(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{
+		Key:      "aws:123456789012",
+		Name:     "prod",
+		Provider: "aws",
+	})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	agentID := uuid.New()
+	if err := ds.UpsertAgent(t.Context(), domain.DiscoveryAgent{
+		ID:         agentID,
+		Name:       "org-agent",
+		AccountID:  125672604241,
+		APIKeyID:   "key-1",
+		LastSeenAt: time.Now().UTC(),
+		CreatedAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("upsert agent: %v", err)
+	}
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/sync",
+		`{"agent_id":"`+agentID.String()+`","account_id":`+itoa(account.ID)+`}`, http.StatusOK)
+	var job domain.SyncJob
+	if err := json.Unmarshal(rr.Body.Bytes(), &job); err != nil {
+		t.Fatalf("decode job: %v", err)
+	}
+	if job.AccountID != account.ID {
+		t.Fatalf("AccountID = %d, want %d", job.AccountID, account.ID)
+	}
+	if job.AgentID == nil || *job.AgentID != agentID {
+		t.Fatalf("AgentID = %v, want %s", job.AgentID, agentID)
+	}
+}
+
+func TestTriggerSyncAgentResolvesAWSAccountKeyFallback(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{
+		Key:      "aws:125672604241",
+		Name:     "management",
+		Provider: "aws",
+	})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	agentID := uuid.New()
+	if err := ds.UpsertAgent(t.Context(), domain.DiscoveryAgent{
+		ID:         agentID,
+		Name:       "org-agent",
+		AccountID:  125672604241,
+		APIKeyID:   "key-1",
+		LastSeenAt: time.Now().UTC(),
+		CreatedAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("upsert agent: %v", err)
+	}
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/sync",
+		`{"agent_id":"`+agentID.String()+`"}`, http.StatusOK)
+	var job domain.SyncJob
+	if err := json.Unmarshal(rr.Body.Bytes(), &job); err != nil {
+		t.Fatalf("decode job: %v", err)
+	}
+	if job.AccountID != account.ID {
+		t.Fatalf("AccountID = %d, want %d", job.AccountID, account.ID)
+	}
+}
+
 func TestOrgIngestRefreshesRegisteredAgentLastSeen(t *testing.T) {
 	discSrv, _, ds, _ := setupDiscoveryTestServer()
 

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -199,7 +199,7 @@ export default function DiscoveryPage() {
         targetAgentId === 'all' && healthyAgents.length > 0
           ? await triggerSync({ allAgents: true })
           : targetAgentId !== 'all'
-            ? await triggerSync({ agentId: targetAgentId })
+            ? await triggerSync({ accountId: selectedAccountId, agentId: targetAgentId })
             : await triggerSync({ accountId: selectedAccountId })
 
       const queuedJobs = 'items' in response ? response.items : [response]

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,7 +12,7 @@
         }
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-D5LJH4g0.js"></script>
+    <script type="module" crossorigin src="/assets/index-Ci8z8kRP.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-cLTP9fnK.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-icons-em_AXDBH.js">
     <link rel="stylesheet" crossorigin href="/assets/index-BtBYY6is.css">


### PR DESCRIPTION
## Summary

Fixes the `account not found` modal when clicking `Scan` on a discovery agent whose stored `account_id` is an AWS account number rather than a CloudPAM account row ID.

This is tracked as `0.14.2 - 2026-05-28`.

## Detailed Changes

### Per-Agent Scan Requests

- The Agents tab now sends the currently selected CloudPAM account ID with single-agent scan requests.
- The backend honors that requested CloudPAM account ID when queueing the agent sync job.
- If no account is provided, the backend still uses the agent's stored account ID when it matches a CloudPAM account row.
- If the stored ID is an AWS account number, the backend attempts to resolve `aws:<account-id>` through the account key lookup and queues the job against the matching CloudPAM account.
- All-agent queueing uses the same resolver and skips only agents whose account cannot be resolved.

### Tests

- Added coverage for per-agent scans using an explicit selected CloudPAM account when the stored agent account is not a CloudPAM row.
- Added coverage for resolving an agent stored with AWS account number `125672604241` through a CloudPAM account key `aws:125672604241`.

### Changelog

- Added `0.14.2 - 2026-05-28` with the scan-account-resolution fix.

## Verification

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./...`
- `(cd ui && npx tsc -b)`
- `(cd ui && npm run build)`
