### PR TITLE
network: implement real conflict import/link actions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.16.1] - 2026-06-02
+
+### Fixed
+- Network conflict import actions now fail and roll back when any selected resource is skipped or errors, preventing partial imports from marking the whole conflict resolved.
+- PostgreSQL-backed deployments now persist drift and network conflict resolution metadata instead of falling back to in-memory drift storage.
+
 ## [0.16.0] - 2026-06-01
 
 ### Added

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -416,7 +416,15 @@ func (d *DiscoveryServer) applyDiscoveryImport(ctx context.Context, req domain.D
 			resp.Skipped++
 			continue
 		}
+		resp.CreatedPoolIDs = append(resp.CreatedPoolIDs, pool.ID)
 		if err := d.store.LinkResourceToPool(ctx, item.ResourceID, pool.ID); err != nil {
+			if ok, cleanupErr := d.srv.store.DeletePool(ctx, pool.ID); cleanupErr != nil {
+				resp.Errors = append(resp.Errors, fmt.Sprintf("%s: cleanup created pool %d: %v", res.ResourceID, pool.ID, cleanupErr))
+			} else if !ok {
+				resp.Errors = append(resp.Errors, fmt.Sprintf("%s: cleanup created pool %d: not found", res.ResourceID, pool.ID))
+			} else {
+				resp.CreatedPoolIDs = resp.CreatedPoolIDs[:len(resp.CreatedPoolIDs)-1]
+			}
 			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: link new pool: %v", res.ResourceID, err))
 			resp.Skipped++
 			continue
@@ -424,7 +432,6 @@ func (d *DiscoveryServer) applyDiscoveryImport(ctx context.Context, req domain.D
 		createdPoolByProviderID[res.ResourceID] = pool.ID
 		resp.PoolsCreated++
 		resp.ResourcesLinked++
-		resp.CreatedPoolIDs = append(resp.CreatedPoolIDs, pool.ID)
 		resp.LinkedResourceIDs = append(resp.LinkedResourceIDs, item.ResourceID)
 	}
 

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -447,6 +447,9 @@ func (d *DiscoveryServer) previewDiscoveryImport(ctx context.Context, req domain
 		if !ok {
 			return domain.DiscoveryImportPreviewResponse{}, fmt.Errorf("selected pool not found")
 		}
+		if pool.AccountID != nil && *pool.AccountID != req.AccountID {
+			return domain.DiscoveryImportPreviewResponse{}, fmt.Errorf("selected pool account does not match import account")
+		}
 		selectedPool = &pool
 	}
 

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -307,11 +307,24 @@ func (d *DiscoveryServer) handleImportApply(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	previewReq := domain.DiscoveryImportPreviewRequest(req)
-	preview, err := d.previewDiscoveryImport(r.Context(), previewReq)
+	resp, err := d.applyDiscoveryImport(r.Context(), req, discoveryImportApplyOptions{})
 	if err != nil {
-		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "preview import failed", err.Error())
+		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "apply import failed", err.Error())
 		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+type discoveryImportApplyOptions struct {
+	AllowBlocked bool
+}
+
+func (d *DiscoveryServer) applyDiscoveryImport(ctx context.Context, req domain.DiscoveryImportApplyRequest, opts discoveryImportApplyOptions) (domain.DiscoveryImportApplyResponse, error) {
+	previewReq := domain.DiscoveryImportPreviewRequest(req)
+	preview, err := d.previewDiscoveryImport(ctx, previewReq)
+	if err != nil {
+		return domain.DiscoveryImportApplyResponse{}, err
 	}
 
 	resp := domain.DiscoveryImportApplyResponse{Preview: preview, Errors: []string{}}
@@ -331,25 +344,26 @@ func (d *DiscoveryServer) handleImportApply(w http.ResponseWriter, r *http.Reque
 
 	createdPoolByProviderID := make(map[string]int64)
 	for _, item := range items {
-		if item.Status != "importable" {
+		if item.Status != "importable" && !canForceDiscoveryImport(item, opts) {
 			resp.Skipped++
 			continue
 		}
-		res, err := d.store.GetDiscoveredResource(r.Context(), item.ResourceID)
+		res, err := d.store.GetDiscoveredResource(ctx, item.ResourceID)
 		if err != nil {
 			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: load resource: %v", item.ResourceID, err))
 			resp.Skipped++
 			continue
 		}
 
-		if item.ProposedAction == "link_pool" && item.ProposedPoolID != nil {
-			if err := d.store.LinkResourceToPool(r.Context(), item.ResourceID, *item.ProposedPoolID); err != nil {
+		if item.ProposedPoolID != nil && (item.ProposedAction == "link_pool" || opts.AllowBlocked) {
+			if err := d.store.LinkResourceToPool(ctx, item.ResourceID, *item.ProposedPoolID); err != nil {
 				resp.Errors = append(resp.Errors, fmt.Sprintf("%s: link pool: %v", res.ResourceID, err))
 				resp.Skipped++
 				continue
 			}
 			createdPoolByProviderID[res.ResourceID] = *item.ProposedPoolID
 			resp.ResourcesLinked++
+			resp.LinkedResourceIDs = append(resp.LinkedResourceIDs, item.ResourceID)
 			continue
 		}
 
@@ -364,13 +378,13 @@ func (d *DiscoveryServer) handleImportApply(w http.ResponseWriter, r *http.Reque
 			resp.Skipped++
 			continue
 		}
-		pool, err := d.createDiscoveredPool(r.Context(), req.AccountID, *res, parentID)
+		pool, err := d.createDiscoveredPool(ctx, req.AccountID, *res, parentID)
 		if err != nil {
 			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: create pool: %v", res.ResourceID, err))
 			resp.Skipped++
 			continue
 		}
-		if err := d.store.LinkResourceToPool(r.Context(), item.ResourceID, pool.ID); err != nil {
+		if err := d.store.LinkResourceToPool(ctx, item.ResourceID, pool.ID); err != nil {
 			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: link new pool: %v", res.ResourceID, err))
 			resp.Skipped++
 			continue
@@ -378,9 +392,28 @@ func (d *DiscoveryServer) handleImportApply(w http.ResponseWriter, r *http.Reque
 		createdPoolByProviderID[res.ResourceID] = pool.ID
 		resp.PoolsCreated++
 		resp.ResourcesLinked++
+		resp.CreatedPoolIDs = append(resp.CreatedPoolIDs, pool.ID)
+		resp.LinkedResourceIDs = append(resp.LinkedResourceIDs, item.ResourceID)
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	return resp, nil
+}
+
+func canForceDiscoveryImport(item domain.DiscoveryImportPreviewItem, opts discoveryImportApplyOptions) bool {
+	if !opts.AllowBlocked {
+		return false
+	}
+	if item.Status == "not_found" || item.Status == "already_linked" || item.Status == "linked_only" {
+		return false
+	}
+	if item.ResourceType != domain.ResourceTypeVPC && item.ResourceType != domain.ResourceTypeSubnet {
+		return false
+	}
+	if item.CIDR == "" {
+		return false
+	}
+	_, err := netip.ParsePrefix(item.CIDR)
+	return err == nil
 }
 
 func validateDiscoveryImportSelection(accountID int64, resourceIDs []uuid.UUID) error {

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -284,6 +284,10 @@ func (d *DiscoveryServer) handleImportPreview(w http.ResponseWriter, r *http.Req
 
 	resp, err := d.previewDiscoveryImport(r.Context(), req)
 	if err != nil {
+		if isDiscoveryImportClientError(err) {
+			d.srv.writeErr(r.Context(), w, http.StatusBadRequest, err.Error(), "")
+			return
+		}
 		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "preview import failed", err.Error())
 		return
 	}
@@ -309,6 +313,10 @@ func (d *DiscoveryServer) handleImportApply(w http.ResponseWriter, r *http.Reque
 
 	resp, err := d.applyDiscoveryImport(r.Context(), req, discoveryImportApplyOptions{})
 	if err != nil {
+		if isDiscoveryImportClientError(err) {
+			d.srv.writeErr(r.Context(), w, http.StatusBadRequest, err.Error(), "")
+			return
+		}
 		d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "apply import failed", err.Error())
 		return
 	}
@@ -318,6 +326,23 @@ func (d *DiscoveryServer) handleImportApply(w http.ResponseWriter, r *http.Reque
 
 type discoveryImportApplyOptions struct {
 	AllowBlocked bool
+}
+
+type discoveryImportClientError struct {
+	message string
+}
+
+func (e discoveryImportClientError) Error() string {
+	return e.message
+}
+
+func newDiscoveryImportClientError(message string) error {
+	return discoveryImportClientError{message: message}
+}
+
+func isDiscoveryImportClientError(err error) bool {
+	var target discoveryImportClientError
+	return errors.As(err, &target)
 }
 
 func (d *DiscoveryServer) applyDiscoveryImport(ctx context.Context, req domain.DiscoveryImportApplyRequest, opts discoveryImportApplyOptions) (domain.DiscoveryImportApplyResponse, error) {
@@ -378,6 +403,13 @@ func (d *DiscoveryServer) applyDiscoveryImport(ctx context.Context, req domain.D
 			resp.Skipped++
 			continue
 		}
+		if parentID != nil {
+			if err := d.validateImportParentPool(ctx, req.AccountID, *parentID); err != nil {
+				resp.Errors = append(resp.Errors, fmt.Sprintf("%s: %v", res.ResourceID, err))
+				resp.Skipped++
+				continue
+			}
+		}
 		pool, err := d.createDiscoveredPool(ctx, req.AccountID, *res, parentID)
 		if err != nil {
 			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: create pool: %v", res.ResourceID, err))
@@ -430,7 +462,7 @@ func (d *DiscoveryServer) previewDiscoveryImport(ctx context.Context, req domain
 	if _, found, err := d.srv.store.GetAccount(ctx, req.AccountID); err != nil {
 		return domain.DiscoveryImportPreviewResponse{}, err
 	} else if !found {
-		return domain.DiscoveryImportPreviewResponse{}, fmt.Errorf("account not found")
+		return domain.DiscoveryImportPreviewResponse{}, newDiscoveryImportClientError("account not found")
 	}
 
 	pools, err := d.srv.store.ListPools(ctx)
@@ -445,10 +477,10 @@ func (d *DiscoveryServer) previewDiscoveryImport(ctx context.Context, req domain
 	if req.PoolID != nil {
 		pool, ok := poolsByID[*req.PoolID]
 		if !ok {
-			return domain.DiscoveryImportPreviewResponse{}, fmt.Errorf("selected pool not found")
+			return domain.DiscoveryImportPreviewResponse{}, newDiscoveryImportClientError("selected pool not found")
 		}
 		if pool.AccountID != nil && *pool.AccountID != req.AccountID {
-			return domain.DiscoveryImportPreviewResponse{}, fmt.Errorf("selected pool account does not match import account")
+			return domain.DiscoveryImportPreviewResponse{}, newDiscoveryImportClientError("selected pool account does not match import account")
 		}
 		selectedPool = &pool
 	}
@@ -631,6 +663,9 @@ func (d *DiscoveryServer) classifyPoolRelationships(item *domain.DiscoveryImport
 			continue
 		}
 		if cidrContains(pool.CIDR, res.CIDR) {
+			if pool.AccountID != nil && *pool.AccountID != res.AccountID {
+				continue
+			}
 			if bits := prefixLength(pool.CIDR); bits > bestParentBits {
 				bestParentBits = bits
 				parentID := pool.ID
@@ -645,6 +680,20 @@ func (d *DiscoveryServer) classifyPoolRelationships(item *domain.DiscoveryImport
 			item.Evidence = append(item.Evidence, fmt.Sprintf("%s overlaps existing pool %d (%s)", res.CIDR, pool.ID, pool.CIDR))
 		}
 	}
+}
+
+func (d *DiscoveryServer) validateImportParentPool(ctx context.Context, accountID int64, parentID int64) error {
+	parent, found, err := d.srv.store.GetPool(ctx, parentID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("parent pool %d not found", parentID)
+	}
+	if parent.AccountID != nil && *parent.AccountID != accountID {
+		return fmt.Errorf("parent pool account does not match import account")
+	}
+	return nil
 }
 
 func (d *DiscoveryServer) duplicateCIDRsByAccount(ctx context.Context, accountID int64, selected []domain.DiscoveredResource) (map[string][]uuid.UUID, error) {

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -358,6 +358,46 @@ func TestDiscoveryImportPreviewBlocksOutsideSelectedPool(t *testing.T) {
 	}
 }
 
+func TestDiscoveryImportPreviewAndApplyRejectInvalidSelectedPool(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	otherAccount, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:222222222222", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create other account: %v", err)
+	}
+	otherPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "dev", CIDR: "10.32.0.0/16", Type: domain.PoolTypeSupernet, AccountID: &otherAccount.ID})
+	if err != nil {
+		t.Fatalf("create other pool: %v", err)
+	}
+
+	vpcID := uuid.New()
+	now := time.Now().UTC()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-1",
+		Name:         "prod-vpc",
+		CIDR:         "10.32.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+
+	missingPoolBody := fmt.Sprintf(`{"account_id":%d,"pool_id":999999,"resource_ids":["%s"]}`, account.ID, vpcID)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", missingPoolBody, http.StatusBadRequest)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/apply", missingPoolBody, http.StatusBadRequest)
+
+	accountMismatchBody := fmt.Sprintf(`{"account_id":%d,"pool_id":%d,"resource_ids":["%s"]}`, account.ID, otherPool.ID, vpcID)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", accountMismatchBody, http.StatusBadRequest)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/apply", accountMismatchBody, http.StatusBadRequest)
+}
+
 func TestDiscoveryImportPreviewFlagsDuplicateAcrossAccounts(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	a1, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:111111111111", Name: "prod", Provider: "aws"})

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"cloudpam/internal/domain"
+	"cloudpam/internal/storage"
 )
 
 func TestTriggerSyncAllHealthyAgents(t *testing.T) {
@@ -398,6 +400,58 @@ func TestDiscoveryImportPreviewAndApplyRejectInvalidSelectedPool(t *testing.T) {
 	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/apply", accountMismatchBody, http.StatusBadRequest)
 }
 
+func TestDiscoveryImportApplyDeletesCreatedPoolWhenLinkFails(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	vpcID := uuid.New()
+	now := time.Now().UTC()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-link-fails",
+		Name:         "vpc-link-fails",
+		CIDR:         "10.33.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+	discSrv.store = &failLinkDiscoveryStore{DiscoveryStore: ds, failID: vpcID}
+
+	body := fmt.Sprintf("{\"account_id\":%d,\"resource_ids\":[\"%s\"]}", account.ID, vpcID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/apply", body, http.StatusOK)
+	var applied domain.DiscoveryImportApplyResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &applied); err != nil {
+		t.Fatalf("unmarshal apply: %v", err)
+	}
+	if applied.PoolsCreated != 0 || applied.ResourcesLinked != 0 || applied.Skipped != 1 {
+		t.Fatalf("failed link should skip without completed imports: %+v", applied)
+	}
+	if len(applied.CreatedPoolIDs) != 0 {
+		t.Fatalf("created pool id should be removed after cleanup succeeds: %+v", applied.CreatedPoolIDs)
+	}
+	pools, err := st.ListPools(t.Context())
+	if err != nil {
+		t.Fatalf("list pools: %v", err)
+	}
+	if len(pools) != 0 {
+		t.Fatalf("link failure should clean up created pool, got %+v", pools)
+	}
+	res, err := ds.GetDiscoveredResource(t.Context(), vpcID)
+	if err != nil {
+		t.Fatalf("get discovered resource: %v", err)
+	}
+	if res.PoolID != nil {
+		t.Fatalf("link failure should leave resource unlinked, got pool %d", *res.PoolID)
+	}
+}
+
 func TestDiscoveryImportPreviewFlagsDuplicateAcrossAccounts(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	a1, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:111111111111", Name: "prod", Provider: "aws"})
@@ -558,4 +612,16 @@ func containsString(items []string, want string) bool {
 		}
 	}
 	return false
+}
+
+type failLinkDiscoveryStore struct {
+	storage.DiscoveryStore
+	failID uuid.UUID
+}
+
+func (s *failLinkDiscoveryStore) LinkResourceToPool(ctx context.Context, resourceID uuid.UUID, poolID int64) error {
+	if resourceID == s.failID {
+		return errors.New("forced link failure")
+	}
+	return s.DiscoveryStore.LinkResourceToPool(ctx, resourceID, poolID)
 }

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -298,6 +298,21 @@ func (ns *NetworkServer) handleNetworkConflictImportAction(w http.ResponseWriter
 		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, err.Error(), "")
 		return
 	}
+	if req.PoolID != nil {
+		pool, found, err := ns.store.GetPool(r.Context(), *req.PoolID)
+		if err != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "pool lookup failed", err.Error())
+			return
+		}
+		if !found {
+			ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "selected pool not found", "")
+			return
+		}
+		if pool.AccountID != nil && *pool.AccountID != accountID {
+			ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "selected pool account does not match import account", "")
+			return
+		}
+	}
 	importReq := domain.DiscoveryImportApplyRequest{
 		AccountID:   accountID,
 		ResourceIDs: req.ResourceIDs,

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -112,10 +112,29 @@ func (ns *NetworkServer) handleConflicts(w http.ResponseWriter, r *http.Request)
 func (ns *NetworkServer) handleConflictSubroutes(w http.ResponseWriter, r *http.Request) {
 	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/network/conflicts/"), "/")
 	parts := strings.Split(path, "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] != "resolve" {
+	if len(parts) < 2 || parts[0] == "" {
 		ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "not found", "")
 		return
 	}
+	if parts[1] == "resolve" && len(parts) == 2 {
+		ns.handleResolveNetworkConflict(w, r, parts[0])
+		return
+	}
+	if parts[1] == "actions" && len(parts) == 3 {
+		switch parts[2] {
+		case "link":
+			ns.handleNetworkConflictLinkAction(w, r, parts[0])
+		case "import":
+			ns.handleNetworkConflictImportAction(w, r, parts[0])
+		default:
+			ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "not found", "")
+		}
+		return
+	}
+	ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "not found", "")
+}
+
+func (ns *NetworkServer) handleResolveNetworkConflict(w http.ResponseWriter, r *http.Request, conflictID string) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
@@ -140,7 +159,7 @@ func (ns *NetworkServer) handleConflictSubroutes(w http.ResponseWriter, r *http.
 		return
 	}
 	for _, conflict := range view.conflicts {
-		if conflict.ID == parts[0] {
+		if conflict.ID == conflictID {
 			if err := ns.persistNetworkConflictResolution(r.Context(), conflict, req); err != nil {
 				ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "resolve conflict failed", err.Error())
 				return
@@ -153,6 +172,195 @@ func (ns *NetworkServer) handleConflictSubroutes(w http.ResponseWriter, r *http.
 		}
 	}
 	ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "conflict not found", "")
+}
+
+func (ns *NetworkServer) handleNetworkConflictLinkAction(w http.ResponseWriter, r *http.Request, conflictID string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	var req domain.NetworkConflictLinkActionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+	if req.DiscoveredID == uuid.Nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "discovered_id is required", "")
+		return
+	}
+	if req.PoolID < 1 {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "pool_id is required", "")
+		return
+	}
+
+	conflict, err := ns.findNetworkConflict(r.Context(), conflictID)
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "network conflicts failed", err.Error())
+		return
+	}
+	if conflict == nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "conflict not found", "")
+		return
+	}
+	res, err := ns.discStore.GetDiscoveredResource(r.Context(), req.DiscoveredID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrNotFound) {
+			status = http.StatusBadRequest
+		}
+		ns.srv.writeErr(r.Context(), w, status, "discovered resource not found", err.Error())
+		return
+	}
+	pool, found, err := ns.store.GetPool(r.Context(), req.PoolID)
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "pool lookup failed", err.Error())
+		return
+	}
+	if !found {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "pool not found", "")
+		return
+	}
+	if err := validateNetworkConflictLinkAction(*conflict, *res, pool, req); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, err.Error(), "")
+		return
+	}
+
+	actionDetails := map[string]string{
+		"network_conflict_action": "link",
+		"discovered_id":           req.DiscoveredID.String(),
+		"pool_id":                 fmt.Sprintf("%d", req.PoolID),
+	}
+	resolveReq := domain.ResolveNetworkConflictRequest{
+		Decision: "link",
+		Reason:   networkActionReason("link", req.Reason, actionDetails),
+	}
+	if err := ns.ensureNetworkConflictResolutionRecord(r.Context(), *conflict, networkActionReason("link_pending", req.Reason, actionDetails), actionDetails); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "prepare conflict action failed", err.Error())
+		return
+	}
+	previousPoolID := res.PoolID
+	if err := ns.discStore.LinkResourceToPool(r.Context(), req.DiscoveredID, req.PoolID); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "link resource to pool failed", err.Error())
+		return
+	}
+	if err := ns.persistNetworkConflictActionResolution(r.Context(), *conflict, resolveReq, actionDetails); err != nil {
+		rollbackErr := ns.rollbackNetworkConflictLink(r.Context(), req.DiscoveredID, previousPoolID)
+		if rollbackErr != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "record conflict action failed and rollback failed", err.Error()+"; rollback: "+rollbackErr.Error())
+			return
+		}
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "record conflict action failed", err.Error())
+		return
+	}
+
+	updated := ns.conflictAfterAction(r.Context(), *conflict, "link")
+	writeJSON(w, http.StatusOK, domain.NetworkConflictActionResponse{
+		Conflict:       updated,
+		Action:         "link",
+		ResourceLinked: true,
+		DiscoveredID:   &req.DiscoveredID,
+		PoolID:         &req.PoolID,
+	})
+}
+
+func (ns *NetworkServer) handleNetworkConflictImportAction(w http.ResponseWriter, r *http.Request, conflictID string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	var req domain.NetworkConflictImportActionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+	if len(req.ResourceIDs) == 0 {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "resource_ids must include at least one discovered resource", "")
+		return
+	}
+
+	conflict, err := ns.findNetworkConflict(r.Context(), conflictID)
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "network conflicts failed", err.Error())
+		return
+	}
+	if conflict == nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "conflict not found", "")
+		return
+	}
+	if err := validateNetworkConflictImportSelection(*conflict, req); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, err.Error(), "")
+		return
+	}
+	accountID, err := ns.importActionAccountID(r.Context(), *conflict, req.ResourceIDs)
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, err.Error(), "")
+		return
+	}
+	importReq := domain.DiscoveryImportApplyRequest{
+		AccountID:   accountID,
+		ResourceIDs: req.ResourceIDs,
+		PoolID:      req.PoolID,
+	}
+	discoveryServer := &DiscoveryServer{srv: ns.srv, store: ns.discStore}
+	if !req.Override {
+		preview, err := discoveryServer.previewDiscoveryImport(r.Context(), domain.DiscoveryImportPreviewRequest(importReq))
+		if err != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "preview import failed", err.Error())
+			return
+		}
+		if preview.Importable != len(req.ResourceIDs) {
+			ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "selected resources are not all importable; set override to import conflict rows", "")
+			return
+		}
+	}
+	actionDetails := map[string]string{
+		"network_conflict_action": "import",
+		"resource_ids":            joinUUIDs(req.ResourceIDs),
+	}
+	if req.PoolID != nil {
+		actionDetails["pool_id"] = fmt.Sprintf("%d", *req.PoolID)
+	}
+	if err := ns.ensureNetworkConflictResolutionRecord(r.Context(), *conflict, networkActionReason("import_pending", req.Reason, actionDetails), actionDetails); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "prepare conflict action failed", err.Error())
+		return
+	}
+	importResp, err := discoveryServer.applyDiscoveryImport(r.Context(), importReq, discoveryImportApplyOptions{AllowBlocked: req.Override})
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "apply import failed", err.Error())
+		return
+	}
+	if importResp.PoolsCreated+importResp.ResourcesLinked == 0 {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "import did not create or link any resources", strings.Join(importResp.Errors, "; "))
+		return
+	}
+	actionDetails["pools_created"] = fmt.Sprintf("%d", importResp.PoolsCreated)
+	actionDetails["resources_linked"] = fmt.Sprintf("%d", importResp.ResourcesLinked)
+	actionDetails["skipped"] = fmt.Sprintf("%d", importResp.Skipped)
+	actionDetails["created_pool_ids"] = joinInt64s(importResp.CreatedPoolIDs)
+	actionDetails["linked_resource_ids"] = joinUUIDs(importResp.LinkedResourceIDs)
+	resolveReq := domain.ResolveNetworkConflictRequest{
+		Decision: "import",
+		Reason:   networkActionReason("import", req.Reason, actionDetails),
+	}
+	if err := ns.persistNetworkConflictActionResolution(r.Context(), *conflict, resolveReq, actionDetails); err != nil {
+		rollbackErr := ns.rollbackNetworkConflictImport(r.Context(), importResp)
+		if rollbackErr != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "record conflict action failed and rollback failed", err.Error()+"; rollback: "+rollbackErr.Error())
+			return
+		}
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "record conflict action failed", err.Error())
+		return
+	}
+
+	updated := ns.conflictAfterAction(r.Context(), *conflict, "import")
+	writeJSON(w, http.StatusOK, domain.NetworkConflictActionResponse{
+		Conflict: updated,
+		Action:   "import",
+		PoolID:   req.PoolID,
+		Import:   &importResp,
+	})
 }
 
 type networkViewFilters struct {
@@ -467,7 +675,32 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 			if res.PoolID != nil && *res.PoolID == pool.ID {
 				continue
 			}
-			if res.CIDR == "" || pool.CIDR == "" || networkCIDREqual(res.CIDR, pool.CIDR) || !networkCIDROverlaps(res.CIDR, pool.CIDR) {
+			if res.CIDR == "" || pool.CIDR == "" {
+				continue
+			}
+			if networkCIDREqual(res.CIDR, pool.CIDR) {
+				if res.PoolID == nil {
+					add(domain.NetworkConflict{
+						ID:                fmt.Sprintf("unlinked-exact-pool:%s:%d", res.ID.String(), pool.ID),
+						Type:              "unlinked_exact_pool",
+						Severity:          "warning",
+						Status:            "open",
+						Title:             "Discovered CIDR matches managed pool",
+						Description:       fmt.Sprintf("%s (%s) exactly matches pool %s", res.ResourceID, res.CIDR, pool.Name),
+						RecommendedAction: "Link the discovered resource to the matching managed pool, import separately, or mark reviewed.",
+						NodeIDs:           []string{nodeID, poolNodeID(pool.ID)},
+						DiscoveredIDs:     []uuid.UUID{res.ID},
+						PoolIDs:           []int64{pool.ID},
+						AccountIDs:        accountIDsForPool(res.AccountID, pool),
+						Regions:           []string{res.Region},
+						ObjectTypes:       []string{string(res.ResourceType), string(pool.Type)},
+						CIDR:              res.CIDR,
+						Evidence:          []string{fmt.Sprintf("pool_id=%d", pool.ID), "pool_cidr=" + pool.CIDR},
+					})
+				}
+				continue
+			}
+			if !networkCIDROverlaps(res.CIDR, pool.CIDR) {
 				continue
 			}
 			if networkCIDRContains(pool.CIDR, res.CIDR) || networkCIDRContains(res.CIDR, pool.CIDR) {
@@ -566,11 +799,20 @@ func (ns *NetworkServer) applyStoredConflictResolutions(ctx context.Context, con
 }
 
 func (ns *NetworkServer) persistNetworkConflictResolution(ctx context.Context, conflict domain.NetworkConflict, req domain.ResolveNetworkConflictRequest) error {
+	return ns.persistNetworkConflictActionResolution(ctx, conflict, req, nil)
+}
+
+func (ns *NetworkServer) persistNetworkConflictActionResolution(ctx context.Context, conflict domain.NetworkConflict, req domain.ResolveNetworkConflictRequest, details map[string]string) error {
 	if ns.driftStore == nil {
 		return fmt.Errorf("drift store is not available")
 	}
 	status := networkDecisionStatus(req.Decision)
 	reason := networkResolutionReason(req.Decision, req.Reason)
+	if len(details) > 0 {
+		if err := ns.driftStore.UpdateDriftDetails(ctx, conflict.ID, details); err != nil && !errors.Is(err, storage.ErrNotFound) {
+			return err
+		}
+	}
 	if err := ns.driftStore.UpdateDriftStatus(ctx, conflict.ID, status, reason); err == nil {
 		return nil
 	} else if !errors.Is(err, storage.ErrNotFound) {
@@ -594,6 +836,9 @@ func (ns *NetworkServer) persistNetworkConflictResolution(ctx context.Context, c
 		DetectedAt: now,
 		UpdatedAt:  now,
 	}
+	for key, value := range details {
+		item.Details[key] = value
+	}
 	if len(conflict.DiscoveredIDs) > 0 {
 		item.ResourceID = &conflict.DiscoveredIDs[0]
 	}
@@ -604,6 +849,166 @@ func (ns *NetworkServer) persistNetworkConflictResolution(ctx context.Context, c
 		return err
 	}
 	return ns.driftStore.UpdateDriftStatus(ctx, conflict.ID, status, reason)
+}
+
+func (ns *NetworkServer) ensureNetworkConflictResolutionRecord(ctx context.Context, conflict domain.NetworkConflict, reason string, details map[string]string) error {
+	if ns.driftStore == nil {
+		return fmt.Errorf("drift store is not available")
+	}
+	if _, err := ns.driftStore.GetDriftItem(ctx, conflict.ID); err == nil {
+		if len(details) > 0 {
+			if err := ns.driftStore.UpdateDriftDetails(ctx, conflict.ID, details); err != nil {
+				return err
+			}
+		}
+		return ns.driftStore.UpdateDriftStatus(ctx, conflict.ID, domain.DriftStatusOpen, reason)
+	} else if !errors.Is(err, storage.ErrNotFound) {
+		return err
+	}
+
+	now := time.Now().UTC()
+	item := domain.DriftItem{
+		ID:           conflict.ID,
+		AccountID:    firstConflictAccountID(conflict),
+		Type:         domain.DriftTypeAccountDrift,
+		Severity:     driftSeverityFromNetwork(conflict.Severity),
+		Status:       domain.DriftStatusOpen,
+		Title:        conflict.Title,
+		Description:  conflict.Description,
+		ResourceCIDR: conflict.CIDR,
+		Details: map[string]string{
+			"network_conflict_type": conflict.Type,
+			"recommended_action":    conflict.RecommendedAction,
+		},
+		IgnoreReason: reason,
+		DetectedAt:   now,
+		UpdatedAt:    now,
+	}
+	for key, value := range details {
+		item.Details[key] = value
+	}
+	if len(conflict.DiscoveredIDs) > 0 {
+		item.ResourceID = &conflict.DiscoveredIDs[0]
+	}
+	if len(conflict.PoolIDs) > 0 {
+		item.PoolID = &conflict.PoolIDs[0]
+	}
+	return ns.driftStore.CreateDriftItem(ctx, item)
+}
+
+func (ns *NetworkServer) rollbackNetworkConflictLink(ctx context.Context, discoveredID uuid.UUID, previousPoolID *int64) error {
+	if previousPoolID == nil {
+		return ns.discStore.UnlinkResource(ctx, discoveredID)
+	}
+	return ns.discStore.LinkResourceToPool(ctx, discoveredID, *previousPoolID)
+}
+
+func (ns *NetworkServer) rollbackNetworkConflictImport(ctx context.Context, resp domain.DiscoveryImportApplyResponse) error {
+	var errs []string
+	for _, resourceID := range resp.LinkedResourceIDs {
+		if err := ns.discStore.UnlinkResource(ctx, resourceID); err != nil {
+			errs = append(errs, fmt.Sprintf("unlink %s: %v", resourceID, err))
+		}
+	}
+	for i := len(resp.CreatedPoolIDs) - 1; i >= 0; i-- {
+		if ok, err := ns.store.DeletePool(ctx, resp.CreatedPoolIDs[i]); err != nil {
+			errs = append(errs, fmt.Sprintf("delete pool %d: %v", resp.CreatedPoolIDs[i], err))
+		} else if !ok {
+			errs = append(errs, fmt.Sprintf("delete pool %d: not found", resp.CreatedPoolIDs[i]))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func (ns *NetworkServer) findNetworkConflict(ctx context.Context, conflictID string) (*domain.NetworkConflict, error) {
+	view, err := ns.buildNetworkView(ctx, networkViewFilters{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range view.conflicts {
+		if view.conflicts[i].ID == conflictID {
+			return &view.conflicts[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func (ns *NetworkServer) conflictAfterAction(ctx context.Context, fallback domain.NetworkConflict, action string) domain.NetworkConflict {
+	conflict, err := ns.findNetworkConflict(ctx, fallback.ID)
+	if err == nil && conflict != nil {
+		return *conflict
+	}
+	fallback.Status = string(domain.DriftStatusResolved)
+	fallback.ResolutionState = fallback.Status
+	fallback.ResolutionRequested = action
+	return fallback
+}
+
+func validateNetworkConflictLinkAction(conflict domain.NetworkConflict, res domain.DiscoveredResource, pool domain.Pool, req domain.NetworkConflictLinkActionRequest) error {
+	if !req.Override {
+		if !containsUUID(conflict.DiscoveredIDs, req.DiscoveredID) {
+			return fmt.Errorf("discovered resource is not part of this conflict")
+		}
+		if !containsInt64(conflict.PoolIDs, req.PoolID) {
+			return fmt.Errorf("pool is not part of this conflict")
+		}
+		if res.PoolID != nil {
+			return fmt.Errorf("discovered resource is already linked")
+		}
+		if pool.AccountID != nil && *pool.AccountID != res.AccountID {
+			return fmt.Errorf("pool account does not match discovered resource account; set override to force")
+		}
+		if res.CIDR == "" || pool.CIDR == "" {
+			return fmt.Errorf("resource and pool must both have CIDR values")
+		}
+		if !networkCIDREqual(pool.CIDR, res.CIDR) && !networkCIDRContains(pool.CIDR, res.CIDR) {
+			return fmt.Errorf("pool CIDR does not contain discovered resource CIDR; set override to force")
+		}
+	}
+	return nil
+}
+
+func validateNetworkConflictImportSelection(conflict domain.NetworkConflict, req domain.NetworkConflictImportActionRequest) error {
+	if req.PoolID != nil && *req.PoolID < 1 {
+		return fmt.Errorf("pool_id must be a positive integer")
+	}
+	if req.Override {
+		return nil
+	}
+	for _, id := range req.ResourceIDs {
+		if !containsUUID(conflict.DiscoveredIDs, id) {
+			return fmt.Errorf("resource %s is not part of this conflict", id)
+		}
+	}
+	return nil
+}
+
+func (ns *NetworkServer) importActionAccountID(ctx context.Context, conflict domain.NetworkConflict, resourceIDs []uuid.UUID) (int64, error) {
+	var accountID int64
+	for _, id := range resourceIDs {
+		res, err := ns.discStore.GetDiscoveredResource(ctx, id)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return 0, fmt.Errorf("resource %s not found", id)
+			}
+			return 0, err
+		}
+		if accountID == 0 {
+			accountID = res.AccountID
+		} else if accountID != res.AccountID {
+			return 0, fmt.Errorf("selected resources must belong to one account")
+		}
+	}
+	if accountID == 0 {
+		accountID = firstConflictAccountID(conflict)
+	}
+	if accountID < 1 {
+		return 0, fmt.Errorf("could not determine import account")
+	}
+	return accountID, nil
 }
 
 func buildNetworkHierarchy(flat []domain.NetworkNode) []domain.NetworkNode {
@@ -722,10 +1127,10 @@ func networkDecisionStatus(decision string) domain.DriftStatus {
 	switch strings.ToLower(strings.TrimSpace(decision)) {
 	case "ignore":
 		return domain.DriftStatusIgnored
+	case "skip", "link", "import":
+		return domain.DriftStatusResolved
 	case "defer":
 		return domain.DriftStatusOpen
-	case "skip":
-		return domain.DriftStatusResolved
 	default:
 		return domain.DriftStatusOpen
 	}
@@ -754,6 +1159,24 @@ func networkResolutionReason(decision string, reason string) string {
 	return "decision=" + decision + " reason=" + reason
 }
 
+func networkActionReason(action string, reason string, details map[string]string) string {
+	parts := []string{}
+	for key, value := range details {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		parts = append(parts, key+"="+strings.TrimSpace(value))
+	}
+	sort.Strings(parts)
+	if reason = strings.TrimSpace(reason); reason != "" {
+		parts = append(parts, "operator_reason="+reason)
+	}
+	if len(parts) == 0 {
+		return action
+	}
+	return action + " " + strings.Join(parts, " ")
+}
+
 func parseNetworkDecision(reason string) string {
 	for _, part := range strings.Fields(reason) {
 		if strings.HasPrefix(part, "decision=") {
@@ -768,6 +1191,31 @@ func firstConflictAccountID(conflict domain.NetworkConflict) int64 {
 		return conflict.AccountIDs[0]
 	}
 	return 0
+}
+
+func containsUUID(values []uuid.UUID, target uuid.UUID) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func joinUUIDs(values []uuid.UUID) string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, value.String())
+	}
+	return strings.Join(out, ",")
+}
+
+func joinInt64s(values []int64) string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, fmt.Sprintf("%d", value))
+	}
+	return strings.Join(out, ",")
 }
 
 func driftSeverityFromNetwork(severity string) domain.DriftSeverity {

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -957,16 +957,16 @@ func (ns *NetworkServer) conflictAfterAction(ctx context.Context, fallback domai
 }
 
 func validateNetworkConflictLinkAction(conflict domain.NetworkConflict, res domain.DiscoveredResource, pool domain.Pool, req domain.NetworkConflictLinkActionRequest) error {
+	if !containsUUID(conflict.DiscoveredIDs, req.DiscoveredID) {
+		return fmt.Errorf("discovered resource is not part of this conflict")
+	}
+	if !containsInt64(conflict.PoolIDs, req.PoolID) {
+		return fmt.Errorf("pool is not part of this conflict")
+	}
+	if res.PoolID != nil {
+		return fmt.Errorf("discovered resource is already linked")
+	}
 	if !req.Override {
-		if !containsUUID(conflict.DiscoveredIDs, req.DiscoveredID) {
-			return fmt.Errorf("discovered resource is not part of this conflict")
-		}
-		if !containsInt64(conflict.PoolIDs, req.PoolID) {
-			return fmt.Errorf("pool is not part of this conflict")
-		}
-		if res.PoolID != nil {
-			return fmt.Errorf("discovered resource is already linked")
-		}
 		if pool.AccountID != nil && *pool.AccountID != res.AccountID {
 			return fmt.Errorf("pool account does not match discovered resource account; set override to force")
 		}
@@ -983,9 +983,6 @@ func validateNetworkConflictLinkAction(conflict domain.NetworkConflict, res doma
 func validateNetworkConflictImportSelection(conflict domain.NetworkConflict, req domain.NetworkConflictImportActionRequest) error {
 	if req.PoolID != nil && *req.PoolID < 1 {
 		return fmt.Errorf("pool_id must be a positive integer")
-	}
-	if req.Override {
-		return nil
 	}
 	for _, id := range req.ResourceIDs {
 		if !containsUUID(conflict.DiscoveredIDs, id) {

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -331,8 +331,17 @@ func (ns *NetworkServer) handleNetworkConflictImportAction(w http.ResponseWriter
 		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "apply import failed", err.Error())
 		return
 	}
-	if importResp.PoolsCreated+importResp.ResourcesLinked == 0 {
-		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "import did not create or link any resources", strings.Join(importResp.Errors, "; "))
+	if importResp.PoolsCreated+importResp.ResourcesLinked == 0 || importResp.Skipped > 0 || len(importResp.Errors) > 0 {
+		rollbackErr := ns.rollbackNetworkConflictImport(r.Context(), importResp)
+		detail := strings.Join(importResp.Errors, "; ")
+		if detail == "" && importResp.Skipped > 0 {
+			detail = fmt.Sprintf("%d selected resources were skipped", importResp.Skipped)
+		}
+		if rollbackErr != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "import was incomplete and rollback failed", detail+"; rollback: "+rollbackErr.Error())
+			return
+		}
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "import did not complete for all selected resources", detail)
 		return
 	}
 	actionDetails["pools_created"] = fmt.Sprintf("%d", importResp.PoolsCreated)

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -331,6 +331,66 @@ func TestNetworkConflictImportActionImportsMissingParentWithOverride(t *testing.
 	}
 }
 
+func TestNetworkConflictImportActionRejectsCrossAccountParentPoolWithOverride(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	otherAccount, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:222222222222", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create other account: %v", err)
+	}
+	otherParentPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "dev-space", CIDR: "10.125.0.0/16", Type: domain.PoolTypeVPC, AccountID: &otherAccount.ID})
+	if err != nil {
+		t.Fatalf("create other parent pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	subnetID := uuid.New()
+	parent := "vpc-missing"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:               subnetID,
+		AccountID:        account.ID,
+		Provider:         "aws",
+		Region:           "us-east-1",
+		ResourceType:     domain.ResourceTypeSubnet,
+		ResourceID:       "subnet-1",
+		Name:             "subnet-1",
+		CIDR:             "10.125.1.0/24",
+		ParentResourceID: &parent,
+		Status:           domain.DiscoveryStatusActive,
+		DiscoveredAt:     now,
+		LastSeenAt:       now,
+	})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected missing-parent conflict, got %+v", conflicts)
+	}
+
+	body := fmt.Sprintf(`{"resource_ids":["%s"],"pool_id":%d,"override":true}`, subnetID, otherParentPool.ID)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/import", conflicts.Items[0].ID), body, http.StatusBadRequest)
+	linked, err := ds.GetDiscoveredResource(t.Context(), subnetID)
+	if err != nil {
+		t.Fatalf("load subnet after rejected import: %v", err)
+	}
+	if linked.PoolID != nil {
+		t.Fatalf("cross-account import should not link resource, got pool %d", *linked.PoolID)
+	}
+	pools, err := st.ListPools(t.Context())
+	if err != nil {
+		t.Fatalf("list pools after rejected import: %v", err)
+	}
+	if len(pools) != 1 {
+		t.Fatalf("cross-account import should not create pools, got %d pools: %+v", len(pools), pools)
+	}
+}
+
 func TestNetworkConflictImportActionRejectsUnrelatedResource(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -391,6 +391,66 @@ func TestNetworkConflictImportActionRejectsCrossAccountParentPoolWithOverride(t 
 	}
 }
 
+func TestNetworkConflictImportActionRejectsImplicitCrossAccountParentPoolWithOverride(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	otherAccount, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:222222222222", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create other account: %v", err)
+	}
+	otherParentPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "dev-space", CIDR: "10.126.0.0/16", Type: domain.PoolTypeVPC, AccountID: &otherAccount.ID})
+	if err != nil {
+		t.Fatalf("create other parent pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	subnetID := uuid.New()
+	parent := "vpc-missing"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:               subnetID,
+		AccountID:        account.ID,
+		Provider:         "aws",
+		Region:           "us-east-1",
+		ResourceType:     domain.ResourceTypeSubnet,
+		ResourceID:       "subnet-1",
+		Name:             "subnet-1",
+		CIDR:             "10.126.1.0/24",
+		ParentResourceID: &parent,
+		Status:           domain.DiscoveryStatusActive,
+		DiscoveredAt:     now,
+		LastSeenAt:       now,
+	})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected missing-parent conflict, got %+v", conflicts)
+	}
+
+	body := fmt.Sprintf(`{"resource_ids":["%s"],"override":true}`, subnetID)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/import", conflicts.Items[0].ID), body, http.StatusBadRequest)
+	linked, err := ds.GetDiscoveredResource(t.Context(), subnetID)
+	if err != nil {
+		t.Fatalf("load subnet after rejected import: %v", err)
+	}
+	if linked.PoolID != nil {
+		t.Fatalf("implicit cross-account import should not link resource, got pool %d", *linked.PoolID)
+	}
+	pools, err := st.ListPools(t.Context())
+	if err != nil {
+		t.Fatalf("list pools after rejected import: %v", err)
+	}
+	if len(pools) != 1 || pools[0].ID != otherParentPool.ID {
+		t.Fatalf("implicit cross-account import should not create pools, got %+v", pools)
+	}
+}
+
 func TestNetworkConflictImportActionRejectsUnrelatedResource(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"cloudpam/internal/domain"
+	"cloudpam/internal/storage"
 )
 
 func TestNetworkFlatShowsDiscoveredObjectsAndDuplicateConflict(t *testing.T) {
@@ -145,6 +148,307 @@ func TestNetworkConflictsExposeMissingParentAndResolveRequest(t *testing.T) {
 	if resp.Items[0].Status != "resolved" || resp.Items[0].ResolutionRequested != "skip" {
 		t.Fatalf("resolution was not durable in computed conflict view: %+v", resp.Items[0])
 	}
+}
+
+func TestNetworkConflictLinkActionLinksExactPoolAndResolves(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	pool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-vpc", CIDR: "10.100.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-prod",
+		Name:         "prod-vpc",
+		CIDR:         "10.100.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected one exact-pool conflict, got %+v", conflicts)
+	}
+
+	body := fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d,"reason":"exact match reviewed"}`, vpcID, pool.ID)
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), body, http.StatusOK)
+	var action domain.NetworkConflictActionResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &action); err != nil {
+		t.Fatalf("unmarshal link action: %v", err)
+	}
+	if action.Action != "link" || !action.ResourceLinked || action.Conflict.ResolutionRequested != "link" {
+		t.Fatalf("unexpected link action response: %+v", action)
+	}
+	linked, err := ds.GetDiscoveredResource(t.Context(), vpcID)
+	if err != nil {
+		t.Fatalf("load linked resource: %v", err)
+	}
+	if linked.PoolID == nil || *linked.PoolID != pool.ID {
+		t.Fatalf("resource was not linked to pool: %+v", linked)
+	}
+}
+
+func TestNetworkConflictLinkActionRejectsUnrelatedAndUnsafeWithoutOverride(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	otherAccount, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:222222222222", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create other account: %v", err)
+	}
+	mismatchPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "mismatch", CIDR: "10.110.0.0/16", Type: domain.PoolTypeVPC, AccountID: &otherAccount.ID})
+	if err != nil {
+		t.Fatalf("create mismatch pool: %v", err)
+	}
+	unrelatedPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "unrelated", CIDR: "10.111.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create unrelated pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	otherID := uuid.New()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: vpcID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-prod", CIDR: "10.110.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: otherID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-other", CIDR: "10.112.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected one exact-pool conflict, got %+v", conflicts)
+	}
+
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d}`, otherID, mismatchPool.ID), http.StatusBadRequest)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d}`, vpcID, unrelatedPool.ID), http.StatusBadRequest)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d}`, vpcID, mismatchPool.ID), http.StatusBadRequest)
+}
+
+func TestNetworkConflictImportActionImportsMissingParentWithOverride(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	parentPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-space", CIDR: "10.120.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create parent pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	subnetID := uuid.New()
+	parent := "vpc-missing"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:               subnetID,
+		AccountID:        account.ID,
+		Provider:         "aws",
+		Region:           "us-east-1",
+		ResourceType:     domain.ResourceTypeSubnet,
+		ResourceID:       "subnet-1",
+		Name:             "subnet-1",
+		CIDR:             "10.120.1.0/24",
+		ParentResourceID: &parent,
+		Status:           domain.DiscoveryStatusActive,
+		DiscoveredAt:     now,
+		LastSeenAt:       now,
+	})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected missing-parent conflict, got %+v", conflicts)
+	}
+
+	noOverride := fmt.Sprintf(`{"resource_ids":["%s"],"pool_id":%d}`, subnetID, parentPool.ID)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/import", conflicts.Items[0].ID), noOverride, http.StatusBadRequest)
+
+	body := fmt.Sprintf(`{"resource_ids":["%s"],"pool_id":%d,"override":true,"reason":"use containing pool"}`, subnetID, parentPool.ID)
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/import", conflicts.Items[0].ID), body, http.StatusOK)
+	var action domain.NetworkConflictActionResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &action); err != nil {
+		t.Fatalf("unmarshal import action: %v", err)
+	}
+	if action.Action != "import" || action.Import == nil || action.Import.PoolsCreated != 1 || action.Import.ResourcesLinked != 1 {
+		t.Fatalf("unexpected import action response: %+v", action)
+	}
+	linked, err := ds.GetDiscoveredResource(t.Context(), subnetID)
+	if err != nil {
+		t.Fatalf("load imported resource: %v", err)
+	}
+	if linked.PoolID == nil {
+		t.Fatalf("resource was not linked after import: %+v", linked)
+	}
+}
+
+func TestNetworkConflictImportActionRejectsUnrelatedResource(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	now := time.Now().UTC()
+	subnetID := uuid.New()
+	otherID := uuid.New()
+	parent := "vpc-missing"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: subnetID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeSubnet, ResourceID: "subnet-1", CIDR: "10.130.1.0/24", ParentResourceID: &parent, Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: otherID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-other", CIDR: "10.131.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected missing-parent conflict, got %+v", conflicts)
+	}
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/import", conflicts.Items[0].ID), fmt.Sprintf(`{"resource_ids":["%s"]}`, otherID), http.StatusBadRequest)
+}
+
+func TestNetworkConflictLinkActionRollsBackWhenResolutionPersistenceFails(t *testing.T) {
+	srv, st := setupTestServer()
+	ds := storage.NewMemoryDiscoveryStore(st)
+	driftStore := &failResolvedDriftStore{base: storage.NewMemoryDriftStore(st)}
+	networkSrv := NewNetworkServer(srv, st, ds, driftStore)
+	networkSrv.RegisterNetworkRoutes()
+
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	pool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-vpc", CIDR: "10.140.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: vpcID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-prod", CIDR: "10.140.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+
+	rr := doJSON(t, srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected one exact-pool conflict, got %+v", conflicts)
+	}
+
+	body := fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d}`, vpcID, pool.ID)
+	doJSON(t, srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), body, http.StatusInternalServerError)
+	res, err := ds.GetDiscoveredResource(t.Context(), vpcID)
+	if err != nil {
+		t.Fatalf("load resource after rollback: %v", err)
+	}
+	if res.PoolID != nil {
+		t.Fatalf("expected failed resolution persistence to rollback link, got pool %d", *res.PoolID)
+	}
+}
+
+func TestNetworkConflictActionUpdatesExistingDriftDetails(t *testing.T) {
+	srv, st := setupTestServer()
+	ds := storage.NewMemoryDiscoveryStore(st)
+	driftStore := storage.NewMemoryDriftStore(st)
+	networkSrv := NewNetworkServer(srv, st, ds, driftStore)
+	networkSrv.RegisterNetworkRoutes()
+
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	pool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-vpc", CIDR: "10.150.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: vpcID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-prod", CIDR: "10.150.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+
+	rr := doJSON(t, srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected one exact-pool conflict, got %+v", conflicts)
+	}
+	existing := domain.DriftItem{
+		ID:          conflicts.Items[0].ID,
+		AccountID:   account.ID,
+		Type:        domain.DriftTypeAccountDrift,
+		Severity:    domain.DriftSeverityWarning,
+		Status:      domain.DriftStatusOpen,
+		Title:       conflicts.Items[0].Title,
+		Description: conflicts.Items[0].Description,
+		Details:     map[string]string{"existing": "true"},
+		DetectedAt:  now,
+		UpdatedAt:   now,
+	}
+	if err := driftStore.CreateDriftItem(t.Context(), existing); err != nil {
+		t.Fatalf("create existing drift: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d}`, vpcID, pool.ID)
+	doJSON(t, srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), body, http.StatusOK)
+	item, err := driftStore.GetDriftItem(t.Context(), conflicts.Items[0].ID)
+	if err != nil {
+		t.Fatalf("get drift item: %v", err)
+	}
+	if item.Details["existing"] != "true" || item.Details["network_conflict_action"] != "link" || item.Details["pool_id"] != fmt.Sprintf("%d", pool.ID) {
+		t.Fatalf("existing drift details were not merged with action details: %+v", item.Details)
+	}
+}
+
+type failResolvedDriftStore struct {
+	base *storage.MemoryDriftStore
+}
+
+func (s *failResolvedDriftStore) CreateDriftItem(ctx context.Context, item domain.DriftItem) error {
+	return s.base.CreateDriftItem(ctx, item)
+}
+
+func (s *failResolvedDriftStore) GetDriftItem(ctx context.Context, id string) (*domain.DriftItem, error) {
+	return s.base.GetDriftItem(ctx, id)
+}
+
+func (s *failResolvedDriftStore) ListDriftItems(ctx context.Context, filters domain.DriftFilters) ([]domain.DriftItem, int, error) {
+	return s.base.ListDriftItems(ctx, filters)
+}
+
+func (s *failResolvedDriftStore) UpdateDriftStatus(ctx context.Context, id string, status domain.DriftStatus, ignoreReason string) error {
+	if status == domain.DriftStatusResolved {
+		return errors.New("forced final resolution failure")
+	}
+	return s.base.UpdateDriftStatus(ctx, id, status, ignoreReason)
+}
+
+func (s *failResolvedDriftStore) UpdateDriftDetails(ctx context.Context, id string, details map[string]string) error {
+	return s.base.UpdateDriftDetails(ctx, id, details)
+}
+
+func (s *failResolvedDriftStore) DeleteOpenForAccount(ctx context.Context, accountID int64) error {
+	return s.base.DeleteOpenForAccount(ctx, accountID)
 }
 
 func hierarchyHasParentChild(nodes []domain.NetworkNode, parentPrefix string, childID string) bool {

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -150,6 +151,32 @@ func TestNetworkConflictsExposeMissingParentAndResolveRequest(t *testing.T) {
 	}
 }
 
