### PR TITLE
Fix Discovery bulk resource linking

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.16.2] - 2026-06-02
+
+### Fixed
+- Cloud Discovery resource checkboxes now allow selecting multiple unlinked resources, including stale discoveries, and linking the selected resources to a chosen pool in one action.
+
 ## [0.16.1] - 2026-06-02
 
 ### Fixed

--- a/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
+++ b/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useState, type ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { DiscoveredResource, Pool } from '../api/types'
+import { ResourcesTab } from '../pages/DiscoveryPage'
+
+const resources: DiscoveredResource[] = [
+  {
+    id: 'resource-active-vpc',
+    account_id: 1,
+    provider: 'aws',
+    region: 'us-west-2',
+    resource_type: 'vpc',
+    resource_id: 'vpc-001',
+    name: 'prod-vpc',
+    cidr: '10.0.0.0/16',
+    pool_id: null,
+    status: 'active',
+    discovered_at: '2026-01-01T00:00:00Z',
+    last_seen_at: '2026-01-02T00:00:00Z',
+  },
+  {
+    id: 'resource-stale-subnet',
+    account_id: 1,
+    provider: 'aws',
+    region: 'us-west-2',
+    resource_type: 'subnet',
+    resource_id: 'subnet-001',
+    name: 'stale-subnet',
+    cidr: '10.0.1.0/24',
+    pool_id: null,
+    status: 'stale',
+    discovered_at: '2026-01-01T00:00:00Z',
+    last_seen_at: '2026-01-02T00:00:00Z',
+  },
+  {
+    id: 'resource-linked-vpc',
+    account_id: 1,
+    provider: 'aws',
+    region: 'us-west-2',
+    resource_type: 'vpc',
+    resource_id: 'vpc-linked',
+    name: 'linked-vpc',
+    cidr: '10.1.0.0/16',
+    pool_id: 7,
+    status: 'active',
+    discovered_at: '2026-01-01T00:00:00Z',
+    last_seen_at: '2026-01-02T00:00:00Z',
+  },
+]
+
+const pools: Pool[] = [
+  {
+    id: 42,
+    name: 'prod pool',
+    cidr: '10.0.0.0/8',
+    type: 'supernet',
+    status: 'active',
+    source: 'manual',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 7,
+    name: 'linked pool',
+    cidr: '10.1.0.0/16',
+    type: 'vpc',
+    status: 'active',
+    source: 'manual',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+function renderResourcesTab(overrides: Partial<ComponentProps<typeof ResourcesTab>> = {}) {
+  const onBulkLink = vi.fn()
+
+  function Wrapper() {
+    const [selectedResourceIds, setSelectedResourceIds] = useState<string[]>([])
+    const toggleSelection = (resource: DiscoveredResource) => {
+      if (resource.pool_id) return
+      setSelectedResourceIds((current) =>
+        current.includes(resource.id)
+          ? current.filter((id) => id !== resource.id)
+          : [...current, resource.id],
+      )
+    }
+
+    const props: ComponentProps<typeof ResourcesTab> = {
+      resources,
+      loading: false,
+      error: null,
+      searchQuery: '',
+      onSearchChange: vi.fn(),
+      statusFilter: '',
+      onStatusChange: vi.fn(),
+      typeFilter: '',
+      onTypeChange: vi.fn(),
+      linkedFilter: '',
+      onLinkedChange: vi.fn(),
+      onLink: vi.fn(),
+      onUnlink: vi.fn(),
+      pools,
+      selectedResourceIds,
+      onToggleSelection: toggleSelection,
+      onSelectVisible: (visibleResources) => {
+        setSelectedResourceIds(
+          visibleResources
+            .filter((resource) => !resource.pool_id)
+            .map((resource) => resource.id),
+        )
+      },
+      onClearSelection: () => setSelectedResourceIds([]),
+      onBulkLink,
+      ...overrides,
+    }
+
+    return <ResourcesTab {...props} />
+  }
+
+  render(<Wrapper />)
+  return { onBulkLink }
+}
+
+describe('ResourcesTab', () => {
+  it('selects multiple unlinked resources and links them to a pool', () => {
+    const { onBulkLink } = renderResourcesTab()
+
+    const activeCheckbox = screen.getAllByLabelText('Select prod-vpc')[0] as HTMLInputElement
+    const staleCheckbox = screen.getAllByLabelText('Select stale-subnet')[0] as HTMLInputElement
+    const linkedCheckbox = screen.getAllByLabelText('Select linked-vpc')[0] as HTMLInputElement
+
+    expect(activeCheckbox.disabled).toBe(false)
+    expect(staleCheckbox.disabled).toBe(false)
+    expect(linkedCheckbox.disabled).toBe(true)
+
+    fireEvent.click(activeCheckbox)
+    fireEvent.click(staleCheckbox)
+
+    expect(screen.getByText('2 selected')).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('Pool for selected resources'), { target: { value: '42' } })
+    fireEvent.click(screen.getByRole('button', { name: /Link selected/i }))
+
+    expect(onBulkLink).toHaveBeenCalledWith(['resource-active-vpc', 'resource-stale-subnet'], 42)
+  })
+})

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -104,6 +104,7 @@ export default function DiscoveryPage() {
   const [trackedScanJobs, setTrackedScanJobs] = useState<SyncJob[]>([])
   const [linkingResource, setLinkingResource] = useState<DiscoveredResource | null>(null)
   const [linkingLoading, setLinkingLoading] = useState(false)
+  const [bulkLinkingLoading, setBulkLinkingLoading] = useState(false)
 
   useEffect(() => {
     fetchAccounts()
@@ -353,6 +354,36 @@ export default function DiscoveryPage() {
     }
   }
 
+  async function handleBulkLink(resourceIds: string[], poolId: number) {
+    const linkableResourceIds = resourceIds.filter((id) => {
+      const resource = resourcesData?.items.find((item) => item.id === id)
+      return resource && isSelectableDiscoveryResource(resource)
+    })
+    if (linkableResourceIds.length === 0) {
+      showToast('Select discovered resources to link', 'error')
+      return
+    }
+    setBulkLinkingLoading(true)
+    try {
+      const results = await Promise.allSettled(linkableResourceIds.map((id) => linkToPool(id, poolId)))
+      const linkedIDs = linkableResourceIds.filter((_, index) => results[index].status === 'fulfilled')
+      const failed = results.length - linkedIDs.length
+      if (linkedIDs.length > 0) {
+        showToast(
+          `Linked ${linkedIDs.length} resource${linkedIDs.length === 1 ? '' : 's'} to pool`,
+          failed > 0 ? 'info' : 'success',
+        )
+        setSelectedResourceIds((current) => current.filter((id) => !linkedIDs.includes(id)))
+        loadResources()
+      }
+      if (failed > 0) {
+        showToast(`${failed} resource${failed === 1 ? '' : 's'} failed to link`, 'error')
+      }
+    } finally {
+      setBulkLinkingLoading(false)
+    }
+  }
+
   async function handleCreateAndLink(resource: DiscoveredResource, data: CreatePoolRequest) {
     setLinkingLoading(true)
     try {
@@ -574,6 +605,8 @@ export default function DiscoveryPage() {
           onToggleSelection={toggleResourceSelection}
           onSelectVisible={selectVisibleImportableResources}
           onClearSelection={() => setSelectedResourceIds([])}
+          onBulkLink={handleBulkLink}
+          bulkLinking={bulkLinkingLoading}
         />
       )}
 
@@ -635,7 +668,7 @@ export default function DiscoveryPage() {
 }
 
 function isSelectableDiscoveryResource(resource: DiscoveredResource) {
-  return resource.status === 'active' && !resource.pool_id
+  return !resource.pool_id
 }
 
 type NetworkMode = 'hierarchy' | 'flat' | 'conflicts'
@@ -1222,7 +1255,7 @@ function NetworkIssueBadges({ issues }: { issues: NetworkIssue[] }) {
   )
 }
 
-function ResourcesTab({
+export function ResourcesTab({
   resources,
   loading,
   error,
@@ -1241,6 +1274,8 @@ function ResourcesTab({
   onToggleSelection,
   onSelectVisible,
   onClearSelection,
+  onBulkLink,
+  bulkLinking = false,
 }: {
   resources: DiscoveredResource[]
   loading: boolean
@@ -1260,8 +1295,12 @@ function ResourcesTab({
   onToggleSelection: (r: DiscoveredResource) => void
   onSelectVisible: (resources: DiscoveredResource[]) => void
   onClearSelection: () => void
+  onBulkLink: (resourceIds: string[], poolId: number) => void
+  bulkLinking?: boolean
 }) {
   const selectableCount = resources.filter(isSelectableDiscoveryResource).length
+  const [bulkLinkPoolId, setBulkLinkPoolId] = useState('')
+  const bulkLinkPool = Number(bulkLinkPoolId)
 
   return (
     <>
@@ -1327,6 +1366,31 @@ function ResourcesTab({
           <span className="text-gray-500 dark:text-gray-400">
             {selectedResourceIds.length} selected
           </span>
+        </div>
+        <div className="flex min-w-[280px] flex-wrap items-center gap-2 text-sm">
+          <select
+            value={bulkLinkPoolId}
+            onChange={(e) => setBulkLinkPoolId(e.target.value)}
+            disabled={pools.length === 0}
+            aria-label="Pool for selected resources"
+            className="min-w-[190px] rounded border border-gray-300 bg-white px-3 py-1.5 text-gray-900 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+          >
+            <option value="">Select pool</option>
+            {pools.map((pool) => (
+              <option key={pool.id} value={pool.id}>
+                {pool.name} ({pool.cidr})
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => bulkLinkPool > 0 && onBulkLink(selectedResourceIds, bulkLinkPool)}
+            disabled={bulkLinking || selectedResourceIds.length === 0 || bulkLinkPool <= 0}
+            className="inline-flex items-center gap-1.5 rounded bg-blue-600 px-3 py-1.5 text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {bulkLinking ? <Loader2 className="h-4 w-4 animate-spin" /> : <Link2 className="h-4 w-4" />}
+            Link selected
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- bump CloudPAM changelog to 0.16.2 for the Discovery selection fix
- allow Cloud Discovery checkboxes to select any unlinked resource, including stale discoveries
- add a bulk pool selector and Link selected action for selected discovered resources
- add a ResourcesTab regression test for multi-select, disabled linked rows, and bulk link callback args

## Verification
- npm test -- DiscoveryResourcesTab.test.tsx changelog.test.ts
- npm test
- npm run build
- git diff --check