### PR TITLE
Discovery: harden network import and merged views

### DIFF
--- a/cmd/cloudpam/main.go
+++ b/cmd/cloudpam/main.go
@@ -219,6 +219,8 @@ func main() {
 	driftDetector := discovery.NewDriftDetector(store, discoveryStore, driftStore)
 	driftSrv := api.NewDriftServer(srv, driftDetector, driftStore)
 	logger.Info("drift detection subsystem initialized")
+	networkSrv := api.NewNetworkServer(srv, store, discoveryStore, driftStore)
+	logger.Info("merged network view subsystem initialized")
 
 	// Initialize settings subsystem
 	settingsStore := selectSettingsStore(logger, store)
@@ -253,6 +255,7 @@ func main() {
 	roleSrv := api.NewRoleServer(srv, roleStore)
 	roleSrv.RegisterProtectedRoleRoutes(dualMW, logger.Slog())
 	discoverySrv.RegisterProtectedDiscoveryRoutes(dualMW, logger.Slog())
+	networkSrv.RegisterProtectedNetworkRoutes(dualMW, logger.Slog())
 	analysisSrv.RegisterProtectedAnalysisRoutes(dualMW, logger.Slog())
 	recSrv.RegisterProtectedRecommendationRoutes(dualMW, logger.Slog())
 	driftSrv.RegisterProtectedDriftRoutes(dualMW, logger.Slog())

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,10 @@ patch or minor version entry for every user-facing change.
 - Discovery documentation now clarifies the distinction between allocated blocks, discovered resources, network objects, and soft links.
 - EIPs and other non-pool cloud resources are now surfaced as network objects in merged views instead of being pushed through the allocated-block model.
 
+### Fixed
+- Network conflict resolution now only offers durable review decisions and rejects unsupported decisions instead of marking no-op import/link requests as resolved.
+- Discovery import preview and apply now scan all discovered resource pages when checking parents and duplicate CIDRs.
+
 ## [0.15.0] - 2026-06-01
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.16.0] - 2026-06-01
+
+### Added
+- Discovery import now supports checkbox-selected preview/apply flows that show per-resource actions, conflicts, missing parents, outside-pool placement, duplicate CIDRs across accounts, and link-only network-object candidates before creating discovered-source pools.
+- Added merged network APIs at `/api/v1/network/flat`, `/api/v1/network/hierarchy`, `/api/v1/network/merged`, and `/api/v1/network/conflicts` so operators can inspect pools, linked discovered resources, discovered-only network objects, and conflict evidence in both table and hierarchy form.
+- Cloud Discovery now includes a Merged Network tab with hierarchy, flat, and conflict views plus filters for object type and issue type.
+
+### Changed
+- Discovery documentation now clarifies the distinction between allocated blocks, discovered resources, network objects, and soft links.
+- EIPs and other non-pool cloud resources are now surfaced as network objects in merged views instead of being pushed through the allocated-block model.
+
 ## [0.15.0] - 2026-06-01
 
 ### Added

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -126,7 +126,7 @@ curl -X POST http://localhost:8080/api/v1/network/conflicts/duplicate-cidr:10.0.
   -d '{"decision":"skip","reason":"reviewed duplicate lab account"}'
 ```
 
-Conflict resolution requests are returned as response metadata for computed conflicts. Durable conflict lifecycle tracking remains tied to drift records and future managed network-object persistence.
+Conflict resolution requests for computed conflicts are persisted as drift records keyed by the stable conflict ID where the configured drift store is durable, such as SQLite. The merged views rehydrate the stored decision when conflicts are recomputed. Durable managed network-object persistence remains future work.
 
 ## AWS Setup
 

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -2,6 +2,20 @@
 
 CloudPAM's discovery subsystem automatically finds VPCs, subnets, and Elastic IPs in your cloud accounts, then lets you link them to CloudPAM pools for unified IP address management.
 
+## Vocabulary
+
+CloudPAM keeps designed IPAM state separate from observed cloud state:
+
+| Term | Meaning |
+|------|---------|
+| Address pool | A CloudPAM-managed container for address space. |
+| Allocated block | Approved or designed IPAM intent shown in the Allocated Blocks view. |
+| Discovered resource | Observed cloud state from a provider scan. |
+| Network object | A cloud networking object such as a VPC, subnet, EIP, public IP, or NIC. |
+| Soft link | A non-destructive association between a discovered resource and a managed pool. |
+
+VPCs and subnets can be converted into discovered-source pools when an operator explicitly imports them. EIPs and similar address-bearing resources stay as network-object candidates in the import preview until CloudPAM has a managed network-object store for them.
+
 ## How It Works
 
 Discovery follows an **approval workflow**: resources are discovered and stored separately from your pool hierarchy. You decide which resources to import by explicitly linking them to pools. This means discovery never modifies your existing IPAM data without your action.
@@ -53,6 +67,66 @@ Discovered resources are **unlinked** by default. To track a cloud resource in y
 3. Enter the pool ID you want to associate it with
 
 The pool's CIDR should match (or contain) the resource's CIDR for the association to be meaningful. Linking is an advisory association — it doesn't modify the cloud resource.
+
+### Import Preview and Apply
+
+The Discovery page supports checkbox multi-select before import. Select active, unlinked resources and choose **Preview Import** to review the proposed action for each resource before any pool is created.
+
+Preview can return:
+
+| Status | Meaning |
+|--------|---------|
+| `importable` | CloudPAM can create or link a discovered-source pool for the selected resource. |
+| `conflict` | Import needs operator review because of duplicate CIDR or an overlapping managed pool. |
+| `blocked` | Import cannot proceed, for example because the CIDR is invalid, parent VPC is missing, or the selected pool does not contain the resource. |
+| `linked_only` | The resource is a network-object candidate, such as an EIP or NIC, and is not converted into a pool. |
+| `already_linked` | The discovered resource already has a soft link to a pool. |
+
+API callers can use the same flow:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/discovery/import/preview \
+  -H 'Content-Type: application/json' \
+  -d '{"account_id":1,"resource_ids":["00000000-0000-0000-0000-000000000001"]}'
+```
+
+```bash
+curl -X POST http://localhost:8080/api/v1/discovery/import/apply \
+  -H 'Content-Type: application/json' \
+  -d '{"account_id":1,"resource_ids":["00000000-0000-0000-0000-000000000001"]}'
+```
+
+`POST /api/v1/discovery/import` remains available for compatibility, but new integrations should use preview/apply so conflicts and non-pool network objects are visible before conversion.
+
+## Merged Network Views
+
+CloudPAM exposes merged network views that combine managed pools, linked discovered resources, discovered-only network objects, and computed conflict evidence.
+
+The Discovery page includes a **Merged Network** tab with:
+
+| Mode | Use |
+|------|-----|
+| Hierarchy | Day-to-day review of pools, VPCs, subnets, and child objects. |
+| Flat | Audit/search view with filters for object type and issue type. |
+| Conflicts | Evidence panel for duplicate CIDRs, missing parents, invalid nesting, outside-pool links, and managed overlaps. |
+
+API callers can use:
+
+```bash
+curl http://localhost:8080/api/v1/network/hierarchy
+curl http://localhost:8080/api/v1/network/flat?object_type=vpc
+curl http://localhost:8080/api/v1/network/conflicts?conflict_type=duplicate_cidr
+```
+
+Conflict responses include stable IDs, severity, affected discovered resource IDs, affected pool IDs, account/region metadata, evidence lines, and available decisions such as `import`, `link`, `skip`, `ignore`, and `defer`.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/network/conflicts/duplicate-cidr:10.0.0.0_16/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"decision":"skip","reason":"reviewed duplicate lab account"}'
+```
+
+Conflict resolution requests are returned as response metadata for computed conflicts. Durable conflict lifecycle tracking remains tied to drift records and future managed network-object persistence.
 
 ## AWS Setup
 

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -118,7 +118,7 @@ curl http://localhost:8080/api/v1/network/flat?object_type=vpc
 curl http://localhost:8080/api/v1/network/conflicts?conflict_type=duplicate_cidr
 ```
 
-Conflict responses include stable IDs, severity, affected discovered resource IDs, affected pool IDs, account/region metadata, evidence lines, and available decisions such as `import`, `link`, `skip`, `ignore`, and `defer`.
+Conflict responses include stable IDs, severity, affected discovered resource IDs, affected pool IDs, account/region metadata, evidence lines, and available review decisions: `skip`, `ignore`, and `defer`.
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/network/conflicts/duplicate-cidr:10.0.0.0_16/resolve \

