### PR TITLE
UI: fix discovery-linked blocks and pool editing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to CloudPAM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.5] - 2026-05-28
+
+### Added
+- Address Pools now has a real Edit Pool flow from both the pool table and detail panel so name, account, type, status, and description can be updated in place.
+
+### Fixed
+- Allocated Blocks now includes imported or discovery-built top-level VPC and subnet pools instead of hiding them because they have no parent pool.
+- Allocated Blocks responses now include pool type, status, and source metadata so discovered VPCs and subnets render with their actual classification.
+- Pool PATCH requests that omit `account_id` now preserve the existing account assignment instead of accidentally clearing it during name, status, type, or description edits.
+
 ## [0.14.4] - 2026-05-28
 
 ### Added

--- a/internal/api/block_handlers.go
+++ b/internal/api/block_handlers.go
@@ -107,19 +107,22 @@ func (s *Server) handleBlocksList(w http.ResponseWriter, r *http.Request) {
 		ID                 int64     `json:"id"`
 		Name               string    `json:"name"`
 		CIDR               string    `json:"cidr"`
-		ParentID           int64     `json:"parent_id"`
-		ParentName         string    `json:"parent_name"`
+		ParentID           *int64    `json:"parent_id,omitempty"`
+		ParentName         string    `json:"parent_name,omitempty"`
 		AccountID          *int64    `json:"account_id,omitempty"`
 		AccountName        string    `json:"account_name,omitempty"`
 		AccountPlatform    string    `json:"account_platform,omitempty"`
 		AccountTier        string    `json:"account_tier,omitempty"`
 		AccountEnvironment string    `json:"account_environment,omitempty"`
 		AccountRegions     []string  `json:"account_regions,omitempty"`
+		Type               string    `json:"type"`
+		Status             string    `json:"status"`
+		Source             string    `json:"source"`
 		CreatedAt          time.Time `json:"created_at"`
 	}
 	var items []row
 	for _, p := range ps {
-		if p.ParentID == nil {
+		if p.ParentID == nil && p.Type != "vpc" && p.Type != "subnet" {
 			continue
 		}
 		// Filters
@@ -132,18 +135,26 @@ func (s *Server) handleBlocksList(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if len(poolFilter) > 0 {
+			if p.ParentID == nil {
+				continue
+			}
 			if _, ok := poolFilter[*p.ParentID]; !ok {
 				continue
 			}
 		}
 		r := row{
-			ID:         p.ID,
-			Name:       p.Name,
-			CIDR:       p.CIDR,
-			ParentID:   *p.ParentID,
-			ParentName: poolName[*p.ParentID],
-			AccountID:  p.AccountID,
-			CreatedAt:  p.CreatedAt,
+			ID:        p.ID,
+			Name:      p.Name,
+			CIDR:      p.CIDR,
+			ParentID:  p.ParentID,
+			AccountID: p.AccountID,
+			Type:      string(p.Type),
+			Status:    string(p.Status),
+			Source:    string(p.Source),
+			CreatedAt: p.CreatedAt,
+		}
+		if p.ParentID != nil {
+			r.ParentName = poolName[*p.ParentID]
 		}
 		if p.AccountID != nil {
 			if n, ok := accName[*p.AccountID]; ok {

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -122,4 +122,35 @@ func TestImportDiscoveredSchemaCreatesAndLinksPools(t *testing.T) {
 	if vpc.PoolID == nil || subnet.PoolID == nil {
 		t.Fatalf("resources were not linked: vpc=%v subnet=%v", vpc.PoolID, subnet.PoolID)
 	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/blocks?page_size=all", "", http.StatusOK)
+	var blocks struct {
+		Items []struct {
+			ID       int64  `json:"id"`
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Status   string `json:"status"`
+			Source   string `json:"source"`
+			CIDR     string `json:"cidr"`
+			ParentID *int64 `json:"parent_id"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &blocks); err != nil {
+		t.Fatalf("unmarshal blocks: %v", err)
+	}
+	if len(blocks.Items) != 2 {
+		t.Fatalf("len(blocks) = %d, want imported vpc and subnet", len(blocks.Items))
+	}
+	var sawRootVPC, sawSubnet bool
+	for _, block := range blocks.Items {
+		if block.CIDR == "10.0.0.0/16" && block.Type == "vpc" && block.Source == "discovered" && block.ParentID == nil {
+			sawRootVPC = true
+		}
+		if block.CIDR == "10.0.1.0/24" && block.Type == "subnet" && block.Status == "active" && block.ParentID != nil {
+			sawSubnet = true
+		}
+	}
+	if !sawRootVPC || !sawSubnet {
+		t.Fatalf("discovered blocks missing from allocated blocks: %+v", blocks.Items)
+	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -422,6 +422,35 @@ func TestAnalytics_MetadataInBlocks(t *testing.T) {
 	}
 }
 
+func TestPoolPatchPreservesAccountWhenAccountIDIsOmitted(t *testing.T) {
+	srv, _ := setupTestServer()
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:111111111111","name":"Prod"}`, stdhttp.StatusCreated)
+	var account struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &account); err != nil {
+		t.Fatalf("unmarshal account: %v", err)
+	}
+
+	rr = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"prod-vpc","cidr":"10.60.0.0/16","account_id":`+strconv.FormatInt(account.ID, 10)+`,"type":"vpc"}`, stdhttp.StatusCreated)
+	var created poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal pool: %v", err)
+	}
+	if created.AccountID == nil || *created.AccountID != account.ID {
+		t.Fatalf("created account_id = %v, want %d", created.AccountID, account.ID)
+	}
+
+	rr = doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/pools/"+strconv.FormatInt(created.ID, 10), `{"name":"prod-vpc-renamed"}`, stdhttp.StatusOK)
+	var updated poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("unmarshal updated pool: %v", err)
+	}
+	if updated.AccountID == nil || *updated.AccountID != account.ID {
+		t.Fatalf("updated account_id = %v, want %d", updated.AccountID, account.ID)
+	}
+}
+
 func TestBlocks_HostsAndNoExistsElsewhere(t *testing.T) {
 	srv, _ := setupTestServer()
 	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.60.0.0/16"}`, stdhttp.StatusCreated)

--- a/internal/api/pool_handlers.go
+++ b/internal/api/pool_handlers.go
@@ -316,6 +316,17 @@ func (s *Server) handlePoolStats(w http.ResponseWriter, r *http.Request, id int6
 func (s *Server) updatePool(w http.ResponseWriter, r *http.Request, id int64) {
 	ctx := r.Context()
 
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+		s.writeErr(ctx, w, http.StatusBadRequest, "invalid json", "")
+		return
+	}
+	rawBody, err := json.Marshal(raw)
+	if err != nil {
+		s.writeErr(ctx, w, http.StatusBadRequest, "invalid json", "")
+		return
+	}
+
 	var payload struct {
 		AccountID   *int64             `json:"account_id"`
 		Name        *string            `json:"name"`
@@ -324,9 +335,22 @@ func (s *Server) updatePool(w http.ResponseWriter, r *http.Request, id int64) {
 		Description *string            `json:"description"`
 		Tags        *map[string]string `json:"tags"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(rawBody, &payload); err != nil {
 		s.writeErr(ctx, w, http.StatusBadRequest, "invalid json", "")
 		return
+	}
+	accountID := payload.AccountID
+	if _, ok := raw["account_id"]; !ok {
+		current, found, err := s.store.GetPool(ctx, id)
+		if err != nil {
+			s.writeErr(ctx, w, http.StatusInternalServerError, "internal error", err.Error())
+			return
+		}
+		if !found {
+			s.writeErr(ctx, w, http.StatusNotFound, "not found", "")
+			return
+		}
+		accountID = current.AccountID
 	}
 
 	// Validate name if provided
@@ -353,7 +377,7 @@ func (s *Server) updatePool(w http.ResponseWriter, r *http.Request, id int64) {
 
 	update := domain.UpdatePool{
 		Name:        payload.Name,
-		AccountID:   payload.AccountID,
+		AccountID:   accountID,
 		Type:        payload.Type,
 		Status:      payload.Status,
 		Description: payload.Description,

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -132,8 +132,8 @@ export interface Block {
   id: number
   name: string
   cidr: string
-  parent_id: number
-  parent_name: string
+  parent_id?: number | null
+  parent_name?: string
   account_id?: number
   account_name?: string
   account_platform?: string
@@ -142,6 +142,7 @@ export interface Block {
   account_regions?: string[]
   type?: string
   status?: string
+  source?: string
   created_at: string
 }
 

--- a/ui/src/components/PoolDetailPanel.tsx
+++ b/ui/src/components/PoolDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { X } from 'lucide-react'
+import { Pencil, X } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import type { PoolWithStats } from '../api/types'
 import { formatHostCount, getUtilizationColor } from '../utils/format'
@@ -7,9 +7,10 @@ import StatusBadge from './StatusBadge'
 interface PoolDetailPanelProps {
   pool: PoolWithStats
   onClose: () => void
+  onEdit?: () => void
 }
 
-export default function PoolDetailPanel({ pool, onClose }: PoolDetailPanelProps) {
+export default function PoolDetailPanel({ pool, onClose, onEdit }: PoolDetailPanelProps) {
   const navigate = useNavigate()
   const stats = pool.stats
 
@@ -85,12 +86,22 @@ export default function PoolDetailPanel({ pool, onClose }: PoolDetailPanelProps)
 
         {/* Actions */}
         <div className="flex gap-2">
-          <button
-            onClick={() => navigate('/pools')}
-            className="flex-1 px-3 py-2 bg-blue-600 text-white text-sm rounded hover:bg-blue-700"
-          >
-            Manage Pool
-          </button>
+          {onEdit ? (
+            <button
+              onClick={onEdit}
+              className="inline-flex flex-1 items-center justify-center gap-1.5 px-3 py-2 bg-blue-600 text-white text-sm rounded hover:bg-blue-700"
+            >
+              <Pencil className="h-4 w-4" />
+              Edit Pool
+            </button>
+          ) : (
+            <button
+              onClick={() => navigate('/pools')}
+              className="flex-1 px-3 py-2 bg-blue-600 text-white text-sm rounded hover:bg-blue-700"
+            >
+              Manage Pool
+            </button>
+          )}
           <button
             onClick={() => navigate('/audit')}
             className="flex-1 px-3 py-2 border dark:border-gray-600 text-sm dark:text-gray-300 rounded hover:bg-gray-50 dark:hover:bg-gray-700"

--- a/ui/src/pages/PoolsPage.tsx
+++ b/ui/src/pages/PoolsPage.tsx
@@ -1,21 +1,22 @@
 import { useEffect, useState } from 'react'
-import { Plus, Search, Trash2, ChevronRight } from 'lucide-react'
+import { Plus, Search, Trash2, ChevronRight, Pencil, X } from 'lucide-react'
 import { usePools } from '../hooks/usePools'
 import { useAccounts } from '../hooks/useAccounts'
 import { useToast } from '../hooks/useToast'
 import PoolDetailPanel from '../components/PoolDetailPanel'
 import StatusBadge from '../components/StatusBadge'
-import type { Pool, PoolWithStats, CreatePoolRequest, PoolType, PoolStatus } from '../api/types'
+import type { Pool, PoolWithStats, CreatePoolRequest, UpdatePoolRequest, PoolType, PoolStatus } from '../api/types'
 import { formatHostCount, getHostCount, formatTimeAgo } from '../utils/format'
 import { get } from '../api/client'
 
 export default function PoolsPage() {
-  const { pools, loading, error, fetchPools, fetchHierarchy, createPool, deletePool } = usePools()
+  const { pools, loading, error, fetchPools, fetchHierarchy, createPool, updatePool, deletePool } = usePools()
   const { accounts, fetchAccounts } = useAccounts()
   const { showToast } = useToast()
   const [search, setSearch] = useState('')
   const [showCreate, setShowCreate] = useState(false)
   const [selectedPool, setSelectedPool] = useState<PoolWithStats | null>(null)
+  const [editingPool, setEditingPool] = useState<Pool | null>(null)
   const [submitting, setSubmitting] = useState(false)
 
   // Create form state
@@ -72,6 +73,15 @@ export default function PoolsPage() {
     } catch {
       // Fallback to basic pool data
       setSelectedPool({ ...pool, stats: { total_ips: getHostCount(pool.cidr), used_ips: 0, available_ips: getHostCount(pool.cidr), utilization: 0, child_count: 0, direct_children: 0 }, children: [] })
+    }
+  }
+
+  async function handleEditSaved(updated: Pool) {
+    setEditingPool(null)
+    await fetchPools()
+    await fetchHierarchy()
+    if (selectedPool?.id === updated.id) {
+      await handleSelectPool(updated)
     }
   }
 
@@ -246,6 +256,13 @@ export default function PoolsPage() {
                     <td className="px-4 py-2 text-sm text-gray-400 dark:text-gray-500">{formatTimeAgo(p.created_at)}</td>
                     <td className="px-4 py-2 text-right">
                       <button
+                        onClick={() => setEditingPool(p)}
+                        className="text-gray-400 dark:text-gray-500 hover:text-blue-600 dark:hover:text-blue-400 p-1"
+                        title="Edit pool"
+                      >
+                        <Pencil className="w-4 h-4" />
+                      </button>
+                      <button
                         onClick={() => handleSelectPool(p)}
                         className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 p-1"
                         title="View details"
@@ -270,8 +287,158 @@ export default function PoolsPage() {
 
       {/* Detail panel */}
       {selectedPool && (
-        <PoolDetailPanel pool={selectedPool} onClose={() => setSelectedPool(null)} />
+        <PoolDetailPanel
+          pool={selectedPool}
+          onClose={() => setSelectedPool(null)}
+          onEdit={() => setEditingPool(selectedPool)}
+        />
       )}
+
+      {editingPool && (
+        <EditPoolModal
+          pool={editingPool}
+          accounts={accounts}
+          updatePool={updatePool}
+          onClose={() => setEditingPool(null)}
+          onSaved={handleEditSaved}
+        />
+      )}
+    </div>
+  )
+}
+
+function EditPoolModal({
+  pool,
+  accounts,
+  updatePool,
+  onClose,
+  onSaved,
+}: {
+  pool: Pool
+  accounts: { id: number; name: string; key: string }[]
+  updatePool: (id: number, data: UpdatePoolRequest) => Promise<Pool>
+  onClose: () => void
+  onSaved: (pool: Pool) => void
+}) {
+  const { showToast } = useToast()
+  const [name, setName] = useState(pool.name)
+  const [accountId, setAccountId] = useState<string>(pool.account_id ? String(pool.account_id) : '')
+  const [type, setType] = useState<PoolType>(pool.type)
+  const [status, setStatus] = useState<PoolStatus>(pool.status)
+  const [description, setDescription] = useState(pool.description || '')
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    const trimmedName = name.trim()
+    if (!trimmedName) return
+
+    setSaving(true)
+    try {
+      const updated = await updatePool(pool.id, {
+        name: trimmedName,
+        account_id: accountId ? Number(accountId) : null,
+        type,
+        status,
+        description: description.trim(),
+      })
+      showToast(`Updated ${updated.name}`, 'success')
+      onSaved(updated)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update pool', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4">
+        <div className="flex items-center justify-between px-6 py-4 border-b dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Edit Pool</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" title="Close">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="px-6 py-4 space-y-4">
+          <div className="text-sm text-gray-500 dark:text-gray-400 font-mono bg-gray-50 dark:bg-gray-900 px-3 py-2 rounded">
+            {pool.cidr}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+            <input
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Account</label>
+            <select
+              value={accountId}
+              onChange={e => setAccountId(e.target.value)}
+              className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+            >
+              <option value="">None</option>
+              {accounts.map(a => (
+                <option key={a.id} value={a.id}>{a.name} ({a.key})</option>
+              ))}
+            </select>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type</label>
+              <select
+                value={type}
+                onChange={e => setType(e.target.value as PoolType)}
+                className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+              >
+                <option value="supernet">Supernet</option>
+                <option value="region">Region</option>
+                <option value="environment">Environment</option>
+                <option value="vpc">VPC</option>
+                <option value="subnet">Subnet</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Status</label>
+              <select
+                value={status}
+                onChange={e => setStatus(e.target.value as PoolStatus)}
+                className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+              >
+                <option value="active">Active</option>
+                <option value="planned">Planned</option>
+                <option value="deprecated">Deprecated</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description</label>
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              rows={3}
+              className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-gray-100"
+            />
+          </div>
+        </div>
+        <div className="flex justify-end gap-3 px-6 py-4 border-t dark:border-gray-700">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 border dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || !name.trim()}
+            className="px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,9 +12,9 @@
         }
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-VHhgyYRx.js"></script>
+    <script type="module" crossorigin src="/assets/index-DOApqCj9.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-cLTP9fnK.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-em_AXDBH.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-CsdvKQLG.js">
     <link rel="stylesheet" crossorigin href="/assets/index-DZp2w1lT.css">
   </head>
   <body>


### PR DESCRIPTION
## Summary

Fixes two follow-up issues in the discovery/IPAM workflow:

- Allocated Blocks now shows discovered VPC/subnet pools even when they were created as top-level pools from scan data.
- Address Pools now has an actual edit flow from the table and detail panel instead of a detail-panel action that only navigated back to the current page.
- Pool PATCH updates now preserve an existing account assignment when `account_id` is omitted, preventing unrelated edits from silently clearing the pool's account.

## Changelog

### Added

- Added `0.14.5` to `docs/CHANGELOG.md`.
- Added an Edit Pool modal for Address Pools with editable name, account, type, status, and description fields.
- Added an edit icon in the Address Pools table.
- The Address Pool detail panel now exposes an `Edit Pool` action when the caller provides an edit handler, while retaining the existing `Manage Pool` fallback for dashboard usage.

### Fixed

- `/api/v1/blocks` now includes top-level VPC and subnet pools, which covers imported or build-from-discovery scan results that do not have a containing parent pool.
- `/api/v1/blocks` now returns `type`, `status`, and `source` metadata so the Allocated Blocks UI can render discovered resources with their real classification.
- Pool updates that omit `account_id` now keep the pool's current account rather than interpreting omission as a request to clear it.
- Updated frontend block types so parentless allocated VPC/subnet rows are represented correctly.

### Tests

- Added API coverage that imported discovered VPC/subnet resources appear in `/api/v1/blocks`, including the parentless VPC case.
- Added API coverage that PATCHing a pool name without `account_id` preserves the existing account assignment.
- Rebuilt the static UI bundle.

## Verification

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./...`
- `npm run build`
- `git diff --check`
