### PR TITLE
UI: improve discovery resource table controls

### DIFF
--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -120,6 +120,7 @@ func (d *DiscoveryServer) handleResources(w http.ResponseWriter, r *http.Request
 		Region:       q.Get("region"),
 		ResourceType: q.Get("resource_type"),
 		Status:       q.Get("status"),
+		Query:        q.Get("q"),
 		Page:         page,
 		PageSize:     pageSize,
 	}
@@ -206,14 +207,28 @@ func (d *DiscoveryServer) handleLink(w http.ResponseWriter, r *http.Request, id 
 			return
 		}
 
-		// Verify pool exists
-		_, found, err := d.srv.store.GetPool(r.Context(), body.PoolID)
+		// Verify resource and pool exist, and do not cross account boundaries.
+		resource, err := d.store.GetDiscoveredResource(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				d.srv.writeErr(r.Context(), w, http.StatusNotFound, "resource not found", "")
+				return
+			}
+			d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "resource lookup failed", err.Error())
+			return
+		}
+
+		pool, found, err := d.srv.store.GetPool(r.Context(), body.PoolID)
 		if err != nil {
 			d.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "pool lookup failed", err.Error())
 			return
 		}
 		if !found {
 			d.srv.writeErr(r.Context(), w, http.StatusNotFound, "pool not found", "")
+			return
+		}
+		if pool.AccountID != nil && *pool.AccountID != resource.AccountID {
+			d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "pool account does not match discovered resource account", "")
 			return
 		}
 

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -474,7 +474,8 @@ func TestDiscoveryResourcesSearchAcrossPages(t *testing.T) {
 		})
 	}
 
-	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/discovery/resources?account_id=1&page=1&page_size=10&q=needle", "", http.StatusOK)
+	path := fmt.Sprintf("/api/v1/discovery/resources?account_id=%d&page=1&page_size=10&q=needle", account.ID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, path, "", http.StatusOK)
 	var resp domain.DiscoveryResourcesResponse
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal response: %v", err)

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -400,6 +400,93 @@ func TestDiscoveryImportPreviewAndApplyRejectInvalidSelectedPool(t *testing.T) {
 	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/apply", accountMismatchBody, http.StatusBadRequest)
 }
 