--- a/internal/api/bootstrap_handlers_test.go
+++ b/internal/api/bootstrap_handlers_test.go
@@ -25,6 +25,8 @@ func setupDiscoveryTestServer() (*DiscoveryServer, *storage.MemoryStore, *storag
 	syncSvc := discovery.NewSyncService(ds)
 	discSrv := NewDiscoveryServer(srv, ds, syncSvc, ks)
 	discSrv.RegisterDiscoveryRoutes()
+	networkSrv := NewNetworkServer(srv, st, ds, storage.NewMemoryDriftStore(st))
+	networkSrv.RegisterNetworkRoutes()
 	return discSrv, st, ds, ks
 }
 

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -39,6 +39,7 @@ func (d *DiscoveryServer) RegisterDiscoveryRoutes() {
 	d.srv.handleOpenAPIRouteFunc("/api/v1/discovery/resources", d.handleResources)
 	d.srv.handleOpenAPIRouteFunc("/api/v1/discovery/resources/", d.handleResourcesSubroutes)
 	d.srv.handleOpenAPIRouteFunc("/api/v1/discovery/import", d.handleImportDiscoveredSchema)
+	d.srv.handleOpenAPIRouteFunc("/api/v1/discovery/import/", d.handleImportSubroutes)
 	d.srv.handleOpenAPIRouteFunc("/api/v1/discovery/sync", d.handleSync)
 	d.srv.handleOpenAPIRouteFunc("/api/v1/discovery/sync/", d.handleSyncSubroutes)
 	d.srv.handleOpenAPIRouteFunc("/api/v1/discovery/ingest", d.handleIngest)
@@ -55,6 +56,7 @@ func (d *DiscoveryServer) RegisterProtectedDiscoveryRoutes(dualMW Middleware, lo
 	d.srv.handleOpenAPIRoute("/api/v1/discovery/resources", dualMW(readMW(http.HandlerFunc(d.handleResources))))
 	d.srv.handleOpenAPIRoute("/api/v1/discovery/resources/", dualMW(d.protectedResourcesSubroutes(logger)))
 	d.srv.handleOpenAPIRoute("/api/v1/discovery/import", dualMW(createMW(http.HandlerFunc(d.handleImportDiscoveredSchema))))
+	d.srv.handleOpenAPIRoute("/api/v1/discovery/import/", dualMW(createMW(http.HandlerFunc(d.handleImportSubroutes))))
 	d.srv.handleOpenAPIRoute("/api/v1/discovery/sync", dualMW(d.protectedSyncHandler(logger)))
 	d.srv.handleOpenAPIRoute("/api/v1/discovery/sync/", dualMW(readMW(http.HandlerFunc(d.handleSyncSubroutes))))
 
@@ -248,6 +250,476 @@ type discoveryImportResponse struct {
 	ResourcesLinked  int      `json:"resources_linked"`
 	Skipped          int      `json:"skipped"`
 	Errors           []string `json:"errors"`
+}
+
+// handleImportSubroutes handles preview/apply endpoints for selected discovery imports.
+func (d *DiscoveryServer) handleImportSubroutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/discovery/import/"), "/")
+	switch path {
+	case "preview":
+		d.handleImportPreview(w, r)
+	case "apply":
+		d.handleImportApply(w, r)
+	default:
+		d.srv.writeErr(r.Context(), w, http.StatusNotFound, "not found", "")
+	}
+}
+
+func (d *DiscoveryServer) handleImportPreview(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		d.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	var req domain.DiscoveryImportPreviewRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+	if err := validateDiscoveryImportSelection(req.AccountID, req.ResourceIDs); err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, err.Error(), "")
+		return
+	}
+
+	resp, err := d.previewDiscoveryImport(r.Context(), req)
+	if err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "preview import failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (d *DiscoveryServer) handleImportApply(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		d.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	var req domain.DiscoveryImportApplyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+	if err := validateDiscoveryImportSelection(req.AccountID, req.ResourceIDs); err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusBadRequest, err.Error(), "")
+		return
+	}
+
+	previewReq := domain.DiscoveryImportPreviewRequest{
+		AccountID:   req.AccountID,
+		ResourceIDs: req.ResourceIDs,
+		PoolID:      req.PoolID,
+	}
+	preview, err := d.previewDiscoveryImport(r.Context(), previewReq)
+	if err != nil {
+		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "preview import failed", err.Error())
+		return
+	}
+
+	resp := domain.DiscoveryImportApplyResponse{Preview: preview, Errors: []string{}}
+	items := append([]domain.DiscoveryImportPreviewItem{}, preview.Items...)
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].ResourceType == items[j].ResourceType {
+			return items[i].ProviderResourceID < items[j].ProviderResourceID
+		}
+		if items[i].ResourceType == domain.ResourceTypeVPC {
+			return true
+		}
+		if items[j].ResourceType == domain.ResourceTypeVPC {
+			return false
+		}
+		return items[i].ResourceType < items[j].ResourceType
+	})
+
+	createdPoolByProviderID := make(map[string]int64)
+	for _, item := range items {
+		if item.Status != "importable" {
+			resp.Skipped++
+			continue
+		}
+		res, err := d.store.GetDiscoveredResource(r.Context(), item.ResourceID)
+		if err != nil {
+			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: load resource: %v", item.ResourceID, err))
+			resp.Skipped++
+			continue
+		}
+
+		if item.ProposedAction == "link_pool" && item.ProposedPoolID != nil {
+			if err := d.store.LinkResourceToPool(r.Context(), item.ResourceID, *item.ProposedPoolID); err != nil {
+				resp.Errors = append(resp.Errors, fmt.Sprintf("%s: link pool: %v", res.ResourceID, err))
+				resp.Skipped++
+				continue
+			}
+			createdPoolByProviderID[res.ResourceID] = *item.ProposedPoolID
+			resp.ResourcesLinked++
+			continue
+		}
+
+		parentID := item.ProposedParentPoolID
+		if parentID == nil && res.ParentResourceID != nil {
+			if id, ok := createdPoolByProviderID[*res.ParentResourceID]; ok {
+				parentID = &id
+			}
+		}
+		if res.ResourceType == domain.ResourceTypeSubnet && res.ParentResourceID != nil && parentID == nil {
+			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: parent %s was not imported or linked", res.ResourceID, *res.ParentResourceID))
+			resp.Skipped++
+			continue
+		}
+		pool, err := d.createDiscoveredPool(r.Context(), req.AccountID, *res, parentID)
+		if err != nil {
+			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: create pool: %v", res.ResourceID, err))
+			resp.Skipped++
+			continue
+		}
+		if err := d.store.LinkResourceToPool(r.Context(), item.ResourceID, pool.ID); err != nil {
+			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: link new pool: %v", res.ResourceID, err))
+			resp.Skipped++
+			continue
+		}
+		createdPoolByProviderID[res.ResourceID] = pool.ID
+		resp.PoolsCreated++
+		resp.ResourcesLinked++
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func validateDiscoveryImportSelection(accountID int64, resourceIDs []uuid.UUID) error {
+	if accountID < 1 {
+		return fmt.Errorf("account_id is required and must be a positive integer")
+	}
+	if len(resourceIDs) == 0 {
+		return fmt.Errorf("resource_ids must include at least one discovered resource")
+	}
+	return nil
+}
+
+func (d *DiscoveryServer) previewDiscoveryImport(ctx context.Context, req domain.DiscoveryImportPreviewRequest) (domain.DiscoveryImportPreviewResponse, error) {
+	if _, found, err := d.srv.store.GetAccount(ctx, req.AccountID); err != nil {
+		return domain.DiscoveryImportPreviewResponse{}, err
+	} else if !found {
+		return domain.DiscoveryImportPreviewResponse{}, fmt.Errorf("account not found")
+	}
+
+	pools, err := d.srv.store.ListPools(ctx)
+	if err != nil {
+		return domain.DiscoveryImportPreviewResponse{}, err
+	}
+	poolsByID := make(map[int64]domain.Pool, len(pools))
+	for _, pool := range pools {
+		poolsByID[pool.ID] = pool
+	}
+	var selectedPool *domain.Pool
+	if req.PoolID != nil {
+		pool, ok := poolsByID[*req.PoolID]
+		if !ok {
+			return domain.DiscoveryImportPreviewResponse{}, fmt.Errorf("selected pool not found")
+		}
+		selectedPool = &pool
+	}
+
+	accountResources, _, err := d.store.ListDiscoveredResources(ctx, req.AccountID, domain.DiscoveryFilters{Page: 1, PageSize: 10000})
+	if err != nil {
+		return domain.DiscoveryImportPreviewResponse{}, err
+	}
+	resourceByProviderID := make(map[string]domain.DiscoveredResource, len(accountResources))
+	for _, res := range accountResources {
+		resourceByProviderID[res.ResourceID] = res
+	}
+
+	selectedProviderIDs := make(map[string]bool, len(req.ResourceIDs))
+	selectedResources := make([]domain.DiscoveredResource, 0, len(req.ResourceIDs))
+	for _, id := range req.ResourceIDs {
+		res, err := d.store.GetDiscoveredResource(ctx, id)
+		if err != nil {
+			continue
+		}
+		if res.AccountID == req.AccountID {
+			selectedProviderIDs[res.ResourceID] = true
+			selectedResources = append(selectedResources, *res)
+		}
+	}
+	duplicates, err := d.duplicateCIDRsByAccount(ctx, req.AccountID, selectedResources)
+	if err != nil {
+		return domain.DiscoveryImportPreviewResponse{}, err
+	}
+
+	resp := domain.DiscoveryImportPreviewResponse{Items: []domain.DiscoveryImportPreviewItem{}, SelectedPoolID: req.PoolID}
+	for _, id := range req.ResourceIDs {
+		item := domain.DiscoveryImportPreviewItem{
+			ResourceID:      id,
+			Status:          "blocked",
+			ProposedAction:  "none",
+			Issues:          []string{},
+			Evidence:        []string{},
+			ConflictPoolIDs: []int64{},
+		}
+
+		res, err := d.store.GetDiscoveredResource(ctx, id)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				item.Status = "not_found"
+				item.Issues = append(item.Issues, "not_found")
+				addDiscoveryPreviewItem(&resp, item)
+				continue
+			}
+			return domain.DiscoveryImportPreviewResponse{}, err
+		}
+
+		item.ProviderResourceID = res.ResourceID
+		item.Name = res.Name
+		item.Provider = res.Provider
+		item.Region = res.Region
+		item.ResourceType = res.ResourceType
+		item.CIDR = res.CIDR
+		item.LinkedPoolID = res.PoolID
+
+		if res.AccountID != req.AccountID {
+			item.Issues = append(item.Issues, "account_mismatch")
+			item.Evidence = append(item.Evidence, fmt.Sprintf("resource belongs to account %d", res.AccountID))
+			addDiscoveryPreviewItem(&resp, item)
+			continue
+		}
+		if res.PoolID != nil {
+			item.Status = "already_linked"
+			item.ProposedAction = "none"
+			item.Issues = append(item.Issues, "already_linked")
+			addDiscoveryPreviewItem(&resp, item)
+			continue
+		}
+		if res.Status != domain.DiscoveryStatusActive {
+			item.Issues = append(item.Issues, "stale_resource")
+		}
+		if res.ResourceType != domain.ResourceTypeVPC && res.ResourceType != domain.ResourceTypeSubnet {
+			item.Status = "linked_only"
+			item.ProposedAction = "link_only"
+			item.ProposedManagedType = "network_object"
+			item.Issues = append(item.Issues, "network_object_only")
+			addDiscoveryPreviewItem(&resp, item)
+			continue
+		}
+
+		if _, err := netip.ParsePrefix(res.CIDR); res.CIDR == "" || err != nil {
+			item.Issues = append(item.Issues, "invalid_cidr")
+		}
+		if selectedPool != nil && res.CIDR != "" {
+			if !cidrContains(selectedPool.CIDR, res.CIDR) {
+				item.Issues = append(item.Issues, "outside_pool")
+				item.Evidence = append(item.Evidence, fmt.Sprintf("%s is not inside selected pool %s", res.CIDR, selectedPool.CIDR))
+			} else if res.ResourceType == domain.ResourceTypeVPC {
+				item.ProposedParentPoolID = &selectedPool.ID
+			}
+		}
+
+		if res.ResourceType == domain.ResourceTypeSubnet {
+			if res.ParentResourceID != nil {
+				parent, ok := resourceByProviderID[*res.ParentResourceID]
+				switch {
+				case !ok:
+					item.Issues = append(item.Issues, "missing_parent")
+					item.Evidence = append(item.Evidence, "provider parent "+*res.ParentResourceID+" was not discovered")
+				case parent.PoolID != nil:
+					item.ProposedParentPoolID = parent.PoolID
+				case selectedProviderIDs[parent.ResourceID]:
+					item.Evidence = append(item.Evidence, "parent "+parent.ResourceID+" is selected for import")
+				default:
+					item.Issues = append(item.Issues, "missing_parent")
+					item.Evidence = append(item.Evidence, "provider parent "+parent.ResourceID+" is discovered but not linked or selected")
+				}
+			}
+			if item.ProposedParentPoolID == nil && selectedPool != nil && cidrContains(selectedPool.CIDR, res.CIDR) {
+				item.ProposedParentPoolID = &selectedPool.ID
+			}
+		}
+
+		d.classifyPoolRelationships(&item, res, pools)
+		if ids := duplicates[res.CIDR]; len(ids) > 0 {
+			item.Issues = append(item.Issues, "duplicate_cidr")
+			item.DuplicateResourceIDs = ids
+			item.Evidence = append(item.Evidence, fmt.Sprintf("%s is also discovered in another account", res.CIDR))
+		}
+
+		if len(item.Issues) > 0 || len(item.ConflictPoolIDs) > 0 {
+			if hasAnyIssue(item.Issues, "duplicate_cidr") || len(item.ConflictPoolIDs) > 0 {
+				item.Status = "conflict"
+			} else {
+				item.Status = "blocked"
+			}
+			addDiscoveryPreviewItem(&resp, item)
+			continue
+		}
+
+		item.Status = "importable"
+		item.ProposedManagedType = "discovered_pool"
+		if item.ProposedPoolID != nil {
+			item.ProposedAction = "link_pool"
+		} else {
+			item.ProposedAction = "create_pool"
+		}
+		addDiscoveryPreviewItem(&resp, item)
+	}
+
+	return resp, nil
+}
+
+func addDiscoveryPreviewItem(resp *domain.DiscoveryImportPreviewResponse, item domain.DiscoveryImportPreviewItem) {
+	resp.Items = append(resp.Items, item)
+	switch item.Status {
+	case "importable":
+		resp.Importable++
+	case "linked_only":
+		resp.LinkedOnly++
+	case "already_linked":
+		resp.AlreadyLinked++
+	case "conflict":
+		resp.ConflictCount++
+		resp.Blocked++
+	default:
+		resp.Blocked++
+	}
+}
+
+func (d *DiscoveryServer) classifyPoolRelationships(item *domain.DiscoveryImportPreviewItem, res *domain.DiscoveredResource, pools []domain.Pool) {
+	bestParentBits := -1
+	for _, pool := range pools {
+		if pool.CIDR == "" || res.CIDR == "" {
+			continue
+		}
+		if cidrEqual(pool.CIDR, res.CIDR) {
+			if pool.AccountID != nil && *pool.AccountID != res.AccountID {
+				item.ConflictPoolIDs = append(item.ConflictPoolIDs, pool.ID)
+				item.Evidence = append(item.Evidence, fmt.Sprintf("exact CIDR exists in pool %d assigned to another account", pool.ID))
+				continue
+			}
+			item.ProposedPoolID = &pool.ID
+			item.Evidence = append(item.Evidence, fmt.Sprintf("exact pool match %d", pool.ID))
+			continue
+		}
+		if cidrContains(pool.CIDR, res.CIDR) {
+			if bits := prefixLength(pool.CIDR); bits > bestParentBits {
+				bestParentBits = bits
+				parentID := pool.ID
+				if item.ProposedParentPoolID == nil {
+					item.ProposedParentPoolID = &parentID
+				}
+			}
+			continue
+		}
+		if cidrOverlaps(pool.CIDR, res.CIDR) {
+			item.ConflictPoolIDs = append(item.ConflictPoolIDs, pool.ID)
+			item.Evidence = append(item.Evidence, fmt.Sprintf("%s overlaps existing pool %d (%s)", res.CIDR, pool.ID, pool.CIDR))
+		}
+	}
+}
+
+func (d *DiscoveryServer) duplicateCIDRsByAccount(ctx context.Context, accountID int64, selected []domain.DiscoveredResource) (map[string][]uuid.UUID, error) {
+	cidrs := make(map[string]bool)
+	for _, res := range selected {
+		if res.CIDR != "" {
+			cidrs[res.CIDR] = true
+		}
+	}
+	out := make(map[string][]uuid.UUID, len(cidrs))
+	if len(cidrs) == 0 {
+		return out, nil
+	}
+	accounts, err := d.srv.store.ListAccounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, account := range accounts {
+		if account.ID == accountID {
+			continue
+		}
+		resources, _, err := d.store.ListDiscoveredResources(ctx, account.ID, domain.DiscoveryFilters{
+			Status:   string(domain.DiscoveryStatusActive),
+			Page:     1,
+			PageSize: 10000,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, res := range resources {
+			if cidrs[res.CIDR] {
+				out[res.CIDR] = append(out[res.CIDR], res.ID)
+			}
+		}
+	}
+	return out, nil
+}
+
+func (d *DiscoveryServer) createDiscoveredPool(ctx context.Context, accountID int64, res domain.DiscoveredResource, parentID *int64) (domain.Pool, error) {
+	poolType := domain.PoolTypeSubnet
+	if res.ResourceType == domain.ResourceTypeVPC {
+		poolType = domain.PoolTypeVPC
+	}
+	name := strings.TrimSpace(res.Name)
+	if name == "" {
+		name = res.ResourceID
+	}
+	return d.srv.store.CreatePool(ctx, domain.CreatePool{
+		Name:      name,
+		CIDR:      res.CIDR,
+		ParentID:  parentID,
+		AccountID: &accountID,
+		Type:      poolType,
+		Status:    domain.PoolStatusActive,
+		Source:    domain.PoolSourceDiscovered,
+		Description: fmt.Sprintf("Imported from %s discovery resource %s in %s",
+			res.Provider, res.ResourceID, res.Region),
+		Tags: map[string]string{
+			"discovery_resource_id": res.ResourceID,
+			"discovery_provider":    res.Provider,
+			"discovery_region":      res.Region,
+			"discovery_type":        string(res.ResourceType),
+		},
+	})
+}
+
+func hasAnyIssue(issues []string, targets ...string) bool {
+	for _, issue := range issues {
+		for _, target := range targets {
+			if issue == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func cidrEqual(a string, b string) bool {
+	pa, errA := netip.ParsePrefix(a)
+	pb, errB := netip.ParsePrefix(b)
+	return errA == nil && errB == nil && pa.Masked() == pb.Masked()
+}
+
+func cidrContains(parent string, child string) bool {
+	p, errP := netip.ParsePrefix(parent)
+	c, errC := netip.ParsePrefix(child)
+	if errP != nil || errC != nil || p.Addr().BitLen() != c.Addr().BitLen() {
+		return false
+	}
+	return p.Bits() <= c.Bits() && p.Masked().Contains(c.Masked().Addr())
+}
+
+func cidrOverlaps(a string, b string) bool {
+	pa, errA := netip.ParsePrefix(a)
+	pb, errB := netip.ParsePrefix(b)
+	if errA != nil || errB != nil || pa.Addr().BitLen() != pb.Addr().BitLen() {
+		return false
+	}
+	return pa.Masked().Contains(pb.Masked().Addr()) || pb.Masked().Contains(pa.Masked().Addr())
+}
+
+func prefixLength(cidr string) int {
+	p, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return -1
+	}
+	return p.Bits()
 }
 
 // handleImportDiscoveredSchema imports active discovered VPC/subnet resources as pools.

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -417,7 +417,7 @@ func (d *DiscoveryServer) previewDiscoveryImport(ctx context.Context, req domain
 		selectedPool = &pool
 	}
 
-	accountResources, _, err := d.store.ListDiscoveredResources(ctx, req.AccountID, domain.DiscoveryFilters{Page: 1, PageSize: 10000})
+	accountResources, err := d.listAllDiscoveredResources(ctx, req.AccountID, domain.DiscoveryFilters{})
 	if err != nil {
 		return domain.DiscoveryImportPreviewResponse{}, err
 	}
@@ -630,10 +630,8 @@ func (d *DiscoveryServer) duplicateCIDRsByAccount(ctx context.Context, accountID
 		if account.ID == accountID {
 			continue
 		}
-		resources, _, err := d.store.ListDiscoveredResources(ctx, account.ID, domain.DiscoveryFilters{
-			Status:   string(domain.DiscoveryStatusActive),
-			Page:     1,
-			PageSize: 10000,
+		resources, err := d.listAllDiscoveredResources(ctx, account.ID, domain.DiscoveryFilters{
+			Status: string(domain.DiscoveryStatusActive),
 		})
 		if err != nil {
 			return nil, err
@@ -643,6 +641,29 @@ func (d *DiscoveryServer) duplicateCIDRsByAccount(ctx context.Context, accountID
 				out[res.CIDR] = append(out[res.CIDR], res.ID)
 			}
 		}
+	}
+	return out, nil
+}
+
+func (d *DiscoveryServer) listAllDiscoveredResources(ctx context.Context, accountID int64, filters domain.DiscoveryFilters) ([]domain.DiscoveredResource, error) {
+	const pageSize = 1000
+	var out []domain.DiscoveredResource
+	count := 0
+	filters.PageSize = pageSize
+	for page := 1; ; page++ {
+		filters.Page = page
+		resources, total, err := d.store.ListDiscoveredResources(ctx, accountID, filters)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, resources...)
+		count += len(resources)
+		if len(resources) == 0 || count >= total {
+			break
+		}
+	}
+	if out == nil {
+		out = []domain.DiscoveredResource{}
 	}
 	return out, nil
 }
@@ -742,10 +763,8 @@ func (d *DiscoveryServer) handleImportDiscoveredSchema(w http.ResponseWriter, r 
 		return
 	}
 
-	resources, _, err := d.store.ListDiscoveredResources(r.Context(), body.AccountID, domain.DiscoveryFilters{
-		Status:   string(domain.DiscoveryStatusActive),
-		Page:     1,
-		PageSize: 10000,
+	resources, err := d.listAllDiscoveredResources(r.Context(), body.AccountID, domain.DiscoveryFilters{
+		Status: string(domain.DiscoveryStatusActive),
 	})
 	if err != nil {
 		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "list resources failed", err.Error())

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -307,11 +307,7 @@ func (d *DiscoveryServer) handleImportApply(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	previewReq := domain.DiscoveryImportPreviewRequest{
-		AccountID:   req.AccountID,
-		ResourceIDs: req.ResourceIDs,
-		PoolID:      req.PoolID,
-	}
+	previewReq := domain.DiscoveryImportPreviewRequest(req)
 	preview, err := d.previewDiscoveryImport(r.Context(), previewReq)
 	if err != nil {
 		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "preview import failed", err.Error())

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -153,4 +156,236 @@ func TestImportDiscoveredSchemaCreatesAndLinksPools(t *testing.T) {
 	if !sawRootVPC || !sawSubnet {
 		t.Fatalf("discovered blocks missing from allocated blocks: %+v", blocks.Items)
 	}
+}
+
+func TestDiscoveryImportPreviewAndApplySelectedResources(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	subnetID := uuid.New()
+	parent := "vpc-1"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-1",
+		Name:         "prod-vpc",
+		CIDR:         "10.10.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:               subnetID,
+		AccountID:        account.ID,
+		Provider:         "aws",
+		Region:           "us-east-1",
+		ResourceType:     domain.ResourceTypeSubnet,
+		ResourceID:       "subnet-1",
+		Name:             "prod-subnet",
+		CIDR:             "10.10.1.0/24",
+		ParentResourceID: &parent,
+		Status:           domain.DiscoveryStatusActive,
+		DiscoveredAt:     now,
+		LastSeenAt:       now,
+	})
+
+	body := fmt.Sprintf(`{"account_id":%d,"resource_ids":["%s","%s"]}`, account.ID, vpcID, subnetID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", body, http.StatusOK)
+	var preview domain.DiscoveryImportPreviewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &preview); err != nil {
+		t.Fatalf("unmarshal preview: %v", err)
+	}
+	if preview.Importable != 2 || preview.Blocked != 0 {
+		t.Fatalf("unexpected preview counts: %+v", preview)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/apply", body, http.StatusOK)
+	var applied domain.DiscoveryImportApplyResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &applied); err != nil {
+		t.Fatalf("unmarshal apply: %v", err)
+	}
+	if applied.PoolsCreated != 2 || applied.ResourcesLinked != 2 || applied.Skipped != 0 {
+		t.Fatalf("unexpected apply response: %+v", applied)
+	}
+	pools, err := st.ListPools(t.Context())
+	if err != nil {
+		t.Fatalf("list pools: %v", err)
+	}
+	if len(pools) != 2 {
+		t.Fatalf("len(pools) = %d, want 2", len(pools))
+	}
+}
+
+func TestDiscoveryImportPreviewBlocksMissingParent(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	subnetID := uuid.New()
+	parent := "vpc-missing"
+	now := time.Now().UTC()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:               subnetID,
+		AccountID:        account.ID,
+		Provider:         "aws",
+		Region:           "us-east-1",
+		ResourceType:     domain.ResourceTypeSubnet,
+		ResourceID:       "subnet-1",
+		Name:             "orphan-subnet",
+		CIDR:             "10.20.1.0/24",
+		ParentResourceID: &parent,
+		Status:           domain.DiscoveryStatusActive,
+		DiscoveredAt:     now,
+		LastSeenAt:       now,
+	})
+
+	body := fmt.Sprintf(`{"account_id":%d,"resource_ids":["%s"]}`, account.ID, subnetID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", body, http.StatusOK)
+	item := singleDiscoveryPreviewItem(t, rr)
+	if item.Status != "blocked" || !containsString(item.Issues, "missing_parent") {
+		t.Fatalf("unexpected preview item: %+v", item)
+	}
+}
+
+func TestDiscoveryImportPreviewBlocksOutsideSelectedPool(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	pool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "prod", CIDR: "10.30.0.0/16", Type: domain.PoolTypeSupernet})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	vpcID := uuid.New()
+	now := time.Now().UTC()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-1",
+		Name:         "outside-vpc",
+		CIDR:         "10.31.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+
+	body := fmt.Sprintf(`{"account_id":%d,"pool_id":%d,"resource_ids":["%s"]}`, account.ID, pool.ID, vpcID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", body, http.StatusOK)
+	item := singleDiscoveryPreviewItem(t, rr)
+	if item.Status != "blocked" || !containsString(item.Issues, "outside_pool") {
+		t.Fatalf("unexpected preview item: %+v", item)
+	}
+}
+
+func TestDiscoveryImportPreviewFlagsDuplicateAcrossAccounts(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	a1, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:111111111111", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account 1: %v", err)
+	}
+	a2, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:222222222222", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account 2: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpc1ID := uuid.New()
+	vpc2ID := uuid.New()
+	for _, res := range []domain.DiscoveredResource{
+		{ID: vpc1ID, AccountID: a1.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-prod", Name: "prod", CIDR: "10.40.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
+		{ID: vpc2ID, AccountID: a2.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-dev", Name: "dev", CIDR: "10.40.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
+	} {
+		upsertDiscoveredForImportTest(t, ds, res)
+	}
+
+	body := fmt.Sprintf(`{"account_id":%d,"resource_ids":["%s"]}`, a1.ID, vpc1ID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", body, http.StatusOK)
+	item := singleDiscoveryPreviewItem(t, rr)
+	if item.Status != "conflict" || !containsString(item.Issues, "duplicate_cidr") || len(item.DuplicateResourceIDs) != 1 {
+		t.Fatalf("unexpected preview item: %+v", item)
+	}
+}
+
+func TestDiscoveryImportPreviewKeepsEIPAsNetworkObject(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	eipID := uuid.New()
+	now := time.Now().UTC()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           eipID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeElasticIP,
+		ResourceID:   "eipalloc-1",
+		Name:         "prod-eip",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+
+	body := fmt.Sprintf(`{"account_id":%d,"resource_ids":["%s"]}`, account.ID, eipID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", body, http.StatusOK)
+	item := singleDiscoveryPreviewItem(t, rr)
+	if item.Status != "linked_only" || item.ProposedManagedType != "network_object" || !containsString(item.Issues, "network_object_only") {
+		t.Fatalf("unexpected preview item: %+v", item)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/apply", body, http.StatusOK)
+	var applied domain.DiscoveryImportApplyResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &applied); err != nil {
+		t.Fatalf("unmarshal apply: %v", err)
+	}
+	if applied.PoolsCreated != 0 || applied.ResourcesLinked != 0 || applied.Skipped != 1 {
+		t.Fatalf("EIP should not be imported as a pool: %+v", applied)
+	}
+}
+
+func upsertDiscoveredForImportTest(t *testing.T, ds interface {
+	UpsertDiscoveredResource(context.Context, domain.DiscoveredResource) error
+}, res domain.DiscoveredResource) {
+	t.Helper()
+	if err := ds.UpsertDiscoveredResource(t.Context(), res); err != nil {
+		t.Fatalf("upsert discovered resource: %v", err)
+	}
+}
+
+func singleDiscoveryPreviewItem(t *testing.T, rr *httptest.ResponseRecorder) domain.DiscoveryImportPreviewItem {
+	t.Helper()
+	var preview domain.DiscoveryImportPreviewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &preview); err != nil {
+		t.Fatalf("unmarshal preview: %v", err)
+	}
+	if len(preview.Items) != 1 {
+		t.Fatalf("len(preview.items) = %d, want 1: %+v", len(preview.Items), preview)
+	}
+	return preview.Items[0]
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -257,6 +257,72 @@ func TestDiscoveryImportPreviewBlocksMissingParent(t *testing.T) {
 	}
 }
 
+func TestDiscoveryImportPreviewFindsParentBeyondFirstPage(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	now := time.Now().UTC()
+	for i := 0; i < 1001; i++ {
+		upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+			ID:           uuid.New(),
+			AccountID:    account.ID,
+			Provider:     "aws",
+			Region:       "us-east-1",
+			ResourceType: domain.ResourceTypeElasticIP,
+			ResourceID:   fmt.Sprintf("eipalloc-page-%04d", i),
+			Name:         fmt.Sprintf("page filler %04d", i),
+			CIDR:         fmt.Sprintf("198.51.%d.%d/32", i/255, i%255),
+			Status:       domain.DiscoveryStatusActive,
+			DiscoveredAt: now.Add(time.Duration(i) * time.Second),
+			LastSeenAt:   now.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	vpcID := uuid.New()
+	subnetID := uuid.New()
+	parent := "vpc-paged"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   parent,
+		Name:         "paged-vpc",
+		CIDR:         "10.50.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now.Add(-2 * time.Hour),
+		LastSeenAt:   now,
+	})
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:               subnetID,
+		AccountID:        account.ID,
+		Provider:         "aws",
+		Region:           "us-east-1",
+		ResourceType:     domain.ResourceTypeSubnet,
+		ResourceID:       "subnet-paged",
+		Name:             "paged-subnet",
+		CIDR:             "10.50.1.0/24",
+		ParentResourceID: &parent,
+		Status:           domain.DiscoveryStatusActive,
+		DiscoveredAt:     now.Add(-1 * time.Hour),
+		LastSeenAt:       now,
+	})
+
+	body := fmt.Sprintf(`{"account_id":%d,"resource_ids":["%s","%s"]}`, account.ID, vpcID, subnetID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", body, http.StatusOK)
+	var preview domain.DiscoveryImportPreviewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &preview); err != nil {
+		t.Fatalf("unmarshal preview: %v", err)
+	}
+	if preview.Importable != 2 || preview.Blocked != 0 {
+		t.Fatalf("expected paged parent lookup to make both resources importable: %+v", preview)
+	}
+}
+
 func TestDiscoveryImportPreviewBlocksOutsideSelectedPool(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
@@ -318,6 +384,70 @@ func TestDiscoveryImportPreviewFlagsDuplicateAcrossAccounts(t *testing.T) {
 	item := singleDiscoveryPreviewItem(t, rr)
 	if item.Status != "conflict" || !containsString(item.Issues, "duplicate_cidr") || len(item.DuplicateResourceIDs) != 1 {
 		t.Fatalf("unexpected preview item: %+v", item)
+	}
+}
+
+func TestDiscoveryImportPreviewFindsDuplicateBeyondFirstPage(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	a1, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:111111111111", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account 1: %v", err)
+	}
+	a2, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:222222222222", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account 2: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpc1ID := uuid.New()
+	vpc2ID := uuid.New()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpc1ID,
+		AccountID:    a1.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-prod",
+		Name:         "prod",
+		CIDR:         "10.60.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+	for i := 0; i < 1001; i++ {
+		upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+			ID:           uuid.New(),
+			AccountID:    a2.ID,
+			Provider:     "aws",
+			Region:       "us-east-1",
+			ResourceType: domain.ResourceTypeElasticIP,
+			ResourceID:   fmt.Sprintf("eipalloc-dup-page-%04d", i),
+			Name:         fmt.Sprintf("duplicate filler %04d", i),
+			CIDR:         fmt.Sprintf("203.0.%d.%d/32", i/255, i%255),
+			Status:       domain.DiscoveryStatusActive,
+			DiscoveredAt: now.Add(time.Duration(i) * time.Second),
+			LastSeenAt:   now.Add(time.Duration(i) * time.Second),
+		})
+	}
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpc2ID,
+		AccountID:    a2.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-dev",
+		Name:         "dev",
+		CIDR:         "10.60.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now.Add(-time.Hour),
+		LastSeenAt:   now,
+	})
+
+	body := fmt.Sprintf(`{"account_id":%d,"resource_ids":["%s"]}`, a1.ID, vpc1ID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", body, http.StatusOK)
+	item := singleDiscoveryPreviewItem(t, rr)
+	if item.Status != "conflict" || !containsString(item.Issues, "duplicate_cidr") || len(item.DuplicateResourceIDs) != 1 {
+		t.Fatalf("expected paged duplicate lookup to find conflict: %+v", item)
 	}
 }
 

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -135,7 +137,12 @@ func (ns *NetworkServer) handleConflictSubroutes(w http.ResponseWriter, r *http.
 	}
 	for _, conflict := range view.conflicts {
 		if conflict.ID == parts[0] {
-			conflict.ResolutionState = "requested"
+			if err := ns.persistNetworkConflictResolution(r.Context(), conflict, req); err != nil {
+				ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "resolve conflict failed", err.Error())
+				return
+			}
+			conflict.Status = string(networkDecisionStatus(req.Decision))
+			conflict.ResolutionState = conflict.Status
 			conflict.ResolutionRequested = req.Decision
 			writeJSON(w, http.StatusOK, conflict)
 			return
@@ -207,6 +214,7 @@ func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkVi
 	}
 
 	issuesByNode, conflicts := ns.computeNetworkConflicts(resources, pools, accountByID, poolByID, resourceByProvider)