+func TestNetworkConflictRoutesAppearInOpenAPISpec(t *testing.T) {
+	discSrv, _, _, _ := setupDiscoveryTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/openapi.yaml", nil)
+	rr := httptest.NewRecorder()
+	discSrv.srv.mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{
+		`"/api/v1/network/conflicts":`,
+		`"/api/v1/network/conflicts/{conflictId}/resolve":`,
+		`"/api/v1/network/conflicts/{conflictId}/actions/link":`,
+		`"/api/v1/network/conflicts/{conflictId}/actions/import":`,
+		`$ref: '#/components/schemas/ResolveNetworkConflictRequest'`,
+		`$ref: '#/components/schemas/NetworkConflictLinkActionRequest'`,
+		`$ref: '#/components/schemas/NetworkConflictImportActionRequest'`,
+		`$ref: '#/components/schemas/NetworkConflictActionResponse'`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("generated OpenAPI spec missing %s", want)
+		}
+	}
+}
+
 func TestNetworkConflictLinkActionLinksExactPoolAndResolves(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
@@ -204,7 +231,7 @@ func TestNetworkConflictLinkActionLinksExactPoolAndResolves(t *testing.T) {
 	}
 }
 
-func TestNetworkConflictLinkActionRejectsUnrelatedAndUnsafeWithoutOverride(t *testing.T) {
+func TestNetworkConflictLinkActionRejectsUnrelatedAndUnsafePayloads(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
 	if err != nil {
@@ -241,6 +268,8 @@ func TestNetworkConflictLinkActionRejectsUnrelatedAndUnsafeWithoutOverride(t *te
 	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d}`, otherID, mismatchPool.ID), http.StatusBadRequest)
 	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d}`, vpcID, unrelatedPool.ID), http.StatusBadRequest)
 	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d}`, vpcID, mismatchPool.ID), http.StatusBadRequest)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d,"override":true}`, otherID, mismatchPool.ID), http.StatusBadRequest)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d,"override":true}`, vpcID, unrelatedPool.ID), http.StatusBadRequest)
 }
 
 func TestNetworkConflictImportActionImportsMissingParentWithOverride(t *testing.T) {
@@ -325,6 +354,7 @@ func TestNetworkConflictImportActionRejectsUnrelatedResource(t *testing.T) {
 		t.Fatalf("expected missing-parent conflict, got %+v", conflicts)
 	}
 	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/import", conflicts.Items[0].ID), fmt.Sprintf(`{"resource_ids":["%s"]}`, otherID), http.StatusBadRequest)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/import", conflicts.Items[0].ID), fmt.Sprintf(`{"resource_ids":["%s"],"override":true}`, otherID), http.StatusBadRequest)
 }
 
 func TestNetworkConflictImportActionRejectsPartialApplyAndRollsBack(t *testing.T) {

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -327,6 +327,52 @@ func TestNetworkConflictImportActionRejectsUnrelatedResource(t *testing.T) {
 	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/import", conflicts.Items[0].ID), fmt.Sprintf(`{"resource_ids":["%s"]}`, otherID), http.StatusBadRequest)
 }
 
+func TestNetworkConflictImportActionRejectsPartialApplyAndRollsBack(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	parentPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-space", CIDR: "10.135.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create parent pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	subnetID := uuid.New()
+	eipID := uuid.New()
+	parent := "vpc-missing"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: subnetID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeSubnet, ResourceID: "subnet-1", CIDR: "10.135.1.0/24", ParentResourceID: &parent, Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: eipID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeElasticIP, ResourceID: "eip-1", Name: "eip-1", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected missing-parent conflict, got %+v", conflicts)
+	}
+
+	body := fmt.Sprintf(`{"resource_ids":["%s","%s"],"pool_id":%d,"override":true}`, subnetID, eipID, parentPool.ID)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/import", conflicts.Items[0].ID), body, http.StatusBadRequest)
+
+	linked, err := ds.GetDiscoveredResource(t.Context(), subnetID)
+	if err != nil {
+		t.Fatalf("load subnet after failed partial import: %v", err)
+	}
+	if linked.PoolID != nil {
+		t.Fatalf("partial import should rollback subnet link, got pool %d", *linked.PoolID)
+	}
+	pools, err := st.ListPools(t.Context())
+	if err != nil {
+		t.Fatalf("list pools after failed partial import: %v", err)
+	}
+	if len(pools) != 1 {
+		t.Fatalf("partial import should rollback created pools, got %d pools: %+v", len(pools), pools)
+	}
+}
+
 func TestNetworkConflictLinkActionRollsBackWhenResolutionPersistenceFails(t *testing.T) {
 	srv, st := setupTestServer()
 	ds := storage.NewMemoryDiscoveryStore(st)

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -503,6 +503,12 @@ func openAPIComponentTypes() []openAPIComponentType {
 		{"AgentRegisterResponse", reflect.TypeOf(domain.AgentRegisterResponse{})},
 		{"AgentHeartbeatRequest", reflect.TypeOf(domain.AgentHeartbeatRequest{})},
 		{"AgentHeartbeatResponse", reflect.TypeOf(domain.AgentHeartbeatResponse{})},
+		{"NetworkConflict", reflect.TypeOf(domain.NetworkConflict{})},
+		{"NetworkConflictListResponse", reflect.TypeOf(domain.NetworkConflictListResponse{})},
+		{"ResolveNetworkConflictRequest", reflect.TypeOf(domain.ResolveNetworkConflictRequest{})},
+		{"NetworkConflictLinkActionRequest", reflect.TypeOf(domain.NetworkConflictLinkActionRequest{})},
+		{"NetworkConflictImportActionRequest", reflect.TypeOf(domain.NetworkConflictImportActionRequest{})},
+		{"NetworkConflictActionResponse", reflect.TypeOf(domain.NetworkConflictActionResponse{})},
 		{"AnalysisRequest", reflect.TypeOf(planning.AnalysisRequest{})},
 		{"GapAnalysisRequest", reflect.TypeOf(planning.GapAnalysisRequest{})},
 		{"GenerateRecommendationsRequest", reflect.TypeOf(domain.GenerateRecommendationsRequest{})},
@@ -774,6 +780,20 @@ func openAPIRoutesForPattern(pattern string) []openAPIRoute {
 			{http.MethodPost, "/api/v1/discovery/agents/{agentId}/approve"},
 			{http.MethodPost, "/api/v1/discovery/agents/{agentId}/reject"},
 		})
+	case "/api/v1/network/flat":
+		return routesForMethodPath(http.MethodGet, "/api/v1/network/flat")
+	case "/api/v1/network/hierarchy":
+		return routesForMethodPath(http.MethodGet, "/api/v1/network/hierarchy")
+	case "/api/v1/network/merged":
+		return routesForMethodPath(http.MethodGet, "/api/v1/network/merged")
+	case "/api/v1/network/conflicts":
+		return routesForMethodPath(http.MethodGet, "/api/v1/network/conflicts")
+	case "/api/v1/network/conflicts/":
+		return routesForKnown([][2]string{
+			{http.MethodPost, "/api/v1/network/conflicts/{conflictId}/resolve"},
+			{http.MethodPost, "/api/v1/network/conflicts/{conflictId}/actions/link"},
+			{http.MethodPost, "/api/v1/network/conflicts/{conflictId}/actions/import"},
+		})
 	case "/api/v1/analysis":
 		return routesForMethodPath(http.MethodPost, "/api/v1/analysis")
 	case "/api/v1/analysis/gaps":
@@ -890,6 +910,12 @@ func splitMethodPattern(pattern string) (string, string, bool) {
 	switch path {
 	case "/api/v1/ai/sessions/{id}/apply-plan":
 		path = "/api/v1/ai/sessions/{sessionId}/apply-plan"
+	case "/api/v1/network/conflicts/{id}/resolve":
+		path = "/api/v1/network/conflicts/{conflictId}/resolve"
+	case "/api/v1/network/conflicts/{id}/actions/link":
+		path = "/api/v1/network/conflicts/{conflictId}/actions/link"
+	case "/api/v1/network/conflicts/{id}/actions/import":
+		path = "/api/v1/network/conflicts/{conflictId}/actions/import"
 	case "/api/v1/settings/oidc/providers/{id}":
 		path = "/api/v1/settings/oidc/providers/{providerId}"
 	case "/api/v1/settings/oidc/providers/{id}/test":
@@ -994,6 +1020,13 @@ func openAPIOperationCatalog() map[string]openAPIRoute {
 		{Method: "POST", Path: "/api/v1/discovery/agents/heartbeat", Summary: "Record discovery agent heartbeat", Tag: "Discovery", RequestSchema: "AgentHeartbeatRequest", ResponseSchema: "AgentHeartbeatResponse"},
 		{Method: "POST", Path: "/api/v1/discovery/agents/{agentId}/approve", Summary: "Approve discovery agent", Tag: "Discovery", ResponseSchema: "AgentRegisterResponse"},
 		{Method: "POST", Path: "/api/v1/discovery/agents/{agentId}/reject", Summary: "Reject discovery agent", Tag: "Discovery", ResponseSchema: "AgentRegisterResponse"},
+		{Method: "GET", Path: "/api/v1/network/flat", Summary: "Get flat network view", Tag: "Network", ResponseSchema: "Object", Parameters: networkViewQueryParams()},
+		{Method: "GET", Path: "/api/v1/network/hierarchy", Summary: "Get hierarchical network view", Tag: "Network", ResponseSchema: "Object", Parameters: networkViewQueryParams()},
+		{Method: "GET", Path: "/api/v1/network/merged", Summary: "Get merged network view", Tag: "Network", ResponseSchema: "Object", Parameters: networkViewQueryParams()},
+		{Method: "GET", Path: "/api/v1/network/conflicts", Summary: "List network conflicts", Tag: "Network", ResponseSchema: "NetworkConflictListResponse", Parameters: networkViewQueryParams()},
+		{Method: "POST", Path: "/api/v1/network/conflicts/{conflictId}/resolve", Summary: "Record passive network conflict decision", Tag: "Network", RequestSchema: "ResolveNetworkConflictRequest", ResponseSchema: "NetworkConflict"},
+		{Method: "POST", Path: "/api/v1/network/conflicts/{conflictId}/actions/link", Summary: "Link network conflict resource to pool", Tag: "Network", RequestSchema: "NetworkConflictLinkActionRequest", ResponseSchema: "NetworkConflictActionResponse"},
+		{Method: "POST", Path: "/api/v1/network/conflicts/{conflictId}/actions/import", Summary: "Import network conflict resources as pools", Tag: "Network", RequestSchema: "NetworkConflictImportActionRequest", ResponseSchema: "NetworkConflictActionResponse"},
 		{Method: "POST", Path: "/api/v1/analysis", Summary: "Run full network analysis", Tag: "Analysis", RequestSchema: "AnalysisRequest", ResponseSchema: "Object"},
 		{Method: "POST", Path: "/api/v1/analysis/gaps", Summary: "Run gap analysis", Tag: "Analysis", RequestSchema: "GapAnalysisRequest", ResponseSchema: "Object"},
 		{Method: "POST", Path: "/api/v1/analysis/fragmentation", Summary: "Run fragmentation analysis", Tag: "Analysis", RequestSchema: "AnalysisRequest", ResponseSchema: "Object"},
@@ -1095,6 +1128,18 @@ func discoveryResourceQueryParams() []openAPIParameter {
 		queryParam("linked", "Filter linked/unlinked resources", "boolean"),
 		queryParam("page", "Page number", "integer"),
 		queryParam("page_size", "Page size", "integer"),
+	}
+}
+
+func networkViewQueryParams() []openAPIParameter {
+	return []openAPIParameter{
+		queryParam("account_id", "Account ID", "integer"),
+		queryParam("provider", "Cloud provider", "string"),
+		queryParam("region", "Cloud region", "string"),
+		queryParam("object_type", "Network object type", "string"),
+		queryParam("status", "Network object status", "string"),
+		queryParam("conflict_type", "Network conflict type", "string"),
+		queryParam("q", "Search query", "string"),
 	}
 }
 

--- a/internal/domain/discovery.go
+++ b/internal/domain/discovery.go
@@ -177,11 +177,13 @@ type DiscoveryImportPreviewResponse struct {
 // DiscoveryImportApplyResponse reports the result of applying selected,
 // importable discovery preview rows.
 type DiscoveryImportApplyResponse struct {
-	Preview         DiscoveryImportPreviewResponse `json:"preview"`
-	PoolsCreated    int                            `json:"pools_created"`
-	ResourcesLinked int                            `json:"resources_linked"`
-	Skipped         int                            `json:"skipped"`
-	Errors          []string                       `json:"errors"`
+	Preview           DiscoveryImportPreviewResponse `json:"preview"`
+	PoolsCreated      int                            `json:"pools_created"`
+	ResourcesLinked   int                            `json:"resources_linked"`
+	Skipped           int                            `json:"skipped"`
+	Errors            []string                       `json:"errors"`
+	CreatedPoolIDs    []int64                        `json:"created_pool_ids,omitempty"`
+	LinkedResourceIDs []uuid.UUID                    `json:"linked_resource_ids,omitempty"`
 }
 
 // SyncJobsResponse is the response for listing sync jobs.

--- a/internal/domain/network.go
+++ b/internal/domain/network.go
@@ -80,3 +80,32 @@ type ResolveNetworkConflictRequest struct {
 	Decision string `json:"decision"`
 	Reason   string `json:"reason,omitempty"`
 }
+
+// NetworkConflictLinkActionRequest links an affected discovered resource to a
+// managed pool as a real conflict remediation.
+type NetworkConflictLinkActionRequest struct {
+	DiscoveredID uuid.UUID `json:"discovered_id"`
+	PoolID       int64     `json:"pool_id"`
+	Reason       string    `json:"reason,omitempty"`
+	Override     bool      `json:"override,omitempty"`
+}
+
+// NetworkConflictImportActionRequest imports affected discovered resources as
+// managed pools or links them through the discovery import apply workflow.
+type NetworkConflictImportActionRequest struct {
+	ResourceIDs []uuid.UUID `json:"resource_ids"`
+	PoolID      *int64      `json:"pool_id,omitempty"`
+	Reason      string      `json:"reason,omitempty"`
+	Override    bool        `json:"override,omitempty"`
+}
+
+// NetworkConflictActionResponse reports the mutation performed for a conflict
+// action and the conflict state after persistence.
+type NetworkConflictActionResponse struct {
+	Conflict       NetworkConflict               `json:"conflict"`
+	Action         string                        `json:"action"`
+	ResourceLinked bool                          `json:"resource_linked,omitempty"`
+	DiscoveredID   *uuid.UUID                    `json:"discovered_id,omitempty"`
+	PoolID         *int64                        `json:"pool_id,omitempty"`
+	Import         *DiscoveryImportApplyResponse `json:"import,omitempty"`
+}

--- a/internal/storage/drift.go
+++ b/internal/storage/drift.go
@@ -20,6 +20,9 @@ type DriftStore interface {
 	// UpdateDriftStatus updates a drift item's status and optional ignore reason.
 	UpdateDriftStatus(ctx context.Context, id string, status domain.DriftStatus, ignoreReason string) error
 
+	// UpdateDriftDetails merges structured detail metadata into a drift item.
+	UpdateDriftDetails(ctx context.Context, id string, details map[string]string) error
+
 	// DeleteOpenForAccount removes all open drift items for an account (before re-detection).
 	DeleteOpenForAccount(ctx context.Context, accountID int64) error
 }

--- a/internal/storage/drift_memory.go
+++ b/internal/storage/drift_memory.go
@@ -106,6 +106,25 @@ func (m *MemoryDriftStore) UpdateDriftStatus(_ context.Context, id string, statu
 	return nil
 }
 
+func (m *MemoryDriftStore) UpdateDriftDetails(_ context.Context, id string, details map[string]string) error {
+	m.store.mu.Lock()
+	defer m.store.mu.Unlock()
+
+	d, ok := m.drifts[id]
+	if !ok {
+		return ErrNotFound
+	}
+	if d.Details == nil {
+		d.Details = map[string]string{}
+	}
+	for key, value := range details {
+		d.Details[key] = value
+	}
+	d.UpdatedAt = time.Now().UTC()
+	m.drifts[id] = d
+	return nil
+}
+
 func (m *MemoryDriftStore) DeleteOpenForAccount(_ context.Context, accountID int64) error {
 	m.store.mu.Lock()
 	defer m.store.mu.Unlock()

--- a/internal/storage/postgres/drift.go
+++ b/internal/storage/postgres/drift.go
@@ -1,0 +1,235 @@
+//go:build postgres
+
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"cloudpam/internal/domain"
+	"cloudpam/internal/storage"
+)
+
+var _ storage.DriftStore = (*Store)(nil)
+
+func nilStringIfEmpty(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+// CreateDriftItem persists a new drift item.
+func (s *Store) CreateDriftItem(ctx context.Context, item domain.DriftItem) error {
+	detailsJSON := "{}"
+	if item.Details != nil {
+		if b, err := json.Marshal(item.Details); err == nil {
+			detailsJSON = string(b)
+		}
+	}
+
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO drift_items (
+			id, organization_id, account_id, resource_id, pool_id, type, severity, status,
+			title, description, resource_cidr, pool_cidr, details, ignore_reason,
+			resolved_at, detected_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17)`,
+		item.ID, s.orgID, item.AccountID, item.ResourceID, item.PoolID,
+		string(item.Type), string(item.Severity), string(item.Status),
+		item.Title, item.Description, item.ResourceCIDR, item.PoolCIDR,
+		detailsJSON, nilStringIfEmpty(item.IgnoreReason), item.ResolvedAt,
+		item.DetectedAt, item.UpdatedAt,
+	)
+	return storage.WrapIfConflict(err)
+}
+
+// GetDriftItem returns a single drift item by ID.
+func (s *Store) GetDriftItem(ctx context.Context, id string) (*domain.DriftItem, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT id, account_id, resource_id, pool_id, type, severity, status, title,
+			description, resource_cidr, pool_cidr, details::text, ignore_reason,
+			resolved_at, detected_at, updated_at
+		 FROM drift_items
+		 WHERE id = $1 AND organization_id = $2`,
+		id, s.orgID,
+	)
+	return scanPostgresDriftItem(row)
+}
+
+// ListDriftItems returns paginated drift items matching the filters.
+func (s *Store) ListDriftItems(ctx context.Context, filters domain.DriftFilters) ([]domain.DriftItem, int, error) {
+	where := []string{"organization_id = $1"}
+	args := []any{s.orgID}
+	addArg := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if filters.AccountID != 0 {
+		where = append(where, "account_id = "+addArg(filters.AccountID))
+	}
+	if filters.Type != "" {
+		where = append(where, "type = "+addArg(filters.Type))
+	}
+	if filters.Severity != "" {
+		where = append(where, "severity = "+addArg(filters.Severity))
+	}
+	if filters.Status != "" {
+		where = append(where, "status = "+addArg(filters.Status))
+	}
+
+	whereClause := " WHERE " + strings.Join(where, " AND ")
+	var total int
+	if err := s.pool.QueryRow(ctx, "SELECT COUNT(*) FROM drift_items"+whereClause, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	page := filters.Page
+	if page < 1 {
+		page = 1
+	}
+	pageSize := filters.PageSize
+	if pageSize < 1 {
+		pageSize = 50
+	}
+	offset := (page - 1) * pageSize
+
+	queryArgs := append(append([]any{}, args...), pageSize, offset)
+	query := fmt.Sprintf(
+		`SELECT id, account_id, resource_id, pool_id, type, severity, status, title,
+			description, resource_cidr, pool_cidr, details::text, ignore_reason,
+			resolved_at, detected_at, updated_at
+		 FROM drift_items%s
+		 ORDER BY detected_at DESC
+		 LIMIT $%d OFFSET $%d`,
+		whereClause, len(queryArgs)-1, len(queryArgs),
+	)
+	rows, err := s.pool.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	out := []domain.DriftItem{}
+	for rows.Next() {
+		item, err := scanPostgresDriftItemRow(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		out = append(out, item)
+	}
+	return out, total, rows.Err()
+}
+
+// UpdateDriftStatus updates a drift item's status and optional ignore reason.
+func (s *Store) UpdateDriftStatus(ctx context.Context, id string, status domain.DriftStatus, ignoreReason string) error {
+	now := time.Now().UTC()
+	var resolvedAt *time.Time
+	if status == domain.DriftStatusResolved {
+		resolvedAt = &now
+	}
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE drift_items
+		 SET status = $1, ignore_reason = $2, resolved_at = $3, updated_at = $4
+		 WHERE id = $5 AND organization_id = $6`,
+		string(status), nilStringIfEmpty(ignoreReason), resolvedAt, now, id, s.orgID,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
+}
+
+// UpdateDriftDetails merges structured detail metadata into a drift item.
+func (s *Store) UpdateDriftDetails(ctx context.Context, id string, details map[string]string) error {
+	item, err := s.GetDriftItem(ctx, id)
+	if err != nil {
+		return err
+	}
+	merged := map[string]string{}
+	for key, value := range item.Details {
+		merged[key] = value
+	}
+	for key, value := range details {
+		merged[key] = value
+	}
+	detailsJSON := "{}"
+	if b, err := json.Marshal(merged); err == nil {
+		detailsJSON = string(b)
+	}
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE drift_items SET details = $1::jsonb, updated_at = $2 WHERE id = $3 AND organization_id = $4`,
+		detailsJSON, time.Now().UTC(), id, s.orgID,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
+}
+
+// DeleteOpenForAccount removes all open drift items for an account.
+func (s *Store) DeleteOpenForAccount(ctx context.Context, accountID int64) error {
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM drift_items WHERE organization_id = $1 AND account_id = $2 AND status = $3`,
+		s.orgID, accountID, string(domain.DriftStatusOpen),
+	)
+	return err
+}
+
+type postgresDriftRow interface {
+	Scan(dest ...any) error
+}
+
+func scanPostgresDriftItem(row postgresDriftRow) (*domain.DriftItem, error) {
+	item, err := scanPostgresDriftItemValue(row)
+	if err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+func scanPostgresDriftItemRow(row postgresDriftRow) (domain.DriftItem, error) {
+	return scanPostgresDriftItemValue(row)
+}
+
+func scanPostgresDriftItemValue(row postgresDriftRow) (domain.DriftItem, error) {
+	var item domain.DriftItem
+	var resourceID *uuid.UUID
+	var poolID *int64
+	var detailsJSON string
+	var ignoreReason *string
+	var resolvedAt *time.Time
+
+	err := row.Scan(
+		&item.ID, &item.AccountID, &resourceID, &poolID,
+		&item.Type, &item.Severity, &item.Status, &item.Title, &item.Description,
+		&item.ResourceCIDR, &item.PoolCIDR, &detailsJSON, &ignoreReason, &resolvedAt,
+		&item.DetectedAt, &item.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return domain.DriftItem{}, storage.ErrNotFound
+		}
+		return domain.DriftItem{}, err
+	}
+	item.ResourceID = resourceID
+	item.PoolID = poolID
+	if ignoreReason != nil {
+		item.IgnoreReason = *ignoreReason
+	}
+	item.ResolvedAt = resolvedAt
+	_ = json.Unmarshal([]byte(detailsJSON), &item.Details)
+	return item, nil
+}

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -60,6 +60,10 @@ func resetDB(t *testing.T) {
 	// Truncate in dependency order (children before parents)
 	tables := []string{
 		"pool_utilization_cache",
+		"drift_items",
+		"sync_jobs",
+		"discovered_resources",
+		"discovery_agents",
 		"oidc_providers",
 		"settings",
 		"sessions",
@@ -645,6 +649,49 @@ func TestDeletePoolCascade(t *testing.T) {
 		if found {
 			t.Errorf("pool %d should have been cascade deleted", id)
 		}
+	}
+}
+
+func TestDriftStorePersistsAndMergesDetails(t *testing.T) {
+	resetDB(t)
+	ctx := context.Background()
+	store := testDB.store
+
+	account, err := store.CreateAccount(ctx, domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	now := time.Now().UTC()
+	item := domain.DriftItem{
+		ID:          "network-conflict:test",
+		AccountID:   account.ID,
+		Type:        domain.DriftTypeAccountDrift,
+		Severity:    domain.DriftSeverityWarning,
+		Status:      domain.DriftStatusOpen,
+		Title:       "Network conflict",
+		Description: "computed conflict",
+		Details:     map[string]string{"existing": "true"},
+		DetectedAt:  now,
+		UpdatedAt:   now,
+	}
+	if err := store.CreateDriftItem(ctx, item); err != nil {
+		t.Fatalf("create drift item: %v", err)
+	}
+	if err := store.UpdateDriftDetails(ctx, item.ID, map[string]string{"network_conflict_action": "link"}); err != nil {
+		t.Fatalf("update details: %v", err)
+	}
+	if err := store.UpdateDriftStatus(ctx, item.ID, domain.DriftStatusResolved, "decision=link"); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+	got, err := store.GetDriftItem(ctx, item.ID)
+	if err != nil {
+		t.Fatalf("get drift item: %v", err)
+	}
+	if got.Status != domain.DriftStatusResolved || got.IgnoreReason != "decision=link" || got.ResolvedAt == nil {
+		t.Fatalf("unexpected status fields: %+v", got)
+	}
+	if got.Details["existing"] != "true" || got.Details["network_conflict_action"] != "link" {
+		t.Fatalf("details were not merged: %+v", got.Details)
 	}
 }
 

--- a/internal/storage/sqlite/drift.go
+++ b/internal/storage/sqlite/drift.go
@@ -141,6 +141,38 @@ func (s *Store) UpdateDriftStatus(ctx context.Context, id string, status domain.
 	return nil
 }
 
+// UpdateDriftDetails merges structured detail metadata into a drift item.
+func (s *Store) UpdateDriftDetails(ctx context.Context, id string, details map[string]string) error {
+	item, err := s.GetDriftItem(ctx, id)
+	if err != nil {
+		return err
+	}
+	merged := map[string]string{}
+	for key, value := range item.Details {
+		merged[key] = value
+	}
+	for key, value := range details {
+		merged[key] = value
+	}
+	detailsJSON := "{}"
+	if b, err := json.Marshal(merged); err == nil {
+		detailsJSON = string(b)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE drift_items SET details = ?, updated_at = ? WHERE id = ?`,
+		detailsJSON, now, id,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return storage.ErrNotFound
+	}
+	return nil
+}
+
 // DeleteOpenForAccount removes all open drift items for an account.
 func (s *Store) DeleteOpenForAccount(ctx context.Context, accountID int64) error {
 	_, err := s.db.ExecContext(ctx,

--- a/migrations/postgres/0021_drift_items.up.sql
+++ b/migrations/postgres/0021_drift_items.up.sql
@@ -1,0 +1,27 @@
+-- CloudPAM PostgreSQL Drift Schema
+-- Migration 0021: drift detection results and network conflict resolution records
+
+CREATE TABLE IF NOT EXISTS drift_items (
+    id              TEXT PRIMARY KEY,
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    account_id      BIGINT NOT NULL REFERENCES accounts(seq_id) ON DELETE CASCADE,
+    resource_id     UUID,
+    pool_id         BIGINT REFERENCES pools(seq_id) ON DELETE SET NULL,
+    type            VARCHAR(50) NOT NULL CHECK (type IN ('unmanaged','cidr_mismatch','orphaned_pool','name_mismatch','account_drift')),
+    severity        VARCHAR(20) NOT NULL DEFAULT 'warning' CHECK (severity IN ('critical','warning','info')),
+    status          VARCHAR(20) NOT NULL DEFAULT 'open' CHECK (status IN ('open','resolved','ignored')),
+    title           TEXT NOT NULL,
+    description     TEXT NOT NULL DEFAULT '',
+    resource_cidr   TEXT NOT NULL DEFAULT '',
+    pool_cidr       TEXT NOT NULL DEFAULT '',
+    details         JSONB NOT NULL DEFAULT '{}',
+    ignore_reason   TEXT,
+    resolved_at     TIMESTAMPTZ,
+    detected_at     TIMESTAMPTZ NOT NULL,
+    updated_at      TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_drift_items_org_account ON drift_items(organization_id, account_id);
+CREATE INDEX IF NOT EXISTS idx_drift_items_status ON drift_items(status);
+CREATE INDEX IF NOT EXISTS idx_drift_items_type ON drift_items(type);
+CREATE INDEX IF NOT EXISTS idx_drift_items_severity ON drift_items(severity);

--- a/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
+++ b/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { NetworkConflictList } from '../pages/DiscoveryPage'
+import type { DiscoveryImportPreviewResponse, NetworkConflict, Pool } from '../api/types'
+
+const conflict: NetworkConflict = {
+  id: 'unlinked-exact-pool:00000000-0000-0000-0000-000000000001:42',
+  type: 'unlinked_exact_pool',
+  severity: 'warning',
+  status: 'open',
+  title: 'Discovered CIDR matches managed pool',
+  description: 'vpc-prod exactly matches prod-vpc',
+  recommended_action: 'Link the discovered resource to the matching managed pool.',
+  discovered_ids: ['00000000-0000-0000-0000-000000000001'],
+  pool_ids: [42],
+  account_ids: [7],
+  cidr: '10.0.0.0/16',
+  evidence: ['pool_id=42', 'pool_cidr=10.0.0.0/16'],
+  available_decisions: ['skip', 'ignore', 'defer'],
+}
+
+const pools: Pool[] = [
+  {
+    id: 42,
+    name: 'prod-vpc',
+    cidr: '10.0.0.0/16',
+    type: 'vpc',
+    status: 'active',
+    source: 'manual',
+    account_id: 7,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+const preview: DiscoveryImportPreviewResponse = {
+  items: [],
+  importable: 1,
+  blocked: 0,
+  linked_only: 0,
+  already_linked: 0,
+  conflict_count: 0,
+}
+
+function renderList(overrides: Partial<ComponentProps<typeof NetworkConflictList>> = {}) {
+  const props: ComponentProps<typeof NetworkConflictList> = {
+    conflicts: [conflict],
+    loading: false,
+    selected: conflict,
+    onSelect: vi.fn(),
+    onResolve: vi.fn(),
+    onLink: vi.fn(),
+    onImport: vi.fn(),
+    onPreviewImport: vi.fn().mockResolvedValue(preview),
+    pools,
+    ...overrides,
+  }
+  render(<NetworkConflictList {...props} />)
+  return props
+}
+
+describe('NetworkConflictList', () => {
+  it('keeps passive review decisions separate from mutating actions', () => {
+    const props = renderList()
+
+    fireEvent.click(screen.getByRole('button', { name: 'skip' }))
+    expect(props.onResolve).toHaveBeenCalledWith(conflict, 'skip')
+    expect(screen.getByText('Review')).toBeTruthy()
+    expect(screen.getByText('Actions')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Link to pool/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Import as pool/i })).toBeTruthy()
+  })
+
+  it('submits a link action with selected resource, pool, reason, and override', () => {
+    const props = renderList()
+
+    fireEvent.click(screen.getByRole('button', { name: /Link to pool/i }))
+    fireEvent.change(screen.getByPlaceholderText('Reason'), { target: { value: 'exact match reviewed' } })
+    fireEvent.click(screen.getByLabelText('Override validation'))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm link' }))
+
+    expect(props.onLink).toHaveBeenCalledWith(
+      conflict,
+      '00000000-0000-0000-0000-000000000001',
+      42,
+      'exact match reviewed',
+      true,
+    )
+  })
+
+  it('requires import preview before apply and submits selected resources', async () => {
+    const props = renderList()
+
+    fireEvent.click(screen.getByRole('button', { name: /Import as pool/i }))
+    expect((screen.getByRole('button', { name: 'Apply import' }) as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }))
+
+    await waitFor(() => {
+      expect(props.onPreviewImport).toHaveBeenCalledWith(
+        conflict,
+        ['00000000-0000-0000-0000-000000000001'],
+        undefined,
+      )
+      expect(screen.getByText('1 importable, 0 blocked, 0 conflicts')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply import' }))
+    expect(props.onImport).toHaveBeenCalledWith(
+      conflict,
+      ['00000000-0000-0000-0000-000000000001'],
+      undefined,
+      '',
+      false,
+    )
+  })
+})

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -588,6 +588,29 @@ export interface NetworkConflictListResponse {
   total: number
 }
 
+export interface NetworkConflictLinkActionRequest {
+  discovered_id: string
+  pool_id: number
+  reason?: string
+  override?: boolean
+}
+
+export interface NetworkConflictImportActionRequest {
+  resource_ids: string[]
+  pool_id?: number
+  reason?: string
+  override?: boolean
+}
+
+export interface NetworkConflictActionResponse {
+  conflict: NetworkConflict
+  action: 'link' | 'import'
+  resource_linked?: boolean
+  discovered_id?: string
+  pool_id?: number
+  import?: DiscoveryImportApplyResponse
+}
+
 // --- Recommendation types ---
 
 export type RecommendationType = 'allocation' | 'compliance'

--- a/ui/src/hooks/useDiscovery.ts
+++ b/ui/src/hooks/useDiscovery.ts
@@ -118,12 +118,13 @@ export function useSyncJobs() {
   }, [])
 
   const previewDiscoveryImport = useCallback(
-    async (accountId: number, resourceIds: string[]) => {
+    async (accountId: number, resourceIds: string[], poolId?: number) => {
       return post<DiscoveryImportPreviewResponse>(
         '/api/v1/discovery/import/preview',
         {
           account_id: accountId,
           resource_ids: resourceIds,
+          pool_id: poolId,
         },
       )
     },
@@ -131,12 +132,13 @@ export function useSyncJobs() {
   )
 
   const applyDiscoveryImport = useCallback(
-    async (accountId: number, resourceIds: string[]) => {
+    async (accountId: number, resourceIds: string[], poolId?: number) => {
       return post<DiscoveryImportApplyResponse>(
         '/api/v1/discovery/import/apply',
         {
           account_id: accountId,
           resource_ids: resourceIds,
+          pool_id: poolId,
         },
       )
     },

--- a/ui/src/hooks/useNetwork.ts
+++ b/ui/src/hooks/useNetwork.ts
@@ -2,6 +2,9 @@ import { useCallback, useState } from 'react'
 import { get, post } from '../api/client'
 import type {
   NetworkConflict,
+  NetworkConflictActionResponse,
+  NetworkConflictImportActionRequest,
+  NetworkConflictLinkActionRequest,
   NetworkConflictListResponse,
   NetworkViewResponse,
 } from '../api/types'
@@ -94,6 +97,26 @@ export function useNetworkView() {
     [],
   )
 
+  const linkConflict = useCallback(
+    async (id: string, req: NetworkConflictLinkActionRequest) => {
+      return post<NetworkConflictActionResponse>(
+        `/api/v1/network/conflicts/${encodeURIComponent(id)}/actions/link`,
+        req,
+      )
+    },
+    [],
+  )
+
+  const importConflict = useCallback(
+    async (id: string, req: NetworkConflictImportActionRequest) => {
+      return post<NetworkConflictActionResponse>(
+        `/api/v1/network/conflicts/${encodeURIComponent(id)}/actions/import`,
+        req,
+      )
+    },
+    [],
+  )
+
   return {
     flat,
     hierarchy,
@@ -104,5 +127,7 @@ export function useNetworkView() {
     fetchHierarchy,
     fetchConflicts,
     resolveConflict,
+    linkConflict,
+    importConflict,
   }
 }

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -578,7 +578,7 @@ export default function DiscoveryPage() {
       )}
 
       {tab === 'network' && (
-        <NetworkTab selectedAccountId={selectedAccountId} accounts={accounts} />
+        <NetworkTab selectedAccountId={selectedAccountId} accounts={accounts} pools={pools} />
       )}
 
       {tab === 'sync' && (
@@ -643,9 +643,11 @@ type NetworkMode = 'hierarchy' | 'flat' | 'conflicts'
 function NetworkTab({
   selectedAccountId,
   accounts,
+  pools,
 }: {
   selectedAccountId: number | null
   accounts: Account[]
+  pools: Pool[]
 }) {
   const [mode, setMode] = useState<NetworkMode>('hierarchy')
   const [query, setQuery] = useState('')
@@ -662,7 +664,10 @@ function NetworkTab({
     fetchHierarchy,
     fetchConflicts,
     resolveConflict,
+    linkConflict,
+    importConflict,
   } = useNetworkView()
+  const { previewDiscoveryImport: previewNetworkImport } = useSyncJobs()
   const { showToast } = useToast()
 
   const filters = useMemo(() => ({
@@ -695,6 +700,46 @@ function NetworkTab({
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Resolve failed', 'error')
     }
+  }
+
+  async function handleLinkAction(conflict: NetworkConflict, discoveredId: string, poolId: number, reason: string, override: boolean) {
+    try {
+      const resp = await linkConflict(conflict.id, {
+        discovered_id: discoveredId,
+        pool_id: poolId,
+        reason: reason || undefined,
+        override,
+      })
+      showToast('Resource linked to pool', 'success')
+      setSelectedConflict(resp.conflict)
+      load()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Link action failed', 'error')
+    }
+  }
+
+  async function handleImportAction(conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined, reason: string, override: boolean) {
+    try {
+      const resp = await importConflict(conflict.id, {
+        resource_ids: resourceIds,
+        pool_id: poolId,
+        reason: reason || undefined,
+        override,
+      })
+      showToast(`Imported ${resp.import?.pools_created ?? 0} pools and linked ${resp.import?.resources_linked ?? 0} resources`, 'success')
+      setSelectedConflict(resp.conflict)
+      load()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Import action failed', 'error')
+    }
+  }
+
+  async function handlePreviewImportAction(conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined) {
+    const accountId = conflict.account_ids?.[0] ?? selectedAccountId
+    if (!accountId) {
+      throw new Error('Conflict account is required for import preview')
+    }
+    return previewNetworkImport(accountId, resourceIds, poolId)
   }
 
   const activeItems = mode === 'hierarchy' ? hierarchy?.items : flat?.items
@@ -774,6 +819,10 @@ function NetworkTab({
           selected={selectedConflict}
           onSelect={setSelectedConflict}
           onResolve={handleResolve}
+          onLink={handleLinkAction}
+          onImport={handleImportAction}
+          onPreviewImport={handlePreviewImportAction}
+          pools={pools}
         />
       ) : mode === 'flat' ? (
         <NetworkFlatTable nodes={activeItems ?? []} loading={loading} />
@@ -904,20 +953,73 @@ function NetworkFlatTable({ nodes, loading }: { nodes: NetworkNode[]; loading: b
   )
 }
 
-function NetworkConflictList({
+export function NetworkConflictList({
   conflicts,
   loading,
   selected,
   onSelect,
   onResolve,
+  onLink,
+  onImport,
+  onPreviewImport,
+  pools,
 }: {
   conflicts: NetworkConflict[]
   loading: boolean
   selected: NetworkConflict | null
   onSelect: (conflict: NetworkConflict | null) => void
   onResolve: (conflict: NetworkConflict, decision: string) => void
+  onLink: (conflict: NetworkConflict, discoveredId: string, poolId: number, reason: string, override: boolean) => void
+  onImport: (conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined, reason: string, override: boolean) => void
+  onPreviewImport: (conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined) => Promise<DiscoveryImportPreviewResponse>
+  pools: Pool[]
 }) {
+  const [actionMode, setActionMode] = useState<'link' | 'import' | null>(null)
+  const [linkDiscoveredID, setLinkDiscoveredID] = useState('')
+  const [linkPoolID, setLinkPoolID] = useState('')
+  const [importResourceIDs, setImportResourceIDs] = useState<string[]>([])
+  const [importPoolID, setImportPoolID] = useState('')
+  const [reason, setReason] = useState('')
+  const [override, setOverride] = useState(false)
+  const [preview, setPreview] = useState<DiscoveryImportPreviewResponse | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setActionMode(null)
+    setReason('')
+    setOverride(false)
+    setPreview(null)
+    setActionError(null)
+    setLinkDiscoveredID(selected?.discovered_ids?.[0] ?? '')
+    setLinkPoolID(selected?.pool_ids?.[0] ? String(selected.pool_ids[0]) : '')
+    setImportResourceIDs(selected?.discovered_ids ?? [])
+    setImportPoolID('')
+  }, [selected?.id])
+
   if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
+  const poolOptions = pools.filter((pool) => !selected?.pool_ids?.length || selected.pool_ids.includes(pool.id))
+  const allPoolOptions = poolOptions.length > 0 ? poolOptions : pools
+
+  async function previewImport() {
+    if (!selected) return
+    setPreviewLoading(true)
+    setActionError(null)
+    try {
+      const next = await onPreviewImport(
+        selected,
+        importResourceIDs,
+        importPoolID ? Number(importPoolID) : undefined,
+      )
+      setPreview(next)
+    } catch (err) {
+      setPreview(null)
+      setActionError(err instanceof Error ? err.message : 'Import preview failed')
+    } finally {
+      setPreviewLoading(false)
+    }
+  }
+
   return (
     <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
       <div className="overflow-hidden rounded border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
@@ -955,17 +1057,142 @@ function NetworkConflictList({
                 <div key={line}>{line}</div>
               ))}
             </div>
-            <div className="flex flex-wrap gap-2">
-              {(selected.available_decisions ?? ['skip', 'ignore', 'defer']).map((decision) => (
+            <div className="border-t border-gray-100 pt-3 dark:border-gray-700">
+              <div className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">Review</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {(selected.available_decisions ?? ['skip', 'ignore', 'defer']).map((decision) => (
+                  <button
+                    key={decision}
+                    type="button"
+                    onClick={() => onResolve(selected, decision)}
+                    className="rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    {decision}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="border-t border-gray-100 pt-3 dark:border-gray-700">
+              <div className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">Actions</div>
+              <div className="mt-2 flex flex-wrap gap-2">
                 <button
-                  key={decision}
                   type="button"
-                  onClick={() => onResolve(selected, decision)}
-                  className="rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                  onClick={() => setActionMode(actionMode === 'link' ? null : 'link')}
+                  className="inline-flex items-center gap-1 rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
                 >
-                  {decision}
+                  <Link2 className="h-3.5 w-3.5" />
+                  Link to pool
                 </button>
-              ))}
+                <button
+                  type="button"
+                  onClick={() => setActionMode(actionMode === 'import' ? null : 'import')}
+                  className="inline-flex items-center gap-1 rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  <UploadCloud className="h-3.5 w-3.5" />
+                  Import as pool
+                </button>
+              </div>
+              {actionError && <div className="mt-2 text-xs text-red-600 dark:text-red-400">{actionError}</div>}
+              {actionMode === 'link' && (
+                <div className="mt-3 space-y-2">
+                  <select
+                    value={linkDiscoveredID}
+                    onChange={(e) => setLinkDiscoveredID(e.target.value)}
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                  >
+                    {(selected.discovered_ids ?? []).map((id) => <option key={id} value={id}>{id}</option>)}
+                  </select>
+                  <select
+                    value={linkPoolID}
+                    onChange={(e) => setLinkPoolID(e.target.value)}
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                  >
+                    <option value="">Select pool</option>
+                    {allPoolOptions.map((pool) => <option key={pool.id} value={pool.id}>{pool.name} ({pool.cidr})</option>)}
+                  </select>
+                  <input
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    placeholder="Reason"
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                  />
+                  <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+                    <input type="checkbox" checked={override} onChange={(e) => setOverride(e.target.checked)} />
+                    Override validation
+                  </label>
+                  <button
+                    type="button"
+                    disabled={!linkDiscoveredID || !linkPoolID}
+                    onClick={() => selected && onLink(selected, linkDiscoveredID, Number(linkPoolID), reason, override)}
+                    className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Confirm link
+                  </button>
+                </div>
+              )}
+              {actionMode === 'import' && (
+                <div className="mt-3 space-y-2">
+                  <div className="space-y-1">
+                    {(selected.discovered_ids ?? []).map((id) => (
+                      <label key={id} className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+                        <input
+                          type="checkbox"
+                          checked={importResourceIDs.includes(id)}
+                          onChange={(e) => {
+                            setPreview(null)
+                            setImportResourceIDs((current) => e.target.checked ? [...current, id] : current.filter((value) => value !== id))
+                          }}
+                        />
+                        <span className="font-mono">{id}</span>
+                      </label>
+                    ))}
+                  </div>
+                  <select
+                    value={importPoolID}
+                    onChange={(e) => {
+                      setPreview(null)
+                      setImportPoolID(e.target.value)
+                    }}
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                  >
+                    <option value="">No parent pool</option>
+                    {pools.map((pool) => <option key={pool.id} value={pool.id}>{pool.name} ({pool.cidr})</option>)}
+                  </select>
+                  <input
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    placeholder="Reason"
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                  />
+                  <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+                    <input type="checkbox" checked={override} onChange={(e) => setOverride(e.target.checked)} />
+                    Override conflict rows
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      disabled={importResourceIDs.length === 0 || previewLoading}
+                      onClick={() => void previewImport()}
+                      className="rounded border border-gray-300 px-3 py-1 text-xs text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      {previewLoading ? 'Previewing...' : 'Preview'}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={importResourceIDs.length === 0 || !preview}
+                      onClick={() => selected && onImport(selected, importResourceIDs, importPoolID ? Number(importPoolID) : undefined, reason, override)}
+                      className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Apply import
+                    </button>
+                  </div>
+                  {preview && (
+                    <div className="rounded bg-gray-50 p-2 text-xs text-gray-600 dark:bg-gray-900/40 dark:text-gray-300">
+                      {preview.importable} importable, {preview.blocked} blocked, {preview.conflict_count} conflicts
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         ) : (

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -783,6 +783,7 @@ function NetworkTab({
           >
             <option value="">All issues</option>
             <option value="missing_parent">Missing parent</option>
+            <option value="unlinked_exact_pool">Exact pool match</option>
             <option value="invalid_nesting">Invalid nesting</option>
             <option value="outside_pool">Outside pool</option>
             <option value="duplicate_cidr">Duplicate CIDR</option>


### PR DESCRIPTION
## Summary

Closes #200.

This PR separates passive network conflict review decisions from topology-mutating remediation actions. `/resolve` remains review-only for `skip`, `ignore`, and `defer`; real `link` and `import` behavior now lives behind explicit action endpoints that validate the current computed conflict, mutate topology, and then persist resolution metadata.

## Backend

- Adds `POST /api/v1/network/conflicts/{id}/actions/link`.
- Adds `POST /api/v1/network/conflicts/{id}/actions/import`.
- Keeps `POST /api/v1/network/conflicts/{id}/resolve` passive-only.
- Adds network conflict action request/response domain types.
- Adds `unlinked_exact_pool` conflicts so exact discovered CIDR/managed pool matches are visible and linkable.
- Refactors discovery import apply into a reusable internal method used by both the existing discovery import endpoint and the new conflict import action.
- Tracks created pool IDs and linked resource IDs in discovery import apply responses for action metadata and rollback.
- Adds `UpdateDriftDetails` to drift stores so structured action metadata is merged into existing drift records.

## Validation and Safety

Link actions validate that:

- `discovered_id` and `pool_id` exist.
- resource and pool are part of the conflict unless `override=true`.
- the resource is not already linked unless `override=true`.
- account and CIDR relationships are safe unless `override=true`.

Import actions validate that:

- selected resources are non-empty.
- selected resources belong to the conflict unless `override=true`.
- all selected rows are importable unless `override=true`.
- override imports still require VPC/subnet rows with parseable CIDR data.
- conflicts are marked resolved only after at least one resource is created or linked.

Action persistence is hardened by preparing an open conflict/drift record before mutation and only marking it resolved after mutation succeeds. If final resolution persistence fails after mutation, the handler attempts compensation:

- link rollback restores the previous discovered-resource pool link.
- import rollback unlinks affected discovered resources and deletes newly created pools in reverse order.

## UI

- Separates conflict side-panel controls into `Review` and `Actions` sections.
- Review buttons remain `skip`, `ignore`, and `defer`.
- Adds explicit `Link to pool` and `Import as pool` action flows.
- Link action requires selected resource, selected pool, optional reason, and optional override.
- Import action requires selected resources and a preview before apply.
- Updates network and discovery hooks/types for the new action APIs and optional import parent pool selection.

## Tests

Added/updated backend coverage for:

- `/resolve` rejecting mutating decisions.
- exact discovered CIDR/managed pool conflicts exposed as `unlinked_exact_pool`.
- successful `/actions/link` behavior.
- link action rejection for unrelated resources, unrelated pools, and unsafe account/CIDR relationships.
- successful `/actions/import` behavior with override for a missing-parent subnet.
- import action rejection for non-override blocked rows and unrelated resources.
- rollback when final link resolution persistence fails.
- merging structured action metadata into existing drift items.

Added frontend interaction coverage for:

- passive review controls remaining separate from mutating actions.
- link action form submission payload.
- import action requiring preview before apply.

## Verification

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop -c go test ./...`
- `npm test` from `ui/`
- `npm run build` from `ui/`

## Notes

The pipeline handoff files were written under `.pipeline/` during implementation, but that directory is intentionally ignored by the repository and is not included in this PR.