+func TestDiscoveryResourceLinkRejectsCrossAccountPool(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	otherAccount, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:222222222222", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create other account: %v", err)
+	}
+	otherPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "dev", CIDR: "10.40.0.0/16", Type: domain.PoolTypeVPC, AccountID: &otherAccount.ID})
+	if err != nil {
+		t.Fatalf("create other pool: %v", err)
+	}
+
+	resourceID := uuid.New()
+	now := time.Now().UTC()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           resourceID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-prod",
+		Name:         "prod-vpc",
+		CIDR:         "10.40.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+
+	body := fmt.Sprintf("{\"pool_id\":%d}", otherPool.ID)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/resources/"+resourceID.String()+"/link", body, http.StatusBadRequest)
+
+	resource, err := ds.GetDiscoveredResource(t.Context(), resourceID)
+	if err != nil {
+		t.Fatalf("get resource: %v", err)
+	}
+	if resource.PoolID != nil {
+		t.Fatalf("resource linked to cross-account pool: %v", *resource.PoolID)
+	}
+}
+
+func TestDiscoveryResourcesSearchAcrossPages(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	now := time.Now().UTC()
+	for i := 0; i < 30; i++ {
+		name := fmt.Sprintf("ordinary-%02d", i)
+		resourceID := fmt.Sprintf("subnet-%02d", i)
+		cidr := fmt.Sprintf("10.41.%d.0/24", i)
+		if i == 29 {
+			name = "needle-subnet"
+			resourceID = "subnet-needle"
+			cidr = "10.42.99.0/24"
+		}
+		upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+			ID:           uuid.New(),
+			AccountID:    account.ID,
+			Provider:     "aws",
+			Region:       "us-east-1",
+			ResourceType: domain.ResourceTypeSubnet,
+			ResourceID:   resourceID,
+			Name:         name,
+			CIDR:         cidr,
+			Status:       domain.DiscoveryStatusActive,
+			DiscoveredAt: now.Add(time.Duration(i) * time.Minute),
+			LastSeenAt:   now.Add(time.Duration(i) * time.Minute),
+		})
+	}
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/discovery/resources?account_id=1&page=1&page_size=10&q=needle", "", http.StatusOK)
+	var resp domain.DiscoveryResourcesResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Total != 1 || len(resp.Items) != 1 {
+		t.Fatalf("search response = total %d len %d, want one result: %+v", resp.Total, len(resp.Items), resp.Items)
+	}
+	if resp.Items[0].ResourceID != "subnet-needle" {
+		t.Fatalf("resource_id = %s, want subnet-needle", resp.Items[0].ResourceID)
+	}
+}
+
 func TestDiscoveryImportApplyDeletesCreatedPoolWhenLinkFails(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -1125,6 +1125,7 @@ func discoveryResourceQueryParams() []openAPIParameter {
 		queryParam("region", "Cloud region", "string"),
 		queryParam("resource_type", "Resource type", "string"),
 		queryParam("status", "Discovery status", "string"),
+		queryParam("q", "Search by name, resource ID, or CIDR", "string"),
 		queryParam("linked", "Filter linked/unlinked resources", "boolean"),
 		queryParam("page", "Page number", "integer"),
 		queryParam("page_size", "Page size", "integer"),

--- a/internal/domain/discovery.go
+++ b/internal/domain/discovery.go
@@ -111,6 +111,7 @@ type DiscoveryFilters struct {
 	Region       string
 	ResourceType string
 	Status       string
+	Query        string
 	HasPool      *bool // nil = any, true = linked, false = unlinked
 	Page         int
 	PageSize     int

--- a/internal/storage/discovery_memory.go
+++ b/internal/storage/discovery_memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -49,6 +50,14 @@ func (m *MemoryDiscoveryStore) ListDiscoveredResources(_ context.Context, accoun
 		}
 		if filters.Status != "" && string(r.Status) != filters.Status {
 			continue
+		}
+		if filters.Query != "" {
+			q := strings.ToLower(filters.Query)
+			if !strings.Contains(strings.ToLower(r.Name), q) &&
+				!strings.Contains(strings.ToLower(r.ResourceID), q) &&
+				!strings.Contains(strings.ToLower(r.CIDR), q) {
+				continue
+			}
 		}
 		if filters.HasPool != nil {
 			linked := r.PoolID != nil

--- a/internal/storage/postgres/discovery.go
+++ b/internal/storage/postgres/discovery.go
@@ -39,6 +39,10 @@ func (s *Store) ListDiscoveredResources(ctx context.Context, accountID int64, fi
 	if filters.Status != "" {
 		where = append(where, "status = "+addArg(filters.Status))
 	}
+	if filters.Query != "" {
+		q := "%" + strings.ToLower(filters.Query) + "%"
+		where = append(where, fmt.Sprintf("(LOWER(name) LIKE %s OR LOWER(resource_id) LIKE %s OR LOWER(cidr) LIKE %s)", addArg(q), addArg(q), addArg(q)))
+	}
 	if filters.HasPool != nil {
 		if *filters.HasPool {
 			where = append(where, "pool_id IS NOT NULL")

--- a/internal/storage/sqlite/discovery.go
+++ b/internal/storage/sqlite/discovery.go
@@ -37,6 +37,11 @@ func (s *Store) ListDiscoveredResources(ctx context.Context, accountID int64, fi
 		where = append(where, "status = ?")
 		args = append(args, filters.Status)
 	}
+	if filters.Query != "" {
+		where = append(where, "(LOWER(name) LIKE ? OR LOWER(resource_id) LIKE ? OR LOWER(cidr) LIKE ?)")
+		q := "%" + strings.ToLower(filters.Query) + "%"
+		args = append(args, q, q, q)
+	}
 	if filters.HasPool != nil {
 		if *filters.HasPool {
 			where = append(where, "pool_id IS NOT NULL")

--- a/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
+++ b/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { useState, type ComponentProps } from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import type { DiscoveredResource, Pool } from '../api/types'
+import type { Account, DiscoveredResource, Pool } from '../api/types'
 import { ResourcesTab } from '../pages/DiscoveryPage'
 
 const resources: DiscoveredResource[] = [
@@ -72,8 +72,21 @@ const pools: Pool[] = [
   },
 ]
 
+const accounts: Account[] = [
+  {
+    id: 1,
+    key: 'aws:123456789012',
+    name: 'Production AWS',
+    provider: 'aws',
+    external_id: '123456789012',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+]
+
 function renderResourcesTab(overrides: Partial<ComponentProps<typeof ResourcesTab>> = {}) {
   const onBulkLink = vi.fn()
+  const onPageChange = vi.fn()
+  const onPageSizeChange = vi.fn()
 
   function Wrapper() {
     const [selectedResourceIds, setSelectedResourceIds] = useState<string[]>([])
@@ -100,18 +113,28 @@ function renderResourcesTab(overrides: Partial<ComponentProps<typeof ResourcesTa
       onLinkedChange: vi.fn(),
       onLink: vi.fn(),
       onUnlink: vi.fn(),
+      accounts,
       pools,
       selectedResourceIds,
       onToggleSelection: toggleSelection,
-      onSelectVisible: (visibleResources) => {
-        setSelectedResourceIds(
-          visibleResources
-            .filter((resource) => !resource.pool_id)
-            .map((resource) => resource.id),
-        )
+      onSetVisibleSelection: (visibleResources, selected) => {
+        const visibleIDs = visibleResources
+          .filter((resource) => !resource.pool_id)
+          .map((resource) => resource.id)
+        setSelectedResourceIds((current) => {
+          if (selected) {
+            return Array.from(new Set([...current, ...visibleIDs]))
+          }
+          return current.filter((id) => !visibleIDs.includes(id))
+        })
       },
       onClearSelection: () => setSelectedResourceIds([]),
       onBulkLink,
+      total: resources.length,
+      page: 1,
+      pageSize: 25,
+      onPageChange,
+      onPageSizeChange,
       ...overrides,
     }
 
@@ -119,7 +142,7 @@ function renderResourcesTab(overrides: Partial<ComponentProps<typeof ResourcesTa
   }
 
   render(<Wrapper />)
-  return { onBulkLink }
+  return { onBulkLink, onPageChange, onPageSizeChange }
 }
 
 describe('ResourcesTab', () => {
@@ -143,5 +166,50 @@ describe('ResourcesTab', () => {
     fireEvent.click(screen.getByRole('button', { name: /Link selected/i }))
 
     expect(onBulkLink).toHaveBeenCalledWith(['resource-active-vpc', 'resource-stale-subnet'], 42)
+  })
+
+  it('selects and clears all visible unlinked resources from the header checkbox', () => {
+    renderResourcesTab()
+
+    fireEvent.click(screen.getByLabelText('Select all visible resources'))
+
+    expect(screen.getByText('2 selected')).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText('Select all visible resources'))
+
+    expect(screen.getByText('0 selected')).toBeTruthy()
+  })
+
+  it('shows account context and toggles configurable columns', () => {
+    renderResourcesTab()
+
+    expect(screen.getAllByText('Production AWS').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('123456789012').length).toBeGreaterThan(0)
+    expect(screen.queryAllByRole('columnheader', { name: 'Account / Project' }).length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByRole('button', { name: /Columns/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Account / Project' }))
+
+    expect(screen.queryAllByRole('columnheader', { name: 'Account / Project' })).toHaveLength(0)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Account / Project' }))
+
+    expect(screen.queryAllByRole('columnheader', { name: 'Account / Project' }).length).toBeGreaterThan(0)
+  })
+
+  it('calls pagination handlers for page and page-size changes', () => {
+    const { onPageChange, onPageSizeChange } = renderResourcesTab({
+      total: 80,
+      page: 2,
+      pageSize: 25,
+    })
+
+    expect(screen.getByText('Showing 26-50 of 80')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.change(screen.getByLabelText('Rows per page'), { target: { value: '100' } })
+
+    expect(onPageChange).toHaveBeenCalledWith(3)
+    expect(onPageSizeChange).toHaveBeenCalledWith(100)
   })
 })

--- a/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
+++ b/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
@@ -54,6 +54,7 @@ const pools: Pool[] = [
     id: 42,
     name: 'prod pool',
     cidr: '10.0.0.0/8',
+    account_id: 1,
     type: 'supernet',
     status: 'active',
     source: 'manual',
@@ -64,6 +65,18 @@ const pools: Pool[] = [
     id: 7,
     name: 'linked pool',
     cidr: '10.1.0.0/16',
+    account_id: 1,
+    type: 'vpc',
+    status: 'active',
+    source: 'manual',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 99,
+    name: 'dev pool',
+    cidr: '10.99.0.0/16',
+    account_id: 2,
     type: 'vpc',
     status: 'active',
     source: 'manual',
@@ -114,6 +127,7 @@ function renderResourcesTab(overrides: Partial<ComponentProps<typeof ResourcesTa
       onLink: vi.fn(),
       onUnlink: vi.fn(),
       accounts,
+      selectedAccountId: 1,
       pools,
       selectedResourceIds,
       onToggleSelection: toggleSelection,
@@ -166,6 +180,15 @@ describe('ResourcesTab', () => {
     fireEvent.click(screen.getByRole('button', { name: /Link selected/i }))
 
     expect(onBulkLink).toHaveBeenCalledWith(['resource-active-vpc', 'resource-stale-subnet'], 42)
+  })
+
+  it('filters bulk link pools to the selected account', () => {
+    renderResourcesTab()
+
+    const poolSelect = screen.getByLabelText('Pool for selected resources') as HTMLSelectElement
+
+    expect(Array.from(poolSelect.options).map((option) => option.textContent)).toContain('prod pool (10.0.0.0/8)')
+    expect(Array.from(poolSelect.options).map((option) => option.textContent)).not.toContain('dev pool (10.99.0.0/16)')
   })
 
   it('selects and clears all visible unlinked resources from the header checkbox', () => {

--- a/ui/src/hooks/useDiscovery.ts
+++ b/ui/src/hooks/useDiscovery.ts
@@ -26,6 +26,7 @@ export function useDiscoveryResources() {
         region?: string
         resource_type?: string
         status?: string
+        q?: string
         linked?: string
         page?: number
         page_size?: number
@@ -40,6 +41,7 @@ export function useDiscoveryResources() {
         if (filters?.resource_type)
           params.set('resource_type', filters.resource_type)
         if (filters?.status) params.set('status', filters.status)
+        if (filters?.q) params.set('q', filters.q)
         if (filters?.linked) params.set('linked', filters.linked)
         if (filters?.page) params.set('page', String(filters.page))
         if (filters?.page_size)

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -62,6 +62,8 @@ export default function DiscoveryPage() {
   const [typeFilter, setTypeFilter] = useState('')
   const [linkedFilter, setLinkedFilter] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
+  const [resourcePage, setResourcePage] = useState(1)
+  const [resourcePageSize, setResourcePageSize] = useState(25)
   const [showGuide, setShowGuide] = useState(false)
   const [showWizard, setShowWizard] = useState(false)
 
@@ -132,13 +134,19 @@ export default function DiscoveryPage() {
         status: statusFilter || undefined,
         resource_type: typeFilter || undefined,
         linked: linkedFilter || undefined,
+        page: resourcePage,
+        page_size: resourcePageSize,
       })
     }
-  }, [selectedAccountId, statusFilter, typeFilter, linkedFilter, fetchResources])
+  }, [selectedAccountId, statusFilter, typeFilter, linkedFilter, resourcePage, resourcePageSize, fetchResources])
 
   useEffect(() => {
     loadResources()
   }, [loadResources])
+
+  useEffect(() => {
+    setResourcePage(1)
+  }, [selectedAccountId, statusFilter, typeFilter, linkedFilter, searchQuery, resourcePageSize])
 
   useEffect(() => {
     setSelectedResourceIds([])
@@ -316,11 +324,15 @@ export default function DiscoveryPage() {
     )
   }
 
-  function selectVisibleImportableResources(resources: DiscoveredResource[]) {
+  function setVisibleImportableResources(resources: DiscoveredResource[], selected: boolean) {
     const ids = resources
       .filter((resource) => isSelectableDiscoveryResource(resource))
       .map((resource) => resource.id)
-    setSelectedResourceIds((current) => Array.from(new Set([...current, ...ids])))
+    if (selected) {
+      setSelectedResourceIds((current) => Array.from(new Set([...current, ...ids])))
+      return
+    }
+    setSelectedResourceIds((current) => current.filter((id) => !ids.includes(id)))
   }
 
   async function handleDeleteAgent(agent: DiscoveryAgent) {
@@ -355,9 +367,10 @@ export default function DiscoveryPage() {
   }
 
   async function handleBulkLink(resourceIds: string[], poolId: number) {
+    const currentResourcesByID = new Map((resourcesData?.items ?? []).map((resource) => [resource.id, resource]))
     const linkableResourceIds = resourceIds.filter((id) => {
-      const resource = resourcesData?.items.find((item) => item.id === id)
-      return resource && isSelectableDiscoveryResource(resource)
+      const resource = currentResourcesByID.get(id)
+      return !resource || isSelectableDiscoveryResource(resource)
     })
     if (linkableResourceIds.length === 0) {
       showToast('Select discovered resources to link', 'error')
@@ -600,13 +613,22 @@ export default function DiscoveryPage() {
           onLinkedChange={setLinkedFilter}
           onLink={handleLink}
           onUnlink={handleUnlink}
+          accounts={accounts}
           pools={pools}
           selectedResourceIds={selectedResourceIds}
           onToggleSelection={toggleResourceSelection}
-          onSelectVisible={selectVisibleImportableResources}
+          onSetVisibleSelection={setVisibleImportableResources}
           onClearSelection={() => setSelectedResourceIds([])}
           onBulkLink={handleBulkLink}
           bulkLinking={bulkLinkingLoading}
+          total={resourcesData?.total ?? filteredResources.length}
+          page={resourcesData?.page ?? resourcePage}
+          pageSize={resourcesData?.page_size ?? resourcePageSize}
+          onPageChange={setResourcePage}
+          onPageSizeChange={(pageSize) => {
+            setResourcePageSize(pageSize)
+            setResourcePage(1)
+          }}
         />
       )}
 
@@ -670,6 +692,38 @@ export default function DiscoveryPage() {
 function isSelectableDiscoveryResource(resource: DiscoveredResource) {
   return !resource.pool_id
 }
+
+type ResourceColumnKey =
+  | 'type'
+  | 'name'
+  | 'account'
+  | 'cidr'
+  | 'region'
+  | 'status'
+  | 'pool'
+  | 'last_seen'
+
+const RESOURCE_COLUMNS: Array<{ key: ResourceColumnKey; label: string }> = [
+  { key: 'type', label: 'Type' },
+  { key: 'name', label: 'Name / ID' },
+  { key: 'account', label: 'Account / Project' },
+  { key: 'cidr', label: 'CIDR' },
+  { key: 'region', label: 'Region' },
+  { key: 'status', label: 'Status' },
+  { key: 'pool', label: 'Pool' },
+  { key: 'last_seen', label: 'Last Seen' },
+]
+
+const DEFAULT_RESOURCE_COLUMNS: ResourceColumnKey[] = [
+  'type',
+  'name',
+  'account',
+  'cidr',
+  'region',
+  'status',
+  'pool',
+  'last_seen',
+]
 
 type NetworkMode = 'hierarchy' | 'flat' | 'conflicts'
 
@@ -1269,13 +1323,19 @@ export function ResourcesTab({
   onLinkedChange,
   onLink,
   onUnlink,
+  accounts,
   pools,
   selectedResourceIds,
   onToggleSelection,
-  onSelectVisible,
+  onSetVisibleSelection,
   onClearSelection,
   onBulkLink,
   bulkLinking = false,
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
 }: {
   resources: DiscoveredResource[]
   loading: boolean
@@ -1290,17 +1350,50 @@ export function ResourcesTab({
   onLinkedChange: (l: string) => void
   onLink: (r: DiscoveredResource) => void
   onUnlink: (r: DiscoveredResource) => void
+  accounts: Account[]
   pools: Pool[]
   selectedResourceIds: string[]
   onToggleSelection: (r: DiscoveredResource) => void
-  onSelectVisible: (resources: DiscoveredResource[]) => void
+  onSetVisibleSelection: (resources: DiscoveredResource[], selected: boolean) => void
   onClearSelection: () => void
   onBulkLink: (resourceIds: string[], poolId: number) => void
   bulkLinking?: boolean
+  total: number
+  page: number
+  pageSize: number
+  onPageChange: (page: number) => void
+  onPageSizeChange: (pageSize: number) => void
 }) {
-  const selectableCount = resources.filter(isSelectableDiscoveryResource).length
   const [bulkLinkPoolId, setBulkLinkPoolId] = useState('')
+  const [showColumns, setShowColumns] = useState(false)
+  const [visibleColumnKeys, setVisibleColumnKeys] = useState<ResourceColumnKey[]>(DEFAULT_RESOURCE_COLUMNS)
   const bulkLinkPool = Number(bulkLinkPoolId)
+  const visibleColumnSet = useMemo(() => new Set(visibleColumnKeys), [visibleColumnKeys])
+  const selectableResources = resources.filter(isSelectableDiscoveryResource)
+  const selectableVisibleIds = selectableResources.map((resource) => resource.id)
+  const selectedVisibleCount = selectableVisibleIds.filter((id) => selectedResourceIds.includes(id)).length
+  const allVisibleSelected = selectableVisibleIds.length > 0 && selectedVisibleCount === selectableVisibleIds.length
+  const someVisibleSelected = selectedVisibleCount > 0 && selectedVisibleCount < selectableVisibleIds.length
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+  const boundedPage = Math.min(Math.max(page, 1), pageCount)
+  const pageStart = total === 0 ? 0 : (boundedPage - 1) * pageSize + 1
+  const pageEnd = Math.min(total, boundedPage * pageSize)
+
+  function toggleColumn(key: ResourceColumnKey) {
+    setVisibleColumnKeys((current) => {
+      if (current.includes(key)) {
+        return current.length === 1 ? current : current.filter((columnKey) => columnKey !== key)
+      }
+      const next = new Set([...current, key])
+      return RESOURCE_COLUMNS
+        .map((column) => column.key)
+        .filter((columnKey) => next.has(columnKey))
+    })
+  }
+
+  function toggleVisibleSelection() {
+    onSetVisibleSelection(resources, !allVisibleSelected)
+  }
 
   return (
     <>
@@ -1347,14 +1440,16 @@ export function ResourcesTab({
           <option value="false">Unlinked</option>
         </select>
         <div className="flex items-center gap-2 text-sm">
-          <button
-            type="button"
-            onClick={() => onSelectVisible(resources)}
-            disabled={selectableCount === 0}
-            className="rounded border border-gray-300 px-3 py-1.5 text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
-          >
+          <label className="flex items-center gap-2 rounded border border-gray-300 px-3 py-1.5 text-gray-700 dark:border-gray-600 dark:text-gray-200 md:hidden">
+            <SelectAllCheckbox
+              checked={allVisibleSelected}
+              indeterminate={someVisibleSelected}
+              disabled={selectableVisibleIds.length === 0}
+              onChange={toggleVisibleSelection}
+              label="Select all visible resources on this page"
+            />
             Select visible
-          </button>
+          </label>
           <button
             type="button"
             onClick={onClearSelection}
@@ -1366,6 +1461,35 @@ export function ResourcesTab({
           <span className="text-gray-500 dark:text-gray-400">
             {selectedResourceIds.length} selected
           </span>
+        </div>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setShowColumns((open) => !open)}
+            className="inline-flex items-center gap-2 rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+            aria-expanded={showColumns}
+          >
+            <Table2 className="h-4 w-4" />
+            Columns
+          </button>
+          {showColumns && (
+            <div className="absolute right-0 z-20 mt-2 w-56 rounded border border-gray-200 bg-white p-2 shadow-lg dark:border-gray-700 dark:bg-gray-900">
+              {RESOURCE_COLUMNS.map((column) => (
+                <label
+                  key={column.key}
+                  className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                >
+                  <input
+                    type="checkbox"
+                    checked={visibleColumnSet.has(column.key)}
+                    onChange={() => toggleColumn(column.key)}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600"
+                  />
+                  {column.label}
+                </label>
+              ))}
+            </div>
+          )}
         </div>
         <div className="flex min-w-[280px] flex-wrap items-center gap-2 text-sm">
           <select
@@ -1419,29 +1543,18 @@ export function ResourcesTab({
             <thead>
               <tr className="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
                 <th className="w-10 px-4 py-2 text-left">
-                  <span className="sr-only">Select</span>
+                  <SelectAllCheckbox
+                    checked={allVisibleSelected}
+                    indeterminate={someVisibleSelected}
+                    disabled={selectableVisibleIds.length === 0}
+                    onChange={toggleVisibleSelection}
+                  />
                 </th>
-                <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
-                  Type
-                </th>
-                <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
-                  Name / ID
-                </th>
-                <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
-                  CIDR
-                </th>
-                <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
-                  Region
-                </th>
-                <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
-                  Status
-                </th>
-                <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
-                  Pool
-                </th>
-                <th className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
-                  Last Seen
-                </th>
+                {RESOURCE_COLUMNS.filter((column) => visibleColumnSet.has(column.key)).map((column) => (
+                  <th key={column.key} className="px-4 py-2 text-left text-gray-600 dark:text-gray-400 font-medium">
+                    {column.label}
+                  </th>
+                ))}
                 <th className="px-4 py-2 text-right text-gray-600 dark:text-gray-400 font-medium">
                   Actions
                 </th>
@@ -1463,40 +1576,15 @@ export function ResourcesTab({
                       className="h-4 w-4 rounded border-gray-300 text-blue-600 disabled:opacity-40"
                     />
                   </td>
-                  <td className="px-4 py-2">
-                    <ResourceTypeBadge type={r.resource_type} />
-                  </td>
-                  <td className="px-4 py-2">
-                    <div className="text-gray-900 dark:text-gray-100 font-medium">
-                      {r.name || r.resource_id}
-                    </div>
-                    {r.name && (
-                      <div className="text-xs text-gray-500 dark:text-gray-400">
-                        {r.resource_id}
-                      </div>
-                    )}
-                  </td>
-                  <td className="px-4 py-2 font-mono text-gray-700 dark:text-gray-300">
-                    {r.cidr || '-'}
-                  </td>
-                  <td className="px-4 py-2 text-gray-600 dark:text-gray-400">
-                    {r.region || '-'}
-                  </td>
-                  <td className="px-4 py-2">
-                    <StatusBadge label={r.status} />
-                  </td>
-                  <td className="px-4 py-2 text-gray-600 dark:text-gray-400">
-                    {r.pool_id ? (
-                      <PoolLabel poolId={r.pool_id} pools={pools} />
-                    ) : (
-                      <span className="text-gray-400 dark:text-gray-500">
-                        unlinked
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
-                    {formatTimeAgo(r.last_seen_at)}
-                  </td>
+                  {RESOURCE_COLUMNS.filter((column) => visibleColumnSet.has(column.key)).map((column) => (
+                    <ResourceTableCell
+                      key={column.key}
+                      column={column.key}
+                      resource={r}
+                      accounts={accounts}
+                      pools={pools}
+                    />
+                  ))}
                   <td className="px-4 py-2 text-right">
                     {r.pool_id ? (
                       <button
@@ -1532,12 +1620,217 @@ export function ResourcesTab({
               selected={selectedResourceIds.includes(r.id)}
               selectable={isSelectableDiscoveryResource(r)}
               onToggleSelection={onToggleSelection}
+              accountLabel={resourceAccountLabel(r, accounts)}
             />
           ))}
         </div>
+        <ResourcePagination
+          total={total}
+          pageSize={pageSize}
+          pageStart={pageStart}
+          pageEnd={pageEnd}
+          pageCount={pageCount}
+          boundedPage={boundedPage}
+          onPageChange={onPageChange}
+          onPageSizeChange={onPageSizeChange}
+        />
         </>
       )}
     </>
+  )
+}
+
+function SelectAllCheckbox({
+  checked,
+  indeterminate,
+  disabled,
+  onChange,
+  label = 'Select all visible resources',
+}: {
+  checked: boolean
+  indeterminate: boolean
+  disabled: boolean
+  onChange: () => void
+  label?: string
+}) {
+  const ref = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.indeterminate = indeterminate
+    }
+  }, [indeterminate])
+
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      disabled={disabled}
+      onChange={onChange}
+      aria-label={label}
+      className="h-4 w-4 rounded border-gray-300 text-blue-600 disabled:opacity-40"
+    />
+  )
+}
+
+function ResourceTableCell({
+  column,
+  resource,
+  accounts,
+  pools,
+}: {
+  column: ResourceColumnKey
+  resource: DiscoveredResource
+  accounts: Account[]
+  pools: Pool[]
+}) {
+  switch (column) {
+    case 'type':
+      return (
+        <td className="px-4 py-2">
+          <ResourceTypeBadge type={resource.resource_type} />
+        </td>
+      )
+    case 'name':
+      return (
+        <td className="px-4 py-2">
+          <div className="text-gray-900 dark:text-gray-100 font-medium">
+            {resource.name || resource.resource_id}
+          </div>
+          {resource.name && (
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              {resource.resource_id}
+            </div>
+          )}
+        </td>
+      )
+    case 'account':
+      return (
+        <td className="px-4 py-2 text-gray-600 dark:text-gray-400">
+          <ResourceAccountLabel resource={resource} accounts={accounts} />
+        </td>
+      )
+    case 'cidr':
+      return (
+        <td className="px-4 py-2 font-mono text-gray-700 dark:text-gray-300">
+          {resource.cidr || '-'}
+        </td>
+      )
+    case 'region':
+      return (
+        <td className="px-4 py-2 text-gray-600 dark:text-gray-400">
+          {resource.region || '-'}
+        </td>
+      )
+    case 'status':
+      return (
+        <td className="px-4 py-2">
+          <StatusBadge label={resource.status} />
+        </td>
+      )
+    case 'pool':
+      return (
+        <td className="px-4 py-2 text-gray-600 dark:text-gray-400">
+          {resource.pool_id ? (
+            <PoolLabel poolId={resource.pool_id} pools={pools} />
+          ) : (
+            <span className="text-gray-400 dark:text-gray-500">
+              unlinked
+            </span>
+          )}
+        </td>
+      )
+    case 'last_seen':
+      return (
+        <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
+          {formatTimeAgo(resource.last_seen_at)}
+        </td>
+      )
+  }
+}
+
+function ResourceAccountLabel({ resource, accounts }: { resource: DiscoveredResource; accounts: Account[] }) {
+  const account = accounts.find((candidate) => candidate.id === resource.account_id)
+  const label = resourceAccountLabel(resource, accounts)
+  const detail = account?.external_id || account?.key || account?.provider || resource.provider
+
+  return (
+    <div>
+      <div className="font-medium text-gray-800 dark:text-gray-200">{label}</div>
+      {detail && detail !== label && (
+        <div className="text-xs text-gray-500 dark:text-gray-400">{detail}</div>
+      )}
+    </div>
+  )
+}
+
+function resourceAccountLabel(resource: DiscoveredResource, accounts: Account[]) {
+  const account = accounts.find((candidate) => candidate.id === resource.account_id)
+  if (account?.name) return account.name
+  if (account?.key) return account.key
+  return `Account #${resource.account_id}`
+}
+
+function ResourcePagination({
+  total,
+  pageSize,
+  pageStart,
+  pageEnd,
+  pageCount,
+  boundedPage,
+  onPageChange,
+  onPageSizeChange,
+}: {
+  total: number
+  pageSize: number
+  pageStart: number
+  pageEnd: number
+  pageCount: number
+  boundedPage: number
+  onPageChange: (page: number) => void
+  onPageSizeChange: (pageSize: number) => void
+}) {
+  return (
+    <div className="mt-3 flex flex-col gap-3 text-sm text-gray-600 dark:text-gray-400 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        Showing {pageStart}-{pageEnd} of {total}
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="flex items-center gap-2">
+          <span>Rows</span>
+          <select
+            value={pageSize}
+            onChange={(event) => onPageSizeChange(Number(event.target.value))}
+            aria-label="Rows per page"
+            className="rounded border border-gray-300 bg-white px-2 py-1 text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+          >
+            {[10, 25, 50, 100].map((size) => (
+              <option key={size} value={size}>{size}</option>
+            ))}
+          </select>
+        </label>
+        <span>
+          Page {boundedPage} of {pageCount}
+        </span>
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.max(1, boundedPage - 1))}
+          disabled={boundedPage <= 1}
+          className="rounded border border-gray-300 px-3 py-1 text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.min(pageCount, boundedPage + 1))}
+          disabled={boundedPage >= pageCount}
+          className="rounded border border-gray-300 px-3 py-1 text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+        >
+          Next
+        </button>
+      </div>
+    </div>
   )
 }
 
@@ -1719,6 +2012,7 @@ function ResourceCard({
   selected,
   selectable,
   onToggleSelection,
+  accountLabel,
 }: {
   resource: DiscoveredResource
   pools: Pool[]
@@ -1727,6 +2021,7 @@ function ResourceCard({
   selected: boolean
   selectable: boolean
   onToggleSelection: (r: DiscoveredResource) => void
+  accountLabel: string
 }) {
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-3 text-sm dark:border-gray-700 dark:bg-gray-800">
@@ -1781,6 +2076,10 @@ function ResourceCard({
         <div>
           <div className="text-gray-500 dark:text-gray-400">Region</div>
           <div className="text-gray-800 dark:text-gray-200">{resource.region || '-'}</div>
+        </div>
+        <div className="col-span-2">
+          <div className="text-gray-500 dark:text-gray-400">Account / Project</div>
+          <div className="text-gray-800 dark:text-gray-200">{accountLabel}</div>
         </div>
         <div className="col-span-2">
           <div className="text-gray-500 dark:text-gray-400">Pool</div>

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -134,11 +134,12 @@ export default function DiscoveryPage() {
         status: statusFilter || undefined,
         resource_type: typeFilter || undefined,
         linked: linkedFilter || undefined,
+        q: searchQuery || undefined,
         page: resourcePage,
         page_size: resourcePageSize,
       })
     }
-  }, [selectedAccountId, statusFilter, typeFilter, linkedFilter, resourcePage, resourcePageSize, fetchResources])
+  }, [selectedAccountId, statusFilter, typeFilter, linkedFilter, searchQuery, resourcePage, resourcePageSize, fetchResources])
 
   useEffect(() => {
     loadResources()
@@ -423,15 +424,7 @@ export default function DiscoveryPage() {
     }
   }
 
-  const filteredResources = (resourcesData?.items ?? []).filter((r) => {
-    if (!searchQuery) return true
-    const q = searchQuery.toLowerCase()
-    return (
-      r.name.toLowerCase().includes(q) ||
-      r.resource_id.toLowerCase().includes(q) ||
-      (r.cidr || '').toLowerCase().includes(q)
-    )
-  })
+  const filteredResources = resourcesData?.items ?? []
 
   if (accounts.length === 0) {
     return (
@@ -604,7 +597,10 @@ export default function DiscoveryPage() {
           loading={resLoading}
           error={resError}
           searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
+          onSearchChange={(query) => {
+            setSearchQuery(query)
+            setResourcePage(1)
+          }}
           statusFilter={statusFilter}
           onStatusChange={setStatusFilter}
           typeFilter={typeFilter}
@@ -614,6 +610,7 @@ export default function DiscoveryPage() {
           onLink={handleLink}
           onUnlink={handleUnlink}
           accounts={accounts}
+          selectedAccountId={selectedAccountId}
           pools={pools}
           selectedResourceIds={selectedResourceIds}
           onToggleSelection={toggleResourceSelection}
@@ -1324,6 +1321,7 @@ export function ResourcesTab({
   onLink,
   onUnlink,
   accounts,
+  selectedAccountId,
   pools,
   selectedResourceIds,
   onToggleSelection,
@@ -1351,6 +1349,7 @@ export function ResourcesTab({
   onLink: (r: DiscoveredResource) => void
   onUnlink: (r: DiscoveredResource) => void
   accounts: Account[]
+  selectedAccountId: number | null
   pools: Pool[]
   selectedResourceIds: string[]
   onToggleSelection: (r: DiscoveredResource) => void
@@ -1369,6 +1368,10 @@ export function ResourcesTab({
   const [visibleColumnKeys, setVisibleColumnKeys] = useState<ResourceColumnKey[]>(DEFAULT_RESOURCE_COLUMNS)
   const bulkLinkPool = Number(bulkLinkPoolId)
   const visibleColumnSet = useMemo(() => new Set(visibleColumnKeys), [visibleColumnKeys])
+  const bulkLinkPools = useMemo(
+    () => pools.filter((pool) => pool.account_id == null || pool.account_id === selectedAccountId),
+    [pools, selectedAccountId],
+  )
   const selectableResources = resources.filter(isSelectableDiscoveryResource)
   const selectableVisibleIds = selectableResources.map((resource) => resource.id)
   const selectedVisibleCount = selectableVisibleIds.filter((id) => selectedResourceIds.includes(id)).length
@@ -1495,12 +1498,12 @@ export function ResourcesTab({
           <select
             value={bulkLinkPoolId}
             onChange={(e) => setBulkLinkPoolId(e.target.value)}
-            disabled={pools.length === 0}
+            disabled={bulkLinkPools.length === 0}
             aria-label="Pool for selected resources"
             className="min-w-[190px] rounded border border-gray-300 bg-white px-3 py-1.5 text-gray-900 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
           >
             <option value="">Select pool</option>
-            {pools.map((pool) => (
+            {bulkLinkPools.map((pool) => (
               <option key={pool.id} value={pool.id}>
                 {pool.name} ({pool.cidr})
               </option>


### PR DESCRIPTION
## Summary

Improves the Cloud Discovery resources view for large discovery runs and multi-account context.

This PR adds:

- Account/project context for discovered resources by joining `resource.account_id` to the loaded accounts list.
- Server-backed pagination controls using the existing `page` and `page_size` discovery resource query params.
- Page-size choices for 10, 25, 50, and 100 rows.
- A select-all checkbox for currently visible selectable resources.
- A mobile select-visible control using the same selection state.
- A Columns menu for showing or hiding each data column while keeping selection and actions available.
- Focused tests for bulk selection, account display, configurable columns, and pagination callbacks.

## User-Facing Behavior

- The Resources tab now shows which account or project each discovered resource belongs to.
- Operators can page through large discovery result sets instead of loading a fixed default page.
- Operators can select all unlinked resources on the current visible page in one click.
- Linked resources remain disabled for bulk selection.
- Operators can tailor the table by hiding or restoring individual data columns.
- Mobile cards remain usable and include account/project context.

## Implementation Notes

- No backend changes were required because the discovery resources API already accepts `page` and `page_size`.
- Pagination state is local to `DiscoveryPage` and resets to page 1 when account, filters, search, or page size changes.
- Column visibility is local component state and is not persisted across reloads.
- Select-all applies to the currently visible page, not every result across all pages.
- Bulk linking now allows selected IDs from prior pages to remain eligible instead of filtering them out just because they are absent from the current page response.

## Tests

- `cd ui && npm test -- DiscoveryResourcesTab`
- `cd ui && npm test`
- `cd ui && npm run build`

All passed.

## Screenshots

Not included. Playwright screenshot capture was not run for this UI change.

## Known Gaps

- Resource search remains client-side over the currently loaded page because the API does not expose a resource search query parameter.
- Column visibility is not persisted as a user preference.
- Select-all does not select resources across all pages.