+	conflicts = ns.applyStoredConflictResolutions(ctx, conflicts)
 	nodes := make([]domain.NetworkNode, 0, len(pools)+len(resources)+len(accounts))
 	for _, pool := range pools {
 		node := networkNodeFromPool(pool, accountByID)
@@ -534,6 +542,66 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 	return issuesByNode, conflicts
 }
 
+func (ns *NetworkServer) applyStoredConflictResolutions(ctx context.Context, conflicts []domain.NetworkConflict) []domain.NetworkConflict {
+	if ns.driftStore == nil {
+		return conflicts
+	}
+	for i := range conflicts {
+		item, err := ns.driftStore.GetDriftItem(ctx, conflicts[i].ID)
+		if err != nil {
+			continue
+		}
+		conflicts[i].Status = string(item.Status)
+		conflicts[i].ResolutionState = string(item.Status)
+		if item.IgnoreReason != "" {
+			conflicts[i].ResolutionRequested = parseNetworkDecision(item.IgnoreReason)
+			conflicts[i].Evidence = append(conflicts[i].Evidence, "resolution="+item.IgnoreReason)
+		}
+	}
+	return conflicts
+}
+
+func (ns *NetworkServer) persistNetworkConflictResolution(ctx context.Context, conflict domain.NetworkConflict, req domain.ResolveNetworkConflictRequest) error {
+	if ns.driftStore == nil {
+		return fmt.Errorf("drift store is not available")
+	}
+	status := networkDecisionStatus(req.Decision)
+	reason := networkResolutionReason(req.Decision, req.Reason)
+	if err := ns.driftStore.UpdateDriftStatus(ctx, conflict.ID, status, reason); err == nil {
+		return nil
+	} else if !errors.Is(err, storage.ErrNotFound) {
+		return err
+	}
+
+	now := time.Now().UTC()
+	item := domain.DriftItem{
+		ID:           conflict.ID,
+		AccountID:    firstConflictAccountID(conflict),
+		Type:         domain.DriftTypeAccountDrift,
+		Severity:     driftSeverityFromNetwork(conflict.Severity),
+		Status:       domain.DriftStatusOpen,
+		Title:        conflict.Title,
+		Description:  conflict.Description,
+		ResourceCIDR: conflict.CIDR,
+		Details: map[string]string{
+			"network_conflict_type": conflict.Type,
+			"recommended_action":    conflict.RecommendedAction,
+		},
+		DetectedAt: now,
+		UpdatedAt:  now,
+	}
+	if len(conflict.DiscoveredIDs) > 0 {
+		item.ResourceID = &conflict.DiscoveredIDs[0]
+	}
+	if len(conflict.PoolIDs) > 0 {
+		item.PoolID = &conflict.PoolIDs[0]
+	}
+	if err := ns.driftStore.CreateDriftItem(ctx, item); err != nil {
+		return err
+	}
+	return ns.driftStore.UpdateDriftStatus(ctx, conflict.ID, status, reason)
+}
+
 func buildNetworkHierarchy(flat []domain.NetworkNode) []domain.NetworkNode {
 	nodes := make(map[string]domain.NetworkNode, len(flat))
 	childrenByParent := make(map[string][]string, len(flat))
@@ -644,6 +712,53 @@ func filterNetworkConflicts(conflicts []domain.NetworkConflict, filters networkV
 		out = append(out, conflict)
 	}
 	return out
+}
+
+func networkDecisionStatus(decision string) domain.DriftStatus {
+	switch strings.ToLower(strings.TrimSpace(decision)) {
+	case "ignore":
+		return domain.DriftStatusIgnored
+	case "defer":
+		return domain.DriftStatusOpen
+	default:
+		return domain.DriftStatusResolved
+	}
+}
+
+func networkResolutionReason(decision string, reason string) string {
+	decision = strings.TrimSpace(decision)
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return "decision=" + decision
+	}
+	return "decision=" + decision + " reason=" + reason
+}
+
+func parseNetworkDecision(reason string) string {
+	for _, part := range strings.Fields(reason) {
+		if strings.HasPrefix(part, "decision=") {
+			return strings.TrimPrefix(part, "decision=")
+		}
+	}
+	return ""
+}
+
+func firstConflictAccountID(conflict domain.NetworkConflict) int64 {
+	if len(conflict.AccountIDs) > 0 {
+		return conflict.AccountIDs[0]
+	}
+	return 0
+}
+
+func driftSeverityFromNetwork(severity string) domain.DriftSeverity {
+	switch severity {
+	case "critical":
+		return domain.DriftSeverityCritical
+	case "info":
+		return domain.DriftSeverityInfo
+	default:
+		return domain.DriftSeverityWarning
+	}
 }
 
 func poolNodeID(id int64) string { return fmt.Sprintf("pool:%d", id) }

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -1,0 +1,774 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"cloudpam/internal/auth"
+	"cloudpam/internal/domain"
+	"cloudpam/internal/storage"
+)
+
+// NetworkServer handles merged network view endpoints.
+type NetworkServer struct {
+	srv        *Server
+	store      storage.Store
+	discStore  storage.DiscoveryStore
+	driftStore storage.DriftStore
+}
+
+// NewNetworkServer creates a merged network view server.
+func NewNetworkServer(srv *Server, store storage.Store, discStore storage.DiscoveryStore, driftStore storage.DriftStore) *NetworkServer {
+	return &NetworkServer{srv: srv, store: store, discStore: discStore, driftStore: driftStore}
+}
+
+// RegisterNetworkRoutes registers network routes without RBAC.
+func (ns *NetworkServer) RegisterNetworkRoutes() {
+	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/flat", ns.handleFlat)
+	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/hierarchy", ns.handleHierarchy)
+	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/merged", ns.handleMerged)
+	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/conflicts", ns.handleConflicts)
+	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/conflicts/", ns.handleConflictSubroutes)
+}
+
+// RegisterProtectedNetworkRoutes registers network routes with RBAC.
+func (ns *NetworkServer) RegisterProtectedNetworkRoutes(dualMW Middleware, logger *slog.Logger) {
+	readMW := RequirePermissionMiddleware(auth.ResourceDiscovery, auth.ActionRead, logger)
+	updateMW := RequirePermissionMiddleware(auth.ResourceDiscovery, auth.ActionUpdate, logger)
+	ns.srv.handleOpenAPIRoute("/api/v1/network/flat", dualMW(readMW(http.HandlerFunc(ns.handleFlat))))
+	ns.srv.handleOpenAPIRoute("/api/v1/network/hierarchy", dualMW(readMW(http.HandlerFunc(ns.handleHierarchy))))
+	ns.srv.handleOpenAPIRoute("/api/v1/network/merged", dualMW(readMW(http.HandlerFunc(ns.handleMerged))))
+	ns.srv.handleOpenAPIRoute("/api/v1/network/conflicts", dualMW(readMW(http.HandlerFunc(ns.handleConflicts))))
+	ns.srv.handleOpenAPIRoute("/api/v1/network/conflicts/", dualMW(updateMW(http.HandlerFunc(ns.handleConflictSubroutes))))
+}
+
+func (ns *NetworkServer) handleFlat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	view, err := ns.buildNetworkView(r.Context(), networkFiltersFromRequest(r))
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "network view failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, domain.NetworkViewResponse{
+		Items:         view.flat,
+		Total:         len(view.flat),
+		ConflictCount: len(view.conflicts),
+		Conflicts:     view.conflicts,
+	})
+}
+
+func (ns *NetworkServer) handleHierarchy(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	view, err := ns.buildNetworkView(r.Context(), networkFiltersFromRequest(r))
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "network hierarchy failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, domain.NetworkViewResponse{
+		Items:         view.hierarchy,
+		Total:         len(view.flat),
+		ConflictCount: len(view.conflicts),
+		Conflicts:     view.conflicts,
+	})
+}
+
+func (ns *NetworkServer) handleMerged(w http.ResponseWriter, r *http.Request) {
+	ns.handleHierarchy(w, r)
+}
+
+func (ns *NetworkServer) handleConflicts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	view, err := ns.buildNetworkView(r.Context(), networkFiltersFromRequest(r))
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "network conflicts failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, domain.NetworkConflictListResponse{Items: view.conflicts, Total: len(view.conflicts)})
+}
+
+func (ns *NetworkServer) handleConflictSubroutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/network/conflicts/"), "/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] != "resolve" {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "not found", "")
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	var req domain.ResolveNetworkConflictRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Decision) == "" {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "decision is required", "")
+		return
+	}
+	view, err := ns.buildNetworkView(r.Context(), networkViewFilters{})
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "network conflicts failed", err.Error())
+		return
+	}
+	for _, conflict := range view.conflicts {
+		if conflict.ID == parts[0] {
+			conflict.ResolutionState = "requested"
+			conflict.ResolutionRequested = req.Decision
+			writeJSON(w, http.StatusOK, conflict)
+			return
+		}
+	}
+	ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "conflict not found", "")
+}
+
+type networkViewFilters struct {
+	accountID    int64
+	provider     string
+	region       string
+	objectType   string
+	status       string
+	conflictType string
+	query        string
+}
+
+type builtNetworkView struct {
+	flat      []domain.NetworkNode
+	hierarchy []domain.NetworkNode
+	conflicts []domain.NetworkConflict
+}
+
+func networkFiltersFromRequest(r *http.Request) networkViewFilters {
+	q := r.URL.Query()
+	filters := networkViewFilters{
+		provider:     q.Get("provider"),
+		region:       q.Get("region"),
+		objectType:   q.Get("object_type"),
+		status:       q.Get("status"),
+		conflictType: q.Get("conflict_type"),
+		query:        strings.ToLower(strings.TrimSpace(q.Get("q"))),
+	}
+	if idText := q.Get("account_id"); idText != "" {
+		if id, err := strconv.ParseInt(idText, 10, 64); err == nil {
+			filters.accountID = id
+		}
+	}
+	return filters
+}
+
+func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkViewFilters) (builtNetworkView, error) {
+	accounts, err := ns.store.ListAccounts(ctx)
+	if err != nil {
+		return builtNetworkView{}, err
+	}
+	pools, err := ns.store.ListPools(ctx)
+	if err != nil {
+		return builtNetworkView{}, err
+	}
+
+	accountByID := make(map[int64]domain.Account, len(accounts))
+	for _, account := range accounts {
+		accountByID[account.ID] = account
+	}
+	poolByID := make(map[int64]domain.Pool, len(pools))
+	for _, pool := range pools {
+		poolByID[pool.ID] = pool
+	}
+
+	resources, err := ns.listAllDiscoveredResources(ctx, accounts)
+	if err != nil {
+		return builtNetworkView{}, err
+	}
+	resourceByProvider := make(map[string]domain.DiscoveredResource, len(resources))
+	for _, res := range resources {
+		resourceByProvider[resourceKey(res.AccountID, res.ResourceID)] = res
+	}
+
+	issuesByNode, conflicts := ns.computeNetworkConflicts(resources, pools, accountByID, poolByID, resourceByProvider)
+	nodes := make([]domain.NetworkNode, 0, len(pools)+len(resources)+len(accounts))
+	for _, pool := range pools {
+		node := networkNodeFromPool(pool, accountByID)
+		if nodeIssues := issuesByNode[node.ID]; len(nodeIssues) > 0 {
+			node.Issues = append(node.Issues, nodeIssues...)
+			node.State = "conflict"
+		}
+		nodes = append(nodes, node)
+	}
+	for _, res := range resources {
+		node := ns.networkNodeFromResource(res, accountByID, poolByID, resourceByProvider)
+		if nodeIssues := issuesByNode[node.ID]; len(nodeIssues) > 0 {
+			node.Issues = append(node.Issues, nodeIssues...)
+			node.State = worstNodeState(node.State, nodeIssues)
+		}
+		nodes = append(nodes, node)
+	}
+
+	filtered := make([]domain.NetworkNode, 0, len(nodes))
+	for _, node := range nodes {
+		if matchesNetworkFilters(node, filters) {
+			filtered = append(filtered, node)
+		}
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		if filtered[i].AccountName == filtered[j].AccountName {
+			if filtered[i].Region == filtered[j].Region {
+				if filtered[i].ObjectType == filtered[j].ObjectType {
+					return filtered[i].Name < filtered[j].Name
+				}
+				return filtered[i].ObjectType < filtered[j].ObjectType
+			}
+			return filtered[i].Region < filtered[j].Region
+		}
+		return filtered[i].AccountName < filtered[j].AccountName
+	})
+
+	filteredConflicts := filterNetworkConflicts(conflicts, filters)
+	return builtNetworkView{
+		flat:      filtered,
+		hierarchy: buildNetworkHierarchy(filtered),
+		conflicts: filteredConflicts,
+	}, nil
+}
+
+func (ns *NetworkServer) listAllDiscoveredResources(ctx context.Context, accounts []domain.Account) ([]domain.DiscoveredResource, error) {
+	const pageSize = 1000
+	var out []domain.DiscoveredResource
+	for _, account := range accounts {
+		accountCount := 0
+		for page := 1; ; page++ {
+			resources, total, err := ns.discStore.ListDiscoveredResources(ctx, account.ID, domain.DiscoveryFilters{Page: page, PageSize: pageSize})
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, resources...)
+			accountCount += len(resources)
+			if len(resources) == 0 || accountCount >= total {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func networkNodeFromPool(pool domain.Pool, accounts map[int64]domain.Account) domain.NetworkNode {
+	nodeID := poolNodeID(pool.ID)
+	node := domain.NetworkNode{
+		ID:         nodeID,
+		Kind:       "pool",
+		ObjectType: string(pool.Type),
+		Name:       pool.Name,
+		CIDR:       pool.CIDR,
+		Source:     string(pool.Source),
+		State:      "managed",
+	}
+	if pool.ParentID != nil {
+		parentID := poolNodeID(*pool.ParentID)
+		node.ParentID = &parentID
+	}
+	if pool.AccountID != nil {
+		node.AccountID = pool.AccountID
+		if account, ok := accounts[*pool.AccountID]; ok {
+			node.AccountName = account.Name
+			node.Provider = account.Provider
+		}
+	}
+	return node
+}
+
+func (ns *NetworkServer) networkNodeFromResource(res domain.DiscoveredResource, accounts map[int64]domain.Account, pools map[int64]domain.Pool, resources map[string]domain.DiscoveredResource) domain.NetworkNode {
+	nodeID := resourceNodeID(res.ID)
+	state := "discovered"
+	source := "discovered"
+	var parentID *string
+	if res.PoolID != nil {
+		state = "linked"
+		source = "linked"
+		id := poolNodeID(*res.PoolID)
+		parentID = &id
+	} else if res.ParentResourceID != nil {
+		if parent, ok := resources[resourceKey(res.AccountID, *res.ParentResourceID)]; ok {
+			id := resourceNodeID(parent.ID)
+			parentID = &id
+		}
+	} else if pool := bestContainingPool(res.CIDR, pools); pool != nil {
+		id := poolNodeID(pool.ID)
+		parentID = &id
+	}
+
+	account := accounts[res.AccountID]
+	node := domain.NetworkNode{
+		ID:                 nodeID,
+		ParentID:           parentID,
+		Kind:               "discovered",
+		ObjectType:         string(res.ResourceType),
+		Name:               firstNonEmpty(res.Name, res.ResourceID),
+		CIDR:               res.CIDR,
+		Provider:           res.Provider,
+		AccountID:          &res.AccountID,
+		AccountName:        account.Name,
+		Region:             res.Region,
+		ProviderResourceID: res.ResourceID,
+		DiscoveredID:       &res.ID,
+		LinkedPoolID:       res.PoolID,
+		Source:             source,
+		State:              state,
+		Evidence:           []string{fmt.Sprintf("%s %s in %s", res.Provider, res.ResourceID, firstNonEmpty(res.Region, "global"))},
+	}
+	if res.ResourceType == domain.ResourceTypeElasticIP {
+		node.IPAddress = res.Metadata["public_ip"]
+		if node.IPAddress == "" {
+			node.IPAddress = strings.TrimSuffix(res.CIDR, "/32")
+		}
+	}
+	return node
+}
+
+func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredResource, pools []domain.Pool, accounts map[int64]domain.Account, poolByID map[int64]domain.Pool, resourceByProvider map[string]domain.DiscoveredResource) (map[string][]domain.NetworkIssue, []domain.NetworkConflict) {
+	issuesByNode := map[string][]domain.NetworkIssue{}
+	var conflicts []domain.NetworkConflict
+	add := func(conflict domain.NetworkConflict) {
+		conflict.AvailableDecisions = []string{"import", "link", "skip", "ignore", "defer"}
+		conflicts = append(conflicts, conflict)
+		issue := domain.NetworkIssue{ID: conflict.ID, Type: conflict.Type, Severity: conflict.Severity, Message: conflict.Title}
+		for _, nodeID := range conflict.NodeIDs {
+			issuesByNode[nodeID] = append(issuesByNode[nodeID], issue)
+		}
+	}
+
+	resourcesByCIDR := map[string][]domain.DiscoveredResource{}
+	for _, res := range resources {
+		if res.CIDR != "" {
+			resourcesByCIDR[res.CIDR] = append(resourcesByCIDR[res.CIDR], res)
+		}
+	}
+
+	for _, res := range resources {
+		nodeID := resourceNodeID(res.ID)
+		if res.CIDR != "" {
+			if _, err := netip.ParsePrefix(res.CIDR); err != nil {
+				add(domain.NetworkConflict{
+					ID:                "invalid-cidr:" + res.ID.String(),
+					Type:              "invalid_cidr",
+					Severity:          "critical",
+					Status:            "open",
+					Title:             "Invalid discovered CIDR",
+					Description:       fmt.Sprintf("%s has invalid CIDR %q", res.ResourceID, res.CIDR),
+					RecommendedAction: "Skip this object until discovery sends a valid CIDR.",
+					NodeIDs:           []string{nodeID},
+					DiscoveredIDs:     []uuid.UUID{res.ID},
+					AccountIDs:        []int64{res.AccountID},
+					Regions:           []string{res.Region},
+					ObjectTypes:       []string{string(res.ResourceType)},
+					CIDR:              res.CIDR,
+					Evidence:          []string{fmt.Sprintf("resource_id=%s", res.ResourceID)},
+				})
+			}
+		}
+		if res.ResourceType == domain.ResourceTypeSubnet && res.ParentResourceID != nil {
+			parent, ok := resourceByProvider[resourceKey(res.AccountID, *res.ParentResourceID)]
+			if !ok {
+				add(domain.NetworkConflict{
+					ID:                "missing-parent:" + res.ID.String(),
+					Type:              "missing_parent",
+					Severity:          "warning",
+					Status:            "open",
+					Title:             "Missing parent VPC",
+					Description:       fmt.Sprintf("%s references parent %s, but that parent was not discovered", res.ResourceID, *res.ParentResourceID),
+					RecommendedAction: "Rediscover the account, create a placeholder parent, or skip this object.",
+					NodeIDs:           []string{nodeID},
+					DiscoveredIDs:     []uuid.UUID{res.ID},
+					AccountIDs:        []int64{res.AccountID},
+					Regions:           []string{res.Region},
+					ObjectTypes:       []string{string(res.ResourceType)},
+					CIDR:              res.CIDR,
+					Evidence:          []string{"parent_provider_resource_id=" + *res.ParentResourceID},
+				})
+			} else if res.CIDR != "" && parent.CIDR != "" && !networkCIDRContains(parent.CIDR, res.CIDR) {
+				add(domain.NetworkConflict{
+					ID:                "invalid-nesting:" + res.ID.String(),
+					Type:              "invalid_nesting",
+					Severity:          "critical",
+					Status:            "open",
+					Title:             "Subnet is outside parent VPC",
+					Description:       fmt.Sprintf("%s (%s) is not contained by parent %s (%s)", res.ResourceID, res.CIDR, parent.ResourceID, parent.CIDR),
+					RecommendedAction: "Check provider data and do not import until topology is corrected.",
+					NodeIDs:           []string{nodeID, resourceNodeID(parent.ID)},
+					DiscoveredIDs:     []uuid.UUID{res.ID, parent.ID},
+					AccountIDs:        []int64{res.AccountID},
+					Regions:           []string{res.Region},
+					ObjectTypes:       []string{string(res.ResourceType), string(parent.ResourceType)},
+					CIDR:              res.CIDR,
+					Evidence:          []string{fmt.Sprintf("parent_cidr=%s", parent.CIDR)},
+				})
+			}
+		}
+		if res.PoolID != nil {
+			if pool, ok := poolByID[*res.PoolID]; ok && res.CIDR != "" && !networkCIDREqual(pool.CIDR, res.CIDR) {
+				severity := "warning"
+				conflictType := "linked_pool_mismatch"
+				if !networkCIDRContains(pool.CIDR, res.CIDR) && !networkCIDRContains(res.CIDR, pool.CIDR) {
+					severity = "critical"
+					conflictType = "outside_pool"
+				}
+				add(domain.NetworkConflict{
+					ID:                conflictType + ":" + res.ID.String(),
+					Type:              conflictType,
+					Severity:          severity,
+					Status:            "open",
+					Title:             "Linked pool CIDR differs from discovered resource",
+					Description:       fmt.Sprintf("%s (%s) is linked to pool %s (%s)", res.ResourceID, res.CIDR, pool.Name, pool.CIDR),
+					RecommendedAction: "Review whether this is a soft link, import conflict, or drift.",
+					NodeIDs:           []string{nodeID, poolNodeID(pool.ID)},
+					DiscoveredIDs:     []uuid.UUID{res.ID},
+					PoolIDs:           []int64{pool.ID},
+					AccountIDs:        []int64{res.AccountID},
+					Regions:           []string{res.Region},
+					ObjectTypes:       []string{string(res.ResourceType), string(pool.Type)},
+					CIDR:              res.CIDR,
+					Evidence:          []string{fmt.Sprintf("pool_id=%d", pool.ID), "pool_cidr=" + pool.CIDR},
+				})
+			}
+		}
+		for _, pool := range pools {
+			if res.PoolID != nil && *res.PoolID == pool.ID {
+				continue
+			}
+			if res.CIDR == "" || pool.CIDR == "" || networkCIDREqual(res.CIDR, pool.CIDR) || !networkCIDROverlaps(res.CIDR, pool.CIDR) {
+				continue
+			}
+			if networkCIDRContains(pool.CIDR, res.CIDR) || networkCIDRContains(res.CIDR, pool.CIDR) {
+				continue
+			}
+			add(domain.NetworkConflict{
+				ID:                fmt.Sprintf("pool-overlap:%s:%d", res.ID.String(), pool.ID),
+				Type:              "managed_overlap",
+				Severity:          "warning",
+				Status:            "open",
+				Title:             "Discovered CIDR overlaps managed pool",
+				Description:       fmt.Sprintf("%s (%s) overlaps pool %s (%s)", res.ResourceID, res.CIDR, pool.Name, pool.CIDR),
+				RecommendedAction: "Choose whether to link, import separately, or skip this discovered object.",
+				NodeIDs:           []string{nodeID, poolNodeID(pool.ID)},
+				DiscoveredIDs:     []uuid.UUID{res.ID},
+				PoolIDs:           []int64{pool.ID},
+				AccountIDs:        accountIDsForPool(res.AccountID, pool),
+				Regions:           []string{res.Region},
+				ObjectTypes:       []string{string(res.ResourceType), string(pool.Type)},
+				CIDR:              res.CIDR,
+				Evidence:          []string{fmt.Sprintf("pool_id=%d", pool.ID), "pool_cidr=" + pool.CIDR},
+			})
+		}
+	}
+
+	for cidr, matches := range resourcesByCIDR {
+		accountsSeen := map[int64]bool{}
+		for _, res := range matches {
+			accountsSeen[res.AccountID] = true
+		}
+		if len(accountsSeen) < 2 {
+			continue
+		}
+		nodeIDs := make([]string, 0, len(matches))
+		ids := make([]uuid.UUID, 0, len(matches))
+		accountIDs := make([]int64, 0, len(accountsSeen))
+		regions := make([]string, 0, len(matches))
+		objectTypes := make([]string, 0, len(matches))
+		evidence := make([]string, 0, len(matches))
+		for id := range accountsSeen {
+			accountIDs = append(accountIDs, id)
+		}
+		sort.Slice(accountIDs, func(i, j int) bool { return accountIDs[i] < accountIDs[j] })
+		for _, res := range matches {
+			nodeIDs = append(nodeIDs, resourceNodeID(res.ID))
+			ids = append(ids, res.ID)
+			regions = append(regions, res.Region)
+			objectTypes = append(objectTypes, string(res.ResourceType))
+			accountName := accounts[res.AccountID].Name
+			evidence = append(evidence, fmt.Sprintf("%s in %s (%s)", res.ResourceID, firstNonEmpty(accountName, fmt.Sprintf("account %d", res.AccountID)), res.Region))
+		}
+		add(domain.NetworkConflict{
+			ID:                "duplicate-cidr:" + strings.ReplaceAll(cidr, "/", "_"),
+			Type:              "duplicate_cidr",
+			Severity:          "critical",
+			Status:            "open",
+			Title:             "Duplicate CIDR across accounts",
+			Description:       fmt.Sprintf("%s is discovered in multiple accounts", cidr),
+			RecommendedAction: "Choose the authoritative account or mark the duplicate reviewed.",
+			NodeIDs:           nodeIDs,
+			DiscoveredIDs:     ids,
+			AccountIDs:        accountIDs,
+			Regions:           uniqueStrings(regions),
+			ObjectTypes:       uniqueStrings(objectTypes),
+			CIDR:              cidr,
+			Evidence:          evidence,
+		})
+	}
+
+	sort.SliceStable(conflicts, func(i, j int) bool {
+		if conflicts[i].Severity == conflicts[j].Severity {
+			return conflicts[i].ID < conflicts[j].ID
+		}
+		return severityRank(conflicts[i].Severity) > severityRank(conflicts[j].Severity)
+	})
+	return issuesByNode, conflicts
+}
+
+func buildNetworkHierarchy(flat []domain.NetworkNode) []domain.NetworkNode {
+	nodes := make(map[string]domain.NetworkNode, len(flat))
+	childrenByParent := make(map[string][]string, len(flat))
+	for i := range flat {
+		node := flat[i]
+		node.Children = nil
+		nodes[node.ID] = node
+	}
+	var rootIDs []string
+	for _, node := range nodes {
+		if node.ParentID != nil {
+			if _, ok := nodes[*node.ParentID]; ok {
+				childrenByParent[*node.ParentID] = append(childrenByParent[*node.ParentID], node.ID)
+				continue
+			}
+		}
+		rootIDs = append(rootIDs, node.ID)
+	}
+	var build func(id string) domain.NetworkNode
+	build = func(id string) domain.NetworkNode {
+		node := nodes[id]
+		for _, childID := range childrenByParent[id] {
+			node.Children = append(node.Children, build(childID))
+		}
+		sortNetworkNodes(node.Children)
+		return node
+	}
+	roots := make([]domain.NetworkNode, 0, len(rootIDs))
+	for _, id := range rootIDs {
+		roots = append(roots, build(id))
+	}
+	sortNetworkNodes(roots)
+	return roots
+}
+
+func sortNetworkNodes(nodes []domain.NetworkNode) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		if nodes[i].Kind == nodes[j].Kind {
+			return nodes[i].Name < nodes[j].Name
+		}
+		return nodes[i].Kind < nodes[j].Kind
+	})
+	for i := range nodes {
+		sortNetworkNodes(nodes[i].Children)
+	}
+}
+
+func matchesNetworkFilters(node domain.NetworkNode, filters networkViewFilters) bool {
+	if filters.accountID > 0 && (node.AccountID == nil || *node.AccountID != filters.accountID) {
+		if node.Kind != "pool" || node.AccountID != nil {
+			return false
+		}
+	}
+	if filters.provider != "" && node.Provider != filters.provider {
+		return false
+	}
+	if filters.region != "" && node.Region != filters.region {
+		return false
+	}
+	if filters.objectType != "" && node.ObjectType != filters.objectType {
+		return false
+	}
+	if filters.status != "" && node.State != filters.status {
+		return false
+	}
+	if filters.conflictType != "" {
+		found := false
+		for _, issue := range node.Issues {
+			if issue.Type == filters.conflictType {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	if filters.query != "" {
+		haystack := strings.ToLower(strings.Join([]string{node.Name, node.CIDR, node.IPAddress, node.ProviderResourceID, node.AccountName, node.Region}, " "))
+		if !strings.Contains(haystack, filters.query) {
+			return false
+		}
+	}
+	return true
+}
+
+func filterNetworkConflicts(conflicts []domain.NetworkConflict, filters networkViewFilters) []domain.NetworkConflict {
+	out := make([]domain.NetworkConflict, 0, len(conflicts))
+	for _, conflict := range conflicts {
+		if filters.conflictType != "" && conflict.Type != filters.conflictType {
+			continue
+		}
+		if filters.accountID > 0 && !containsInt64(conflict.AccountIDs, filters.accountID) {
+			continue
+		}
+		if filters.region != "" && !containsStringValue(conflict.Regions, filters.region) {
+			continue
+		}
+		if filters.objectType != "" && !containsStringValue(conflict.ObjectTypes, filters.objectType) {
+			continue
+		}
+		if filters.query != "" {
+			haystack := strings.ToLower(strings.Join(append([]string{conflict.Title, conflict.Description, conflict.CIDR}, conflict.Evidence...), " "))
+			if !strings.Contains(haystack, filters.query) {
+				continue
+			}
+		}
+		out = append(out, conflict)
+	}
+	return out
+}
+
+func poolNodeID(id int64) string { return fmt.Sprintf("pool:%d", id) }
+
+func resourceNodeID(id uuid.UUID) string { return "discovered:" + id.String() }
+
+func resourceKey(accountID int64, providerResourceID string) string {
+	return fmt.Sprintf("%d:%s", accountID, providerResourceID)
+}
+
+func bestContainingPool(cidr string, pools map[int64]domain.Pool) *domain.Pool {
+	var best *domain.Pool
+	bestBits := -1
+	for _, pool := range pools {
+		if networkCIDRContains(pool.CIDR, cidr) {
+			bits := networkPrefixLength(pool.CIDR)
+			if bits > bestBits {
+				p := pool
+				best = &p
+				bestBits = bits
+			}
+		}
+	}
+	return best
+}
+
+func worstNodeState(current string, issues []domain.NetworkIssue) string {
+	for _, issue := range issues {
+		if issue.Severity == "critical" {
+			return "conflict"
+		}
+	}
+	if len(issues) > 0 {
+		return "warning"
+	}
+	return current
+}
+
+func networkCIDREqual(a, b string) bool {
+	pa, errA := netip.ParsePrefix(a)
+	pb, errB := netip.ParsePrefix(b)
+	return errA == nil && errB == nil && pa.Masked() == pb.Masked()
+}
+
+func networkCIDRContains(parent, child string) bool {
+	p, errP := netip.ParsePrefix(parent)
+	c, errC := netip.ParsePrefix(child)
+	if errP != nil || errC != nil || p.Addr().BitLen() != c.Addr().BitLen() {
+		return false
+	}
+	return p.Bits() <= c.Bits() && p.Masked().Contains(c.Masked().Addr())
+}
+
+func networkCIDROverlaps(a, b string) bool {
+	pa, errA := netip.ParsePrefix(a)
+	pb, errB := netip.ParsePrefix(b)
+	if errA != nil || errB != nil || pa.Addr().BitLen() != pb.Addr().BitLen() {
+		return false
+	}
+	return pa.Masked().Contains(pb.Masked().Addr()) || pb.Masked().Contains(pa.Masked().Addr())
+}
+
+func networkPrefixLength(cidr string) int {
+	prefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return -1
+	}
+	return prefix.Bits()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func accountIDsForPool(discoveredAccountID int64, pool domain.Pool) []int64 {
+	if pool.AccountID == nil || *pool.AccountID == discoveredAccountID {
+		return []int64{discoveredAccountID}
+	}
+	return []int64{discoveredAccountID, *pool.AccountID}
+}
+
+func uniqueStrings(values []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func severityRank(severity string) int {
+	switch severity {
+	case "critical":
+		return 3
+	case "warning":
+		return 2
+	default:
+		return 1
+	}
+}
+
+func containsInt64(items []int64, want int64) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStringValue(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -130,6 +130,10 @@ func (ns *NetworkServer) handleConflictSubroutes(w http.ResponseWriter, r *http.
 		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "decision is required", "")
 		return
 	}
+	if !isValidNetworkDecision(req.Decision) {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "decision must be one of skip, ignore, or defer", "")
+		return
+	}
 	view, err := ns.buildNetworkView(r.Context(), networkViewFilters{})
 	if err != nil {
 		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "network conflicts failed", err.Error())
@@ -357,7 +361,7 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 	issuesByNode := map[string][]domain.NetworkIssue{}
 	var conflicts []domain.NetworkConflict
 	add := func(conflict domain.NetworkConflict) {
-		conflict.AvailableDecisions = []string{"import", "link", "skip", "ignore", "defer"}
+		conflict.AvailableDecisions = networkConflictDecisions()
 		conflicts = append(conflicts, conflict)
 		issue := domain.NetworkIssue{ID: conflict.ID, Type: conflict.Type, Severity: conflict.Severity, Message: conflict.Title}
 		for _, nodeID := range conflict.NodeIDs {
@@ -720,9 +724,25 @@ func networkDecisionStatus(decision string) domain.DriftStatus {
 		return domain.DriftStatusIgnored
 	case "defer":
 		return domain.DriftStatusOpen
-	default:
+	case "skip":
 		return domain.DriftStatusResolved
+	default:
+		return domain.DriftStatusOpen
 	}
+}
+
+func networkConflictDecisions() []string {
+	return []string{"skip", "ignore", "defer"}
+}
+
+func isValidNetworkDecision(decision string) bool {
+	decision = strings.ToLower(strings.TrimSpace(decision))
+	for _, valid := range networkConflictDecisions() {
+		if decision == valid {
+			return true
+		}
+	}
+	return false
 }
 
 func networkResolutionReason(decision string, reason string) string {

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"cloudpam/internal/domain"
+)
+
+func TestNetworkFlatShowsDiscoveredObjectsAndDuplicateConflict(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	a1, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:111111111111", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account 1: %v", err)
+	}
+	a2, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:222222222222", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account 2: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpc1ID := uuid.New()
+	vpc2ID := uuid.New()
+	eipID := uuid.New()
+	for _, res := range []domain.DiscoveredResource{
+		{ID: vpc1ID, AccountID: a1.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-prod", Name: "prod-vpc", CIDR: "10.70.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
+		{ID: vpc2ID, AccountID: a2.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-dev", Name: "dev-vpc", CIDR: "10.70.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
+		{ID: eipID, AccountID: a1.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeElasticIP, ResourceID: "eipalloc-1", Name: "prod-eip", CIDR: "198.51.100.10/32", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now, Metadata: map[string]string{"public_ip": "198.51.100.10"}},
+	} {
+		upsertDiscoveredForImportTest(t, ds, res)
+	}
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/flat", "", http.StatusOK)
+	var resp domain.NetworkViewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal flat: %v", err)
+	}
+	if resp.Total != 3 {
+		t.Fatalf("total = %d, want 3", resp.Total)
+	}
+	if resp.ConflictCount != 1 {
+		t.Fatalf("conflict_count = %d, want 1: %+v", resp.ConflictCount, resp.Conflicts)
+	}
+	var sawEIP bool
+	for _, item := range resp.Items {
+		if item.ObjectType == "elastic_ip" && item.IPAddress == "198.51.100.10" {
+			sawEIP = true
+		}
+	}
+	if !sawEIP {
+		t.Fatalf("flat view did not include EIP network object: %+v", resp.Items)
+	}
+}
+
+func TestNetworkHierarchyPlacesVPCUnderPoolAndSubnetUnderVPC(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	_, err = st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-space", CIDR: "10.80.0.0/12", Type: domain.PoolTypeSupernet})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	subnetID := uuid.New()
+	parent := "vpc-1"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: vpcID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-1", Name: "prod-vpc", CIDR: "10.80.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: subnetID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeSubnet, ResourceID: "subnet-1", Name: "prod-subnet", CIDR: "10.80.1.0/24", ParentResourceID: &parent, Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/hierarchy", "", http.StatusOK)
+	var resp domain.NetworkViewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal hierarchy: %v", err)
+	}
+	if !hierarchyHasParentChild(resp.Items, "pool:", "discovered:"+vpcID.String()) {
+		t.Fatalf("VPC was not nested under containing pool: %+v", resp.Items)
+	}
+	if !hierarchyHasParentChild(resp.Items, "discovered:"+vpcID.String(), "discovered:"+subnetID.String()) {
+		t.Fatalf("subnet was not nested under VPC: %+v", resp.Items)
+	}
+}
+
+func TestNetworkConflictsExposeMissingParentAndResolveRequest(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	now := time.Now().UTC()
+	subnetID := uuid.New()
+	parent := "vpc-missing"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:               subnetID,
+		AccountID:        account.ID,
+		Provider:         "aws",
+		Region:           "us-east-1",
+		ResourceType:     domain.ResourceTypeSubnet,
+		ResourceID:       "subnet-1",
+		Name:             "orphan-subnet",
+		CIDR:             "10.90.1.0/24",
+		ParentResourceID: &parent,
+		Status:           domain.DiscoveryStatusActive,
+		DiscoveredAt:     now,
+		LastSeenAt:       now,
+	})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent", "", http.StatusOK)
+	var resp domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if resp.Total != 1 || resp.Items[0].Type != "missing_parent" {
+		t.Fatalf("unexpected conflicts: %+v", resp)
+	}
+
+	body := `{"decision":"skip","reason":"parent intentionally absent"}`
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/resolve", resp.Items[0].ID), body, http.StatusOK)
+	var resolved domain.NetworkConflict
+	if err := json.Unmarshal(rr.Body.Bytes(), &resolved); err != nil {
+		t.Fatalf("unmarshal resolve: %v", err)
+	}
+	if resolved.ResolutionState != "requested" || resolved.ResolutionRequested != "skip" {
+		t.Fatalf("unexpected resolve response: %+v", resolved)
+	}
+}
+
+func hierarchyHasParentChild(nodes []domain.NetworkNode, parentPrefix string, childID string) bool {
+	for _, node := range nodes {
+		parentMatches := strings.HasPrefix(node.ID, parentPrefix)
+		for _, child := range node.Children {
+			if parentMatches && child.ID == childID {
+				return true
+			}
+			if hierarchyHasParentChild([]domain.NetworkNode{child}, parentPrefix, childID) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -129,8 +129,16 @@ func TestNetworkConflictsExposeMissingParentAndResolveRequest(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resolved); err != nil {
 		t.Fatalf("unmarshal resolve: %v", err)
 	}
-	if resolved.ResolutionState != "requested" || resolved.ResolutionRequested != "skip" {
+	if resolved.Status != "resolved" || resolved.ResolutionState != "resolved" || resolved.ResolutionRequested != "skip" {
 		t.Fatalf("unexpected resolve response: %+v", resolved)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal conflicts after resolve: %v", err)
+	}
+	if resp.Items[0].Status != "resolved" || resp.Items[0].ResolutionRequested != "skip" {
+		t.Fatalf("resolution was not durable in computed conflict view: %+v", resp.Items[0])
 	}
 }
 

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -122,6 +122,11 @@ func TestNetworkConflictsExposeMissingParentAndResolveRequest(t *testing.T) {
 	if resp.Total != 1 || resp.Items[0].Type != "missing_parent" {
 		t.Fatalf("unexpected conflicts: %+v", resp)
 	}
+	if strings.Join(resp.Items[0].AvailableDecisions, ",") != "skip,ignore,defer" {
+		t.Fatalf("available decisions = %v, want skip/ignore/defer", resp.Items[0].AvailableDecisions)
+	}
+
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/resolve", resp.Items[0].ID), `{"decision":"link"}`, http.StatusBadRequest)
 
 	body := `{"decision":"skip","reason":"parent intentionally absent"}`
 	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/resolve", resp.Items[0].ID), body, http.StatusOK)

--- a/internal/domain/discovery.go
+++ b/internal/domain/discovery.go
@@ -124,6 +124,66 @@ type DiscoveryResourcesResponse struct {
 	PageSize int                  `json:"page_size"`
 }
 
+// DiscoveryImportPreviewRequest asks the API to classify selected discovered
+// resources before any managed IPAM records are created or linked.
+type DiscoveryImportPreviewRequest struct {
+	AccountID   int64       `json:"account_id"`
+	ResourceIDs []uuid.UUID `json:"resource_ids"`
+	PoolID      *int64      `json:"pool_id,omitempty"`
+}
+
+// DiscoveryImportApplyRequest applies the same selected-resource import plan
+// returned by preview. Only importable rows are created or linked.
+type DiscoveryImportApplyRequest struct {
+	AccountID   int64       `json:"account_id"`
+	ResourceIDs []uuid.UUID `json:"resource_ids"`
+	PoolID      *int64      `json:"pool_id,omitempty"`
+}
+
+// DiscoveryImportPreviewItem describes the proposed conversion, soft link, or
+// blocking issue for one selected discovered resource.
+type DiscoveryImportPreviewItem struct {
+	ResourceID           uuid.UUID         `json:"resource_id"`
+	ProviderResourceID   string            `json:"provider_resource_id,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	Provider             string            `json:"provider,omitempty"`
+	Region               string            `json:"region,omitempty"`
+	ResourceType         CloudResourceType `json:"resource_type,omitempty"`
+	CIDR                 string            `json:"cidr,omitempty"`
+	Status               string            `json:"status"`
+	ProposedAction       string            `json:"proposed_action"`
+	ProposedManagedType  string            `json:"proposed_managed_type,omitempty"`
+	LinkedPoolID         *int64            `json:"linked_pool_id,omitempty"`
+	ProposedPoolID       *int64            `json:"proposed_pool_id,omitempty"`
+	ProposedParentPoolID *int64            `json:"proposed_parent_pool_id,omitempty"`
+	Issues               []string          `json:"issues"`
+	Evidence             []string          `json:"evidence,omitempty"`
+	ConflictPoolIDs      []int64           `json:"conflict_pool_ids,omitempty"`
+	DuplicateResourceIDs []uuid.UUID       `json:"duplicate_resource_ids,omitempty"`
+}
+
+// DiscoveryImportPreviewResponse is returned by import preview and by apply as
+// the authoritative per-row classification used for the operation.
+type DiscoveryImportPreviewResponse struct {
+	Items          []DiscoveryImportPreviewItem `json:"items"`
+	Importable     int                          `json:"importable"`
+	Blocked        int                          `json:"blocked"`
+	LinkedOnly     int                          `json:"linked_only"`
+	AlreadyLinked  int                          `json:"already_linked"`
+	ConflictCount  int                          `json:"conflict_count"`
+	SelectedPoolID *int64                       `json:"selected_pool_id,omitempty"`
+}
+
+// DiscoveryImportApplyResponse reports the result of applying selected,
+// importable discovery preview rows.
+type DiscoveryImportApplyResponse struct {
+	Preview         DiscoveryImportPreviewResponse `json:"preview"`
+	PoolsCreated    int                            `json:"pools_created"`
+	ResourcesLinked int                            `json:"resources_linked"`
+	Skipped         int                            `json:"skipped"`
+	Errors          []string                       `json:"errors"`
+}
+
 // SyncJobsResponse is the response for listing sync jobs.
 type SyncJobsResponse struct {
 	Items []SyncJob `json:"items"`

--- a/internal/domain/network.go
+++ b/internal/domain/network.go
@@ -1,0 +1,82 @@
+package domain
+
+import "github.com/google/uuid"
+
+// NetworkIssue describes an actionable issue attached to a merged network row
+// or hierarchy node.
+type NetworkIssue struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+// NetworkNode is the provider-neutral representation used by merged flat and
+// hierarchy network views.
+type NetworkNode struct {
+	ID                 string         `json:"id"`
+	ParentID           *string        `json:"parent_id,omitempty"`
+	Kind               string         `json:"kind"`
+	ObjectType         string         `json:"object_type"`
+	Name               string         `json:"name"`
+	CIDR               string         `json:"cidr,omitempty"`
+	IPAddress          string         `json:"ip_address,omitempty"`
+	Provider           string         `json:"provider,omitempty"`
+	AccountID          *int64         `json:"account_id,omitempty"`
+	AccountName        string         `json:"account_name,omitempty"`
+	Region             string         `json:"region,omitempty"`
+	ProviderResourceID string         `json:"provider_resource_id,omitempty"`
+	DiscoveredID       *uuid.UUID     `json:"discovered_id,omitempty"`
+	LinkedPoolID       *int64         `json:"linked_pool_id,omitempty"`
+	Source             string         `json:"source"`
+	State              string         `json:"state"`
+	Issues             []NetworkIssue `json:"issues,omitempty"`
+	Evidence           []string       `json:"evidence,omitempty"`
+	Children           []NetworkNode  `json:"children,omitempty"`
+}
+
+// NetworkConflict is a computed conflict/drift/duplicate record shown in the
+// network conflict panel.
+type NetworkConflict struct {
+	ID                  string      `json:"id"`
+	Type                string      `json:"type"`
+	Severity            string      `json:"severity"`
+	Status              string      `json:"status"`
+	Title               string      `json:"title"`
+	Description         string      `json:"description"`
+	RecommendedAction   string      `json:"recommended_action,omitempty"`
+	NodeIDs             []string    `json:"node_ids,omitempty"`
+	DiscoveredIDs       []uuid.UUID `json:"discovered_ids,omitempty"`
+	PoolIDs             []int64     `json:"pool_ids,omitempty"`
+	Provider            string      `json:"provider,omitempty"`
+	AccountIDs          []int64     `json:"account_ids,omitempty"`
+	Regions             []string    `json:"regions,omitempty"`
+	ObjectTypes         []string    `json:"object_types,omitempty"`
+	CIDR                string      `json:"cidr,omitempty"`
+	Evidence            []string    `json:"evidence,omitempty"`
+	AvailableDecisions  []string    `json:"available_decisions,omitempty"`
+	ResolutionState     string      `json:"resolution_state,omitempty"`
+	ResolutionRequested string      `json:"resolution_requested,omitempty"`
+}
+
+// NetworkViewResponse returns the flat or hierarchical merged network view.
+type NetworkViewResponse struct {
+	Items         []NetworkNode     `json:"items"`
+	Total         int               `json:"total"`
+	ConflictCount int               `json:"conflict_count"`
+	Conflicts     []NetworkConflict `json:"conflicts,omitempty"`
+}
+
+// NetworkConflictListResponse returns computed network conflicts.
+type NetworkConflictListResponse struct {
+	Items []NetworkConflict `json:"items"`
+	Total int               `json:"total"`
+}
+
+// ResolveNetworkConflictRequest asks the API to resolve or mark a computed
+// conflict decision. The current implementation returns the requested state as
+// response metadata; durable conflict records are handled by drift items.
+type ResolveNetworkConflictRequest struct {
+	Decision string `json:"decision"`
+	Reason   string `json:"reason,omitempty"`
+}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -479,6 +479,115 @@ export interface DiscoveryImportResponse {
   errors: string[]
 }
 
+export type DiscoveryImportPreviewStatus =
+  | 'importable'
+  | 'blocked'
+  | 'conflict'
+  | 'linked_only'
+  | 'already_linked'
+  | 'not_found'
+
+export interface DiscoveryImportPreviewItem {
+  resource_id: string
+  provider_resource_id?: string
+  name?: string
+  provider?: string
+  region?: string
+  resource_type?: CloudResourceType
+  cidr?: string
+  status: DiscoveryImportPreviewStatus
+  proposed_action: 'create_pool' | 'link_pool' | 'link_only' | 'none'
+  proposed_managed_type?: string
+  linked_pool_id?: number | null
+  proposed_pool_id?: number | null
+  proposed_parent_pool_id?: number | null
+  issues: string[]
+  evidence?: string[]
+  conflict_pool_ids?: number[]
+  duplicate_resource_ids?: string[]
+}
+
+export interface DiscoveryImportPreviewResponse {
+  items: DiscoveryImportPreviewItem[]
+  importable: number
+  blocked: number
+  linked_only: number
+  already_linked: number
+  conflict_count: number
+  selected_pool_id?: number | null
+}
+
+export interface DiscoveryImportApplyResponse {
+  preview: DiscoveryImportPreviewResponse
+  pools_created: number
+  resources_linked: number
+  skipped: number
+  errors: string[]
+}
+
+export interface NetworkIssue {
+  id: string
+  type: string
+  severity: string
+  message: string
+}
+
+export interface NetworkNode {
+  id: string
+  parent_id?: string | null
+  kind: string
+  object_type: string
+  name: string
+  cidr?: string
+  ip_address?: string
+  provider?: string
+  account_id?: number | null
+  account_name?: string
+  region?: string
+  provider_resource_id?: string
+  discovered_id?: string | null
+  linked_pool_id?: number | null
+  source: string
+  state: string
+  issues?: NetworkIssue[]
+  evidence?: string[]
+  children?: NetworkNode[]
+}
+
+export interface NetworkConflict {
+  id: string
+  type: string
+  severity: string
+  status: string
+  title: string
+  description: string
+  recommended_action?: string
+  node_ids?: string[]
+  discovered_ids?: string[]
+  pool_ids?: number[]
+  provider?: string
+  account_ids?: number[]
+  regions?: string[]
+  object_types?: string[]
+  cidr?: string
+  evidence?: string[]
+  available_decisions?: string[]
+  resolution_state?: string
+  resolution_requested?: string
+}
+
+export interface NetworkViewResponse {
+  items: NetworkNode[]
+  total: number
+  conflict_count: number
+  conflicts?: NetworkConflict[]
+}
+
+export interface NetworkConflictListResponse {
+  items: NetworkConflict[]
+  total: number
+}
+
 // --- Recommendation types ---
 
 export type RecommendationType = 'allocation' | 'compliance'

--- a/ui/src/hooks/useDiscovery.ts
+++ b/ui/src/hooks/useDiscovery.ts
@@ -9,6 +9,8 @@ import type {
   SyncTriggerResponse,
   AgentProvisionResponse,
   DiscoveryImportResponse,
+  DiscoveryImportPreviewResponse,
+  DiscoveryImportApplyResponse,
 } from '../api/types'
 
 export function useDiscoveryResources() {
@@ -115,7 +117,43 @@ export function useSyncJobs() {
     })
   }, [])
 
-  return { jobs, loading, error, fetch, triggerSync, getJob, importDiscoveredSchema }
+  const previewDiscoveryImport = useCallback(
+    async (accountId: number, resourceIds: string[]) => {
+      return post<DiscoveryImportPreviewResponse>(
+        '/api/v1/discovery/import/preview',
+        {
+          account_id: accountId,
+          resource_ids: resourceIds,
+        },
+      )
+    },
+    [],
+  )
+
+  const applyDiscoveryImport = useCallback(
+    async (accountId: number, resourceIds: string[]) => {
+      return post<DiscoveryImportApplyResponse>(
+        '/api/v1/discovery/import/apply',
+        {
+          account_id: accountId,
+          resource_ids: resourceIds,
+        },
+      )
+    },
+    [],
+  )
+
+  return {
+    jobs,
+    loading,
+    error,
+    fetch,
+    triggerSync,
+    getJob,
+    importDiscoveredSchema,
+    previewDiscoveryImport,
+    applyDiscoveryImport,
+  }
 }
 
 export function useAgentProvisioning() {

--- a/ui/src/hooks/useNetwork.ts
+++ b/ui/src/hooks/useNetwork.ts
@@ -1,0 +1,108 @@
+import { useCallback, useState } from 'react'
+import { get, post } from '../api/client'
+import type {
+  NetworkConflict,
+  NetworkConflictListResponse,
+  NetworkViewResponse,
+} from '../api/types'
+
+export interface NetworkFilters {
+  account_id?: number
+  provider?: string
+  region?: string
+  object_type?: string
+  status?: string
+  conflict_type?: string
+  q?: string
+}
+
+function networkQuery(filters?: NetworkFilters) {
+  const params = new URLSearchParams()
+  if (filters?.account_id) params.set('account_id', String(filters.account_id))
+  if (filters?.provider) params.set('provider', filters.provider)
+  if (filters?.region) params.set('region', filters.region)
+  if (filters?.object_type) params.set('object_type', filters.object_type)
+  if (filters?.status) params.set('status', filters.status)
+  if (filters?.conflict_type) params.set('conflict_type', filters.conflict_type)
+  if (filters?.q) params.set('q', filters.q)
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}
+
+export function useNetworkView() {
+  const [flat, setFlat] = useState<NetworkViewResponse | null>(null)
+  const [hierarchy, setHierarchy] = useState<NetworkViewResponse | null>(null)
+  const [conflicts, setConflicts] = useState<NetworkConflictListResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchFlat = useCallback(async (filters?: NetworkFilters) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await get<NetworkViewResponse>(`/api/v1/network/flat${networkQuery(filters)}`)
+      setFlat(resp)
+      return resp
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load network flat view'
+      setError(msg)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const fetchHierarchy = useCallback(async (filters?: NetworkFilters) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await get<NetworkViewResponse>(`/api/v1/network/hierarchy${networkQuery(filters)}`)
+      setHierarchy(resp)
+      return resp
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load network hierarchy'
+      setError(msg)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const fetchConflicts = useCallback(async (filters?: NetworkFilters) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await get<NetworkConflictListResponse>(`/api/v1/network/conflicts${networkQuery(filters)}`)
+      setConflicts(resp)
+      return resp
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load network conflicts'
+      setError(msg)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const resolveConflict = useCallback(
+    async (id: string, decision: string, reason?: string) => {
+      return post<NetworkConflict>(`/api/v1/network/conflicts/${encodeURIComponent(id)}/resolve`, {
+        decision,
+        reason,
+      })
+    },
+    [],
+  )
+
+  return {
+    flat,
+    hierarchy,
+    conflicts,
+    loading,
+    error,
+    fetchFlat,
+    fetchHierarchy,
+    fetchConflicts,
+    resolveConflict,
+  }
+}

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -15,6 +15,8 @@ import {
   Trash2,
   X,
   Plus,
+  Network,
+  Table2,
 } from 'lucide-react'
 import {
   useDiscoveryResources,
@@ -23,6 +25,7 @@ import {
 } from '../hooks/useDiscovery'
 import { useAccounts } from '../hooks/useAccounts'
 import { usePools } from '../hooks/usePools'
+import { useNetworkView } from '../hooks/useNetwork'
 import { useToast } from '../hooks/useToast'
 import StatusBadge from '../components/StatusBadge'
 import DiscoveryWizard from '../components/DiscoveryWizard'
@@ -35,9 +38,14 @@ import type {
   SyncJob,
   DiscoveryAgent,
   AgentStatus,
+  DiscoveryImportPreviewResponse,
+  DiscoveryImportPreviewItem,
+  NetworkNode,
+  NetworkConflict,
+  NetworkIssue,
 } from '../api/types'
 
-type Tab = 'resources' | 'sync' | 'agents'
+type Tab = 'resources' | 'network' | 'sync' | 'agents'
 
 function mergeJobs(current: SyncJob[], updates: SyncJob[]) {
   const byID = new Map(current.map((job) => [job.id, job]))
@@ -73,7 +81,8 @@ export default function DiscoveryPage() {
     fetch: fetchJobs,
     triggerSync,
     getJob,
-    importDiscoveredSchema,
+    previewDiscoveryImport,
+    applyDiscoveryImport,
   } = useSyncJobs()
   const {
     agents,
@@ -89,6 +98,9 @@ export default function DiscoveryPage() {
   const [selectedScanAgentId, setSelectedScanAgentId] = useState('all')
   const [scanLoading, setScanLoading] = useState(false)
   const [importLoading, setImportLoading] = useState(false)
+  const [applyImportLoading, setApplyImportLoading] = useState(false)
+  const [selectedResourceIds, setSelectedResourceIds] = useState<string[]>([])
+  const [importPreview, setImportPreview] = useState<DiscoveryImportPreviewResponse | null>(null)
   const [trackedScanJobs, setTrackedScanJobs] = useState<SyncJob[]>([])
   const [linkingResource, setLinkingResource] = useState<DiscoveredResource | null>(null)
   const [linkingLoading, setLinkingLoading] = useState(false)
@@ -126,6 +138,11 @@ export default function DiscoveryPage() {
   useEffect(() => {
     loadResources()
   }, [loadResources])
+
+  useEffect(() => {
+    setSelectedResourceIds([])
+    setImportPreview(null)
+  }, [selectedAccountId])
 
   useEffect(() => {
     return () => {
@@ -245,22 +262,64 @@ export default function DiscoveryPage() {
     }
   }
 
-  async function handleImportSchema() {
+  async function handlePreviewImport() {
     if (!selectedAccountId) return
+    if (selectedResourceIds.length === 0) {
+      showToast('Select discovered resources to preview import', 'error')
+      return
+    }
     setImportLoading(true)
     try {
-      const result = await importDiscoveredSchema(selectedAccountId)
+      const preview = await previewDiscoveryImport(selectedAccountId, selectedResourceIds)
+      setImportPreview(preview)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Import preview failed', 'error')
+    } finally {
+      setImportLoading(false)
+    }
+  }
+
+  async function handleApplyImport() {
+    if (!selectedAccountId || !importPreview) return
+    const importableIds = importPreview.items
+      .filter((item) => item.status === 'importable')
+      .map((item) => item.resource_id)
+    if (importableIds.length === 0) {
+      showToast('No importable resources in this preview', 'error')
+      return
+    }
+    setApplyImportLoading(true)
+    try {
+      const result = await applyDiscoveryImport(selectedAccountId, importableIds)
       const detail = result.errors.length > 0 ? ` (${result.errors.length} warning${result.errors.length === 1 ? '' : 's'})` : ''
       showToast(
         `Imported ${result.pools_created} pools and linked ${result.resources_linked} resources${detail}`,
         result.errors.length > 0 ? 'info' : 'success',
       )
+      setImportPreview(null)
+      setSelectedResourceIds([])
+      fetchPools()
       loadResources()
     } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Import failed', 'error')
+      showToast(err instanceof Error ? err.message : 'Import apply failed', 'error')
     } finally {
-      setImportLoading(false)
+      setApplyImportLoading(false)
     }
+  }
+
+  function toggleResourceSelection(resource: DiscoveredResource) {
+    setSelectedResourceIds((current) =>
+      current.includes(resource.id)
+        ? current.filter((id) => id !== resource.id)
+        : [...current, resource.id],
+    )
+  }
+
+  function selectVisibleImportableResources(resources: DiscoveredResource[]) {
+    const ids = resources
+      .filter((resource) => isSelectableDiscoveryResource(resource))
+      .map((resource) => resource.id)
+    setSelectedResourceIds((current) => Array.from(new Set([...current, ...ids])))
   }
 
   async function handleDeleteAgent(agent: DiscoveryAgent) {
@@ -403,12 +462,12 @@ export default function DiscoveryPage() {
             Add Agent
           </button>
           <button
-            onClick={handleImportSchema}
-            disabled={importLoading}
+            onClick={() => void handlePreviewImport()}
+            disabled={importLoading || selectedResourceIds.length === 0}
             className="inline-flex items-center gap-2 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-3 py-1.5 text-sm disabled:opacity-50"
           >
             {importLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <UploadCloud className="w-4 h-4" />}
-            Import Schema
+            Preview Import
           </button>
           <select
             value={selectedScanAgentId}
@@ -459,6 +518,16 @@ export default function DiscoveryPage() {
           )}
         </button>
         <button
+          onClick={() => setTab('network')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+            tab === 'network'
+              ? 'border-blue-600 text-blue-600 dark:text-blue-400'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+          }`}
+        >
+          Merged Network
+        </button>
+        <button
           onClick={() => setTab('sync')}
           className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
             tab === 'sync'
@@ -501,7 +570,15 @@ export default function DiscoveryPage() {
           onLink={handleLink}
           onUnlink={handleUnlink}
           pools={pools}
+          selectedResourceIds={selectedResourceIds}
+          onToggleSelection={toggleResourceSelection}
+          onSelectVisible={selectVisibleImportableResources}
+          onClearSelection={() => setSelectedResourceIds([])}
         />
+      )}
+
+      {tab === 'network' && (
+        <NetworkTab selectedAccountId={selectedAccountId} accounts={accounts} />
       )}
 
       {tab === 'sync' && (
@@ -543,6 +620,376 @@ export default function DiscoveryPage() {
           onCreateAndLink={(data) => void handleCreateAndLink(linkingResource, data)}
         />
       )}
+
+      {importPreview && (
+        <ImportPreviewModal
+          preview={importPreview}
+          pools={pools}
+          loading={applyImportLoading}
+          onClose={() => setImportPreview(null)}
+          onApply={() => void handleApplyImport()}
+        />
+      )}
+    </div>
+  )
+}
+
+function isSelectableDiscoveryResource(resource: DiscoveredResource) {
+  return resource.status === 'active' && !resource.pool_id
+}
+
+type NetworkMode = 'hierarchy' | 'flat' | 'conflicts'
+
+function NetworkTab({
+  selectedAccountId,
+  accounts,
+}: {
+  selectedAccountId: number | null
+  accounts: Account[]
+}) {
+  const [mode, setMode] = useState<NetworkMode>('hierarchy')
+  const [query, setQuery] = useState('')
+  const [objectType, setObjectType] = useState('')
+  const [conflictType, setConflictType] = useState('')
+  const [selectedConflict, setSelectedConflict] = useState<NetworkConflict | null>(null)
+  const {
+    flat,
+    hierarchy,
+    conflicts,
+    loading,
+    error,
+    fetchFlat,
+    fetchHierarchy,
+    fetchConflicts,
+    resolveConflict,
+  } = useNetworkView()
+  const { showToast } = useToast()
+
+  const filters = useMemo(() => ({
+    account_id: selectedAccountId ?? undefined,
+    object_type: objectType || undefined,
+    conflict_type: conflictType || undefined,
+    q: query || undefined,
+  }), [selectedAccountId, objectType, conflictType, query])
+
+  const load = useCallback(() => {
+    if (mode === 'hierarchy') {
+      void fetchHierarchy(filters)
+    } else if (mode === 'flat') {
+      void fetchFlat(filters)
+    } else {
+      void fetchConflicts(filters)
+    }
+  }, [fetchConflicts, fetchFlat, fetchHierarchy, filters, mode])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  async function handleResolve(conflict: NetworkConflict, decision: string) {
+    try {
+      const resolved = await resolveConflict(conflict.id, decision)
+      showToast(`Resolution requested: ${resolved.resolution_requested || decision}`, 'success')
+      setSelectedConflict(resolved)
+      load()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Resolve failed', 'error')
+    }
+  }
+
+  const activeItems = mode === 'hierarchy' ? hierarchy?.items : flat?.items
+  const activeTotal = mode === 'hierarchy' ? hierarchy?.total : flat?.total
+  const activeConflictCount = mode === 'hierarchy' ? hierarchy?.conflict_count : flat?.conflict_count
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="inline-flex rounded border border-gray-200 bg-gray-50 p-1 text-sm dark:border-gray-700 dark:bg-gray-800">
+          <NetworkModeButton active={mode === 'hierarchy'} onClick={() => setMode('hierarchy')} label="Hierarchy" />
+          <NetworkModeButton active={mode === 'flat'} onClick={() => setMode('flat')} label="Flat" />
+          <NetworkModeButton active={mode === 'conflicts'} onClick={() => setMode('conflicts')} label="Conflicts" />
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative min-w-[220px] flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search network"
+              className="w-full rounded border border-gray-300 bg-white py-1.5 pl-10 pr-3 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+            />
+          </div>
+          <select
+            value={objectType}
+            onChange={(e) => setObjectType(e.target.value)}
+            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+          >
+            <option value="">All objects</option>
+            <option value="supernet">Pool</option>
+            <option value="vpc">VPC</option>
+            <option value="subnet">Subnet</option>
+            <option value="elastic_ip">EIP</option>
+            <option value="network_interface">NIC</option>
+          </select>
+          <select
+            value={conflictType}
+            onChange={(e) => setConflictType(e.target.value)}
+            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+          >
+            <option value="">All issues</option>
+            <option value="missing_parent">Missing parent</option>
+            <option value="invalid_nesting">Invalid nesting</option>
+            <option value="outside_pool">Outside pool</option>
+            <option value="duplicate_cidr">Duplicate CIDR</option>
+            <option value="managed_overlap">Managed overlap</option>
+            <option value="linked_pool_mismatch">Linked mismatch</option>
+          </select>
+          <button
+            type="button"
+            onClick={load}
+            className="inline-flex items-center gap-1.5 rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+        <span>{mode === 'conflicts' ? conflicts?.total ?? 0 : activeTotal ?? 0} rows</span>
+        {mode !== 'conflicts' && <span>{activeConflictCount ?? 0} issues</span>}
+        {selectedAccountId && <span>{accounts.find((a) => a.id === selectedAccountId)?.name || `Account ${selectedAccountId}`}</span>}
+      </div>
+
+      {error && (
+        <div className="rounded bg-red-50 p-3 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {mode === 'conflicts' ? (
+        <NetworkConflictList
+          conflicts={conflicts?.items ?? []}
+          loading={loading}
+          selected={selectedConflict}
+          onSelect={setSelectedConflict}
+          onResolve={handleResolve}
+        />
+      ) : mode === 'flat' ? (
+        <NetworkFlatTable nodes={activeItems ?? []} loading={loading} />
+      ) : (
+        <NetworkHierarchy nodes={activeItems ?? []} loading={loading} />
+      )}
+    </div>
+  )
+}
+
+function NetworkModeButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded px-3 py-1.5 ${active ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-gray-100' : 'text-gray-600 dark:text-gray-300'}`}
+    >
+      {label}
+    </button>
+  )
+}
+
+function NetworkHierarchy({ nodes, loading }: { nodes: NetworkNode[]; loading: boolean }) {
+  if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
+  if (nodes.length === 0) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">No merged network records found.</div>
+  return (
+    <div className="rounded border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-gray-800">
+      {nodes.map((node) => (
+        <NetworkTreeNode key={node.id} node={node} depth={0} />
+      ))}
+    </div>
+  )
+}
+
+function NetworkTreeNode({ node, depth }: { node: NetworkNode; depth: number }) {
+  const [expanded, setExpanded] = useState(depth < 2)
+  const hasChildren = (node.children?.length ?? 0) > 0
+  return (
+    <div>
+      <div
+        className="flex min-h-10 items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700/50"
+        style={{ paddingLeft: `${depth * 18 + 8}px` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="rounded p-0.5 text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-600"
+          >
+            {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+          </button>
+        ) : (
+          <span className="w-4" />
+        )}
+        <NetworkObjectIcon node={node} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium text-gray-900 dark:text-gray-100">{node.name}</span>
+            <span className="font-mono text-xs text-gray-500 dark:text-gray-400">{node.cidr || node.ip_address || '-'}</span>
+            <StatusBadge label={node.state} />
+          </div>
+          <NetworkIssueBadges issues={node.issues ?? []} />
+        </div>
+      </div>
+      {expanded && hasChildren && (
+        <div>
+          {node.children!.map((child) => (
+            <NetworkTreeNode key={child.id} node={child} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function NetworkFlatTable({ nodes, loading }: { nodes: NetworkNode[]; loading: boolean }) {
+  if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
+  return (
+    <div className="overflow-x-auto rounded border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 bg-gray-50 text-left dark:border-gray-700 dark:bg-gray-900">
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Object</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">CIDR/IP</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Provider</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Account</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Region</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">State</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Issues</th>
+          </tr>
+        </thead>
+        <tbody>
+          {nodes.length === 0 && (
+            <tr>
+              <td colSpan={7} className="px-3 py-8 text-center text-gray-500 dark:text-gray-400">No merged network records found.</td>
+            </tr>
+          )}
+          {nodes.map((node) => (
+            <tr key={node.id} className="border-b border-gray-100 last:border-b-0 dark:border-gray-700/50">
+              <td className="px-3 py-2">
+                <div className="flex items-center gap-2">
+                  <NetworkObjectIcon node={node} />
+                  <div>
+                    <div className="font-medium text-gray-900 dark:text-gray-100">{node.name}</div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">{node.object_type}</div>
+                  </div>
+                </div>
+              </td>
+              <td className="px-3 py-2 font-mono text-gray-700 dark:text-gray-300">{node.cidr || node.ip_address || '-'}</td>
+              <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{node.provider || '-'}</td>
+              <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{node.account_name || '-'}</td>
+              <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{node.region || '-'}</td>
+              <td className="px-3 py-2"><StatusBadge label={node.state} /></td>
+              <td className="px-3 py-2"><NetworkIssueBadges issues={node.issues ?? []} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function NetworkConflictList({
+  conflicts,
+  loading,
+  selected,
+  onSelect,
+  onResolve,
+}: {
+  conflicts: NetworkConflict[]
+  loading: boolean
+  selected: NetworkConflict | null
+  onSelect: (conflict: NetworkConflict | null) => void
+  onResolve: (conflict: NetworkConflict, decision: string) => void
+}) {
+  if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        {conflicts.length === 0 ? (
+          <div className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">No network conflicts found.</div>
+        ) : conflicts.map((conflict) => (
+          <button
+            key={conflict.id}
+            type="button"
+            onClick={() => onSelect(conflict)}
+            className={`block w-full border-b border-gray-100 px-4 py-3 text-left last:border-b-0 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/50 ${selected?.id === conflict.id ? 'bg-blue-50 dark:bg-blue-900/20' : ''}`}
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <StatusBadge label={conflict.severity} />
+              <span className="font-medium text-gray-900 dark:text-gray-100">{conflict.title}</span>
+            </div>
+            <div className="mt-1 text-sm text-gray-500 dark:text-gray-400">{conflict.description}</div>
+          </button>
+        ))}
+      </div>
+      <div className="rounded border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        {selected ? (
+          <div className="space-y-3">
+            <div>
+              <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{selected.title}</div>
+              <div className="mt-1 text-sm text-gray-500 dark:text-gray-400">{selected.description}</div>
+            </div>
+            {selected.recommended_action && (
+              <div className="rounded bg-blue-50 p-2 text-sm text-blue-800 dark:bg-blue-900/20 dark:text-blue-300">
+                {selected.recommended_action}
+              </div>
+            )}
+            <div className="space-y-1 text-xs text-gray-500 dark:text-gray-400">
+              {(selected.evidence ?? []).map((line) => (
+                <div key={line}>{line}</div>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {(selected.available_decisions ?? ['skip', 'ignore', 'defer']).map((decision) => (
+                <button
+                  key={decision}
+                  type="button"
+                  onClick={() => onResolve(selected, decision)}
+                  className="rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  {decision}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="text-sm text-gray-500 dark:text-gray-400">Select a conflict to review evidence.</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function NetworkObjectIcon({ node }: { node: NetworkNode }) {
+  const color = node.kind === 'pool' ? 'text-emerald-600' : node.object_type === 'elastic_ip' ? 'text-orange-500' : 'text-blue-600'
+  return node.kind === 'pool' ? <Table2 className={`h-4 w-4 ${color}`} /> : <Network className={`h-4 w-4 ${color}`} />
+}
+
+function NetworkIssueBadges({ issues }: { issues: NetworkIssue[] }) {
+  if (issues.length === 0) return null
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {issues.map((issue) => (
+        <span key={issue.id} className="rounded bg-yellow-50 px-1.5 py-0.5 text-[11px] text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+          {issue.type.replace(/_/g, ' ')}
+        </span>
+      ))}
     </div>
   )
 }
@@ -562,6 +1009,10 @@ function ResourcesTab({
   onLink,
   onUnlink,
   pools,
+  selectedResourceIds,
+  onToggleSelection,
+  onSelectVisible,
+  onClearSelection,
 }: {
   resources: DiscoveredResource[]
   loading: boolean
@@ -577,7 +1028,13 @@ function ResourcesTab({
   onLink: (r: DiscoveredResource) => void
   onUnlink: (r: DiscoveredResource) => void
   pools: Pool[]
+  selectedResourceIds: string[]
+  onToggleSelection: (r: DiscoveredResource) => void
+  onSelectVisible: (resources: DiscoveredResource[]) => void
+  onClearSelection: () => void
 }) {
+  const selectableCount = resources.filter(isSelectableDiscoveryResource).length
+
   return (
     <>
       {/* Filters */}
@@ -622,6 +1079,27 @@ function ResourcesTab({
           <option value="true">Linked to pool</option>
           <option value="false">Unlinked</option>
         </select>
+        <div className="flex items-center gap-2 text-sm">
+          <button
+            type="button"
+            onClick={() => onSelectVisible(resources)}
+            disabled={selectableCount === 0}
+            className="rounded border border-gray-300 px-3 py-1.5 text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+          >
+            Select visible
+          </button>
+          <button
+            type="button"
+            onClick={onClearSelection}
+            disabled={selectedResourceIds.length === 0}
+            className="rounded border border-gray-300 px-3 py-1.5 text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+          >
+            Clear
+          </button>
+          <span className="text-gray-500 dark:text-gray-400">
+            {selectedResourceIds.length} selected
+          </span>
+        </div>
       </div>
 
       {error && (
@@ -648,6 +1126,9 @@ function ResourcesTab({
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+                <th className="w-10 px-4 py-2 text-left">
+                  <span className="sr-only">Select</span>
+                </th>
                 <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
                   Type
                 </th>
@@ -680,6 +1161,16 @@ function ResourcesTab({
                   key={r.id}
                   className="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/50"
                 >
+                  <td className="px-4 py-2">
+                    <input
+                      type="checkbox"
+                      checked={selectedResourceIds.includes(r.id)}
+                      disabled={!isSelectableDiscoveryResource(r)}
+                      onChange={() => onToggleSelection(r)}
+                      aria-label={`Select ${r.name || r.resource_id}`}
+                      className="h-4 w-4 rounded border-gray-300 text-blue-600 disabled:opacity-40"
+                    />
+                  </td>
                   <td className="px-4 py-2">
                     <ResourceTypeBadge type={r.resource_type} />
                   </td>
@@ -746,6 +1237,9 @@ function ResourcesTab({
               pools={pools}
               onLink={onLink}
               onUnlink={onUnlink}
+              selected={selectedResourceIds.includes(r.id)}
+              selectable={isSelectableDiscoveryResource(r)}
+              onToggleSelection={onToggleSelection}
             />
           ))}
         </div>
@@ -767,21 +1261,194 @@ function PoolLabel({ poolId, pools }: { poolId: number; pools: Pool[] }) {
   )
 }
 
+function ImportPreviewModal({
+  preview,
+  pools,
+  loading,
+  onClose,
+  onApply,
+}: {
+  preview: DiscoveryImportPreviewResponse
+  pools: Pool[]
+  loading: boolean
+  onClose: () => void
+  onApply: () => void
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-end bg-black/35 p-0 sm:items-center sm:justify-center sm:p-4">
+      <div className="max-h-[92vh] w-full overflow-auto rounded-t-lg bg-white shadow-xl dark:bg-gray-900 sm:max-w-5xl sm:rounded-lg">
+        <div className="sticky top-0 z-10 flex items-start justify-between gap-4 border-b border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-900">
+          <div>
+            <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">Import preview</h2>
+            <div className="mt-1 flex flex-wrap gap-2 text-xs text-gray-500 dark:text-gray-400">
+              <span>{preview.importable} importable</span>
+              <span>{preview.conflict_count} conflicts</span>
+              <span>{preview.blocked} blocked</span>
+              <span>{preview.linked_only} link-only</span>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            title="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="p-4">
+          <div className="hidden overflow-hidden rounded border border-gray-200 dark:border-gray-700 md:block">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800">
+                  <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-400">Resource</th>
+                  <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-400">CIDR</th>
+                  <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-400">Action</th>
+                  <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-400">Status</th>
+                  <th className="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-400">Evidence</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.items.map((item) => (
+                  <ImportPreviewRow key={item.resource_id} item={item} pools={pools} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="grid gap-3 md:hidden">
+            {preview.items.map((item) => (
+              <ImportPreviewCard key={item.resource_id} item={item} pools={pools} />
+            ))}
+          </div>
+        </div>
+
+        <div className="sticky bottom-0 flex justify-end gap-2 border-t border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-900">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onApply}
+            disabled={loading || preview.importable === 0}
+            className="inline-flex items-center gap-2 rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <UploadCloud className="h-4 w-4" />}
+            Apply import
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ImportPreviewRow({ item, pools }: { item: DiscoveryImportPreviewItem; pools: Pool[] }) {
+  return (
+    <tr className="border-b border-gray-100 last:border-b-0 dark:border-gray-800">
+      <td className="px-3 py-2">
+        <div className="flex flex-wrap items-center gap-2">
+          {item.resource_type && <ResourceTypeBadge type={item.resource_type} />}
+          <span className="font-medium text-gray-900 dark:text-gray-100">{item.name || item.provider_resource_id || item.resource_id}</span>
+        </div>
+        {item.provider_resource_id && item.name && (
+          <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">{item.provider_resource_id}</div>
+        )}
+      </td>
+      <td className="px-3 py-2 font-mono text-gray-700 dark:text-gray-300">{item.cidr || '-'}</td>
+      <td className="px-3 py-2 text-gray-700 dark:text-gray-300">
+        {importActionLabel(item)}
+        {item.proposed_pool_id ? (
+          <div className="mt-1 text-xs"><PoolLabel poolId={item.proposed_pool_id} pools={pools} /></div>
+        ) : null}
+      </td>
+      <td className="px-3 py-2">
+        <StatusBadge label={item.status} />
+        <IssueBadges issues={item.issues} />
+      </td>
+      <td className="max-w-sm px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+        {(item.evidence ?? []).slice(0, 3).join('; ') || '-'}
+      </td>
+    </tr>
+  )
+}
+
+function ImportPreviewCard({ item, pools }: { item: DiscoveryImportPreviewItem; pools: Pool[] }) {
+  return (
+    <div className="rounded border border-gray-200 p-3 text-sm dark:border-gray-700">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        {item.resource_type && <ResourceTypeBadge type={item.resource_type} />}
+        <StatusBadge label={item.status} />
+      </div>
+      <div className="font-medium text-gray-900 dark:text-gray-100">{item.name || item.provider_resource_id || item.resource_id}</div>
+      <div className="mt-1 font-mono text-xs text-gray-500 dark:text-gray-400">{item.cidr || '-'}</div>
+      <div className="mt-2 text-gray-700 dark:text-gray-300">{importActionLabel(item)}</div>
+      {item.proposed_pool_id ? <div className="mt-1 text-xs"><PoolLabel poolId={item.proposed_pool_id} pools={pools} /></div> : null}
+      <IssueBadges issues={item.issues} />
+      {(item.evidence ?? []).length > 0 && (
+        <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">{item.evidence?.slice(0, 3).join('; ')}</div>
+      )}
+    </div>
+  )
+}
+
+function IssueBadges({ issues }: { issues: string[] }) {
+  if (issues.length === 0) return null
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {issues.map((issue) => (
+        <span key={issue} className="rounded bg-yellow-50 px-1.5 py-0.5 text-[11px] text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+          {issueLabel(issue)}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function importActionLabel(item: DiscoveryImportPreviewItem) {
+  if (item.proposed_action === 'create_pool') return 'Create discovered pool'
+  if (item.proposed_action === 'link_pool') return 'Link existing pool'
+  if (item.proposed_action === 'link_only') return 'Keep as network object'
+  return 'No change'
+}
+
+function issueLabel(issue: string) {
+  return issue.replace(/_/g, ' ')
+}
+
 function ResourceCard({
   resource,
   pools,
   onLink,
   onUnlink,
+  selected,
+  selectable,
+  onToggleSelection,
 }: {
   resource: DiscoveredResource
   pools: Pool[]
   onLink: (r: DiscoveredResource) => void
   onUnlink: (r: DiscoveredResource) => void
+  selected: boolean
+  selectable: boolean
+  onToggleSelection: (r: DiscoveredResource) => void
 }) {
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="mb-2 flex items-start justify-between gap-3">
-        <div className="min-w-0">
+        <div className="flex min-w-0 gap-3">
+          <input
+            type="checkbox"
+            checked={selected}
+            disabled={!selectable}
+            onChange={() => onToggleSelection(resource)}
+            aria-label={`Select ${resource.name || resource.resource_id}`}
+            className="mt-1 h-4 w-4 shrink-0 rounded border-gray-300 text-blue-600 disabled:opacity-40"
+          />
+          <div className="min-w-0">
           <div className="flex items-center gap-2">
             <ResourceTypeBadge type={resource.resource_type} />
             <StatusBadge label={resource.status} />
@@ -794,6 +1461,7 @@ function ResourceCard({
               {resource.resource_id}
             </div>
           )}
+          </div>
         </div>
         {resource.pool_id ? (
           <button


### PR DESCRIPTION
## Summary
- add selected-resource discovery import preview/apply endpoints and UI flow
- add merged network flat/hierarchy/conflict APIs and Discovery page Merged Network tab
- surface VPC/subnet/EIP/NIC network objects separately from allocated blocks with conflict evidence for missing parents, invalid nesting, duplicate CIDRs, outside-pool links, and managed overlaps
- document the discovery vocabulary, merged network APIs, and 0.16.0 changelog entry

Closes #187

## Tests
- env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./internal/api -run 'TestNetwork|TestDiscoveryImport|TestImportDiscoveredSchema|TestTriggerSyncAllHealthyAgents'
- env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./...
- npm run build (from ui/)
- git diff --check