### PR TITLE
Discovery: persist network objects and relationships

### DIFF
--- a/cmd/cloudpam/main.go
+++ b/cmd/cloudpam/main.go
@@ -220,6 +220,7 @@ func main() {
 	driftSrv := api.NewDriftServer(srv, driftDetector, driftStore)
 	logger.Info("drift detection subsystem initialized")
 	networkSrv := api.NewNetworkServer(srv, store, discoveryStore, driftStore)
+	networkSrv.SetNetworkStore(selectNetworkStore(logger, store))
 	logger.Info("merged network view subsystem initialized")
 
 	// Initialize settings subsystem

--- a/cmd/cloudpam/store_both.go
+++ b/cmd/cloudpam/store_both.go
@@ -206,6 +206,14 @@ func selectDriftStore(logger observability.Logger, mainStore storage.Store) stor
 	return storage.NewMemoryDriftStore(storage.NewMemoryStore())
 }
 
+func selectNetworkStore(logger observability.Logger, mainStore storage.Store) storage.NetworkStore {
+	if ns, ok := mainStore.(storage.NetworkStore); ok {
+		return ns
+	}
+	logger.Warn("main store does not implement NetworkStore; using in-memory fallback")
+	return storage.NewMemoryNetworkStore(storage.NewMemoryStore())
+}
+
 func sqliteStatus(dsn string) string {
 	s, err := sqlitestore.Status(dsn)
 	if err != nil {

--- a/cmd/cloudpam/store_default.go
+++ b/cmd/cloudpam/store_default.go
@@ -104,6 +104,13 @@ func selectDriftStore(_ observability.Logger, mainStore storage.Store) storage.D
 	return storage.NewMemoryDriftStore(storage.NewMemoryStore())
 }
 
+func selectNetworkStore(_ observability.Logger, mainStore storage.Store) storage.NetworkStore {
+	if ms, ok := mainStore.(*storage.MemoryStore); ok {
+		return storage.NewMemoryNetworkStore(ms)
+	}
+	return storage.NewMemoryNetworkStore(storage.NewMemoryStore())
+}
+
 // sqliteStatus returns schema status string when not built with sqlite tag.
 func sqliteStatus(dsn string) string { return "" }
 

--- a/cmd/cloudpam/store_postgres.go
+++ b/cmd/cloudpam/store_postgres.go
@@ -147,6 +147,14 @@ func selectDriftStore(logger observability.Logger, mainStore storage.Store) stor
 	return storage.NewMemoryDriftStore(storage.NewMemoryStore())
 }
 
+func selectNetworkStore(logger observability.Logger, mainStore storage.Store) storage.NetworkStore {
+	if ns, ok := mainStore.(storage.NetworkStore); ok {
+		return ns
+	}
+	logger.Warn("main store does not implement NetworkStore; using in-memory fallback")
+	return storage.NewMemoryNetworkStore(storage.NewMemoryStore())
+}
+
 // sqliteStatus is a no-op for postgres builds.
 func sqliteStatus(_ string) string { return "" }
 

--- a/cmd/cloudpam/store_sqlite.go
+++ b/cmd/cloudpam/store_sqlite.go
@@ -149,6 +149,14 @@ func selectDriftStore(logger observability.Logger, mainStore storage.Store) stor
 	return storage.NewMemoryDriftStore(storage.NewMemoryStore())
 }
 
+func selectNetworkStore(logger observability.Logger, mainStore storage.Store) storage.NetworkStore {
+	if ns, ok := mainStore.(storage.NetworkStore); ok {
+		return ns
+	}
+	logger.Warn("main store does not implement NetworkStore; using in-memory fallback")
+	return storage.NewMemoryNetworkStore(storage.NewMemoryStore())
+}
+
 // sqliteStatus returns migration status when built with sqlite tag.
 func sqliteStatus(dsn string) string {
 	s, err := sqlitestore.Status(dsn)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.17.0] - 2026-06-03
+
+### Added
+- Added durable managed network objects and explicit network relationships so VPCs, subnets, EIPs/public IPs, soft links, conflict evidence, placeholder parents, and imported relationships can be stored separately from allocated blocks.
+- Added network object and relationship APIs under `/api/v1/network/objects` and `/api/v1/network/relationships`, plus placeholder-parent conflict action support.
+- Added `POST /api/v1/network/relationships/resolve` so relationship IDs that contain URL path separators can be resolved from the request body while server-generated relationship IDs remain URL-safe.
+- Merged network conflict evaluation now supports schema policy query options for account-level, region-level, global, and manual duplicate handling with policy evidence in conflict responses.
+
 ## [0.16.2] - 2026-06-02
 
 ### Fixed

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -11,10 +11,10 @@ CloudPAM keeps designed IPAM state separate from observed cloud state:
 | Address pool | A CloudPAM-managed container for address space. |
 | Allocated block | Approved or designed IPAM intent shown in the Allocated Blocks view. |
 | Discovered resource | Observed cloud state from a provider scan. |
-| Network object | A cloud networking object such as a VPC, subnet, EIP, public IP, or NIC. |
+| Network object | A durable managed cloud/networking object such as a VPC, subnet, EIP, public IP, network, or placeholder parent. |
 | Soft link | A non-destructive association between a discovered resource and a managed pool. |
 
-VPCs and subnets can be converted into discovered-source pools when an operator explicitly imports them. EIPs and similar address-bearing resources stay as network-object candidates in the import preview until CloudPAM has a managed network-object store for them.
+VPCs and subnets can be converted into discovered-source pools when an operator explicitly imports them. EIPs, public IPs, placeholder parents, and other provider-neutral resources can be represented as managed network objects without becoming allocated blocks.
 
 ## How It Works
 
@@ -100,7 +100,7 @@ curl -X POST http://localhost:8080/api/v1/discovery/import/apply \
 
 ## Merged Network Views
 
-CloudPAM exposes merged network views that combine managed pools, linked discovered resources, discovered-only network objects, and computed conflict evidence.
+CloudPAM exposes merged network views that combine managed pools, linked discovered resources, durable managed network objects, discovered-only network objects, explicit relationships, and computed conflict evidence.
 
 The Discovery page includes a **Merged Network** tab with:
 
@@ -116,9 +116,11 @@ API callers can use:
 curl http://localhost:8080/api/v1/network/hierarchy
 curl http://localhost:8080/api/v1/network/flat?object_type=vpc
 curl http://localhost:8080/api/v1/network/conflicts?conflict_type=duplicate_cidr
+curl http://localhost:8080/api/v1/network/objects?object_type=eip
+curl http://localhost:8080/api/v1/network/relationships?type=matches
 ```
 
-Conflict responses include stable IDs, severity, affected discovered resource IDs, affected pool IDs, account/region metadata, evidence lines, and available review decisions: `skip`, `ignore`, and `defer`.
+Conflict responses include stable IDs, severity, affected discovered resource IDs, affected pool IDs, account/region metadata, evidence lines, explicit relationship records when present, and available review decisions: `skip`, `ignore`, and `defer`.
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/network/conflicts/duplicate-cidr:10.0.0.0_16/resolve \
@@ -126,7 +128,40 @@ curl -X POST http://localhost:8080/api/v1/network/conflicts/duplicate-cidr:10.0.
   -d '{"decision":"skip","reason":"reviewed duplicate lab account"}'
 ```
 
-Conflict resolution requests for computed conflicts are persisted as drift records keyed by the stable conflict ID where the configured drift store is durable, such as SQLite. The merged views rehydrate the stored decision when conflicts are recomputed. Durable managed network-object persistence remains future work.
+Conflict resolution requests for computed conflicts are persisted as drift records keyed by the stable conflict ID where the configured drift store is durable, such as SQLite or PostgreSQL. Computed conflicts also write explicit relationship records when network relationship storage is available, and merged views rehydrate those relationships when conflicts are recomputed.
+
+### Managed Network Objects
+
+Managed network objects are for cloud/network entities that should be queryable without being treated as approved IPAM allocations. Use them for EIPs/public IPs, imported-but-not-allocated resources, placeholders for missing parents, or provider-neutral objects that do not belong in the pool hierarchy.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/network/objects \
+  -H 'Content-Type: application/json' \
+  -d '{"object_type":"public_ip","provider":"aws","account_id":1,"region":"us-east-1","name":"nat-eip","ip_address":"198.51.100.10","provider_resource_id":"eipalloc-123"}'
+```
+
+Relationships connect pools, discovered resources, managed network objects, and conflict evidence without changing import state. Relationship types include `contains`, `matches`, `conflicts`, `missing_parent`, `candidate_import`, `imported_as`, and `duplicate_of`.
+
+Relationship resolution can be updated by ID in the request body. Use the body form when a caller-supplied relationship ID contains URL path separators such as `/`.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/network/relationships/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"tenant/a","resolution_state":"resolved","reason":"accepted"}'
+```
+
+### Schema Policy
+
+Duplicate and hierarchy evidence can be evaluated with a schema policy:
+
+```bash
+curl http://localhost:8080/api/v1/network/conflicts?schema_policy=account_level
+curl http://localhost:8080/api/v1/network/conflicts?schema_policy=region_level
+curl http://localhost:8080/api/v1/network/conflicts?schema_policy=global
+curl http://localhost:8080/api/v1/network/conflicts?schema_policy=manual
+```
+
+`account_level` is the default conservative behavior. `region_level` scopes duplicate CIDR checks by region, `global` treats duplicate CIDRs anywhere as conflicts, and `manual` suppresses duplicate conflicts unless callers pass an explicit duplicate override.
 
 ## AWS Setup
 

--- a/internal/api/bootstrap_handlers_test.go
+++ b/internal/api/bootstrap_handlers_test.go
@@ -26,6 +26,7 @@ func setupDiscoveryTestServer() (*DiscoveryServer, *storage.MemoryStore, *storag
 	discSrv := NewDiscoveryServer(srv, ds, syncSvc, ks)
 	discSrv.RegisterDiscoveryRoutes()
 	networkSrv := NewNetworkServer(srv, st, ds, storage.NewMemoryDriftStore(st))
+	networkSrv.SetNetworkStore(storage.NewMemoryNetworkStore(st))
 	networkSrv.RegisterNetworkRoutes()
 	return discSrv, st, ds, ks
 }

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,15 +24,21 @@ import (
 
 // NetworkServer handles merged network view endpoints.
 type NetworkServer struct {
-	srv        *Server
-	store      storage.Store
-	discStore  storage.DiscoveryStore
-	driftStore storage.DriftStore
+	srv          *Server
+	store        storage.Store
+	discStore    storage.DiscoveryStore
+	driftStore   storage.DriftStore
+	networkStore storage.NetworkStore
 }
 
 // NewNetworkServer creates a merged network view server.
 func NewNetworkServer(srv *Server, store storage.Store, discStore storage.DiscoveryStore, driftStore storage.DriftStore) *NetworkServer {
 	return &NetworkServer{srv: srv, store: store, discStore: discStore, driftStore: driftStore}
+}
+
+// SetNetworkStore attaches durable managed network object and relationship storage.
+func (ns *NetworkServer) SetNetworkStore(networkStore storage.NetworkStore) {
+	ns.networkStore = networkStore
 }
 
 // RegisterNetworkRoutes registers network routes without RBAC.
@@ -40,6 +48,10 @@ func (ns *NetworkServer) RegisterNetworkRoutes() {
 	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/merged", ns.handleMerged)
 	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/conflicts", ns.handleConflicts)
 	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/conflicts/", ns.handleConflictSubroutes)
+	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/objects", ns.handleNetworkObjects)
+	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/objects/", ns.handleNetworkObjectSubroutes)
+	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/relationships", ns.handleNetworkRelationships)
+	ns.srv.handleOpenAPIRouteFunc("/api/v1/network/relationships/", ns.handleNetworkRelationshipSubroutes)
 }
 
 // RegisterProtectedNetworkRoutes registers network routes with RBAC.
@@ -51,6 +63,13 @@ func (ns *NetworkServer) RegisterProtectedNetworkRoutes(dualMW Middleware, logge
 	ns.srv.handleOpenAPIRoute("/api/v1/network/merged", dualMW(readMW(http.HandlerFunc(ns.handleMerged))))
 	ns.srv.handleOpenAPIRoute("/api/v1/network/conflicts", dualMW(readMW(http.HandlerFunc(ns.handleConflicts))))
 	ns.srv.handleOpenAPIRoute("/api/v1/network/conflicts/", dualMW(updateMW(http.HandlerFunc(ns.handleConflictSubroutes))))
+	ns.srv.handleOpenAPIRoute("GET /api/v1/network/objects", dualMW(readMW(http.HandlerFunc(ns.handleNetworkObjects))))
+	ns.srv.handleOpenAPIRoute("POST /api/v1/network/objects", dualMW(updateMW(http.HandlerFunc(ns.handleNetworkObjects))))
+	ns.srv.handleOpenAPIRoute("GET /api/v1/network/objects/", dualMW(readMW(http.HandlerFunc(ns.handleNetworkObjectSubroutes))))
+	ns.srv.handleOpenAPIRoute("PATCH /api/v1/network/objects/", dualMW(updateMW(http.HandlerFunc(ns.handleNetworkObjectSubroutes))))
+	ns.srv.handleOpenAPIRoute("GET /api/v1/network/relationships", dualMW(readMW(http.HandlerFunc(ns.handleNetworkRelationships))))
+	ns.srv.handleOpenAPIRoute("POST /api/v1/network/relationships", dualMW(updateMW(http.HandlerFunc(ns.handleNetworkRelationships))))
+	ns.srv.handleOpenAPIRoute("/api/v1/network/relationships/", dualMW(updateMW(http.HandlerFunc(ns.handleNetworkRelationshipSubroutes))))
 }
 
 func (ns *NetworkServer) handleFlat(w http.ResponseWriter, r *http.Request) {
@@ -126,12 +145,188 @@ func (ns *NetworkServer) handleConflictSubroutes(w http.ResponseWriter, r *http.
 			ns.handleNetworkConflictLinkAction(w, r, parts[0])
 		case "import":
 			ns.handleNetworkConflictImportAction(w, r, parts[0])
+		case "create_placeholder_parent":
+			ns.handleNetworkConflictPlaceholderParentAction(w, r, parts[0])
 		default:
 			ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "not found", "")
 		}
 		return
 	}
 	ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "not found", "")
+}
+
+func (ns *NetworkServer) handleNetworkObjects(w http.ResponseWriter, r *http.Request) {
+	if ns.networkStore == nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotImplemented, "network object storage is not available", "")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		objects, err := ns.networkStore.ListNetworkObjects(r.Context(), networkObjectFiltersFromRequest(r))
+		if err != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "list network objects failed", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, domain.NetworkObjectListResponse{Items: objects, Total: len(objects)})
+	case http.MethodPost:
+		var req domain.CreateNetworkObject
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+			return
+		}
+		obj, err := ns.networkStore.CreateNetworkObject(r.Context(), req)
+		if err != nil {
+			ns.srv.writeStoreErr(r.Context(), w, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, obj)
+	default:
+		w.Header().Set("Allow", strings.Join([]string{http.MethodGet, http.MethodPost}, ", "))
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+	}
+}
+
+func (ns *NetworkServer) handleNetworkObjectSubroutes(w http.ResponseWriter, r *http.Request) {
+	if ns.networkStore == nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotImplemented, "network object storage is not available", "")
+		return
+	}
+	idText := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/network/objects/"), "/")
+	id, err := strconv.ParseInt(idText, 10, 64)
+	if err != nil || id < 1 {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "not found", "")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		obj, found, err := ns.networkStore.GetNetworkObject(r.Context(), id)
+		if err != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "get network object failed", err.Error())
+			return
+		}
+		if !found {
+			ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "network object not found", "")
+			return
+		}
+		writeJSON(w, http.StatusOK, obj)
+	case http.MethodPatch:
+		var req domain.UpdateNetworkObject
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+			return
+		}
+		obj, found, err := ns.networkStore.UpdateNetworkObject(r.Context(), id, req)
+		if err != nil {
+			ns.srv.writeStoreErr(r.Context(), w, err)
+			return
+		}
+		if !found {
+			ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "network object not found", "")
+			return
+		}
+		writeJSON(w, http.StatusOK, obj)
+	default:
+		w.Header().Set("Allow", strings.Join([]string{http.MethodGet, http.MethodPatch}, ", "))
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+	}
+}
+
+func (ns *NetworkServer) handleNetworkRelationships(w http.ResponseWriter, r *http.Request) {
+	if ns.networkStore == nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotImplemented, "network relationship storage is not available", "")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		relationships, err := ns.networkStore.ListNetworkRelationships(r.Context(), networkRelationshipFiltersFromRequest(r))
+		if err != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "list network relationships failed", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, domain.NetworkRelationshipListResponse{Items: relationships, Total: len(relationships)})
+	case http.MethodPost:
+		var req domain.CreateNetworkRelationship
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+			return
+		}
+		rel, err := ns.networkStore.UpsertNetworkRelationship(r.Context(), req)
+		if err != nil {
+			ns.srv.writeStoreErr(r.Context(), w, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, rel)
+	default:
+		w.Header().Set("Allow", strings.Join([]string{http.MethodGet, http.MethodPost}, ", "))
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+	}
+}
+
+func (ns *NetworkServer) handleNetworkRelationshipSubroutes(w http.ResponseWriter, r *http.Request) {
+	if ns.networkStore == nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotImplemented, "network relationship storage is not available", "")
+		return
+	}
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/network/relationships/"), "/")
+	parts := strings.Split(path, "/")
+	if len(parts) == 1 && parts[0] == "resolve" {
+		ns.handleResolveNetworkRelationshipByBody(w, r)
+		return
+	}
+	if len(parts) != 2 || parts[0] == "" || parts[1] != "resolve" {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "not found", "")
+		return
+	}
+	ns.handleResolveNetworkRelationship(w, r, parts[0])
+}
+
+func (ns *NetworkServer) handleResolveNetworkRelationshipByBody(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	var req domain.ResolveNetworkRelationshipRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+	ns.handleResolveNetworkRelationshipRequest(w, r, req)
+}
+
+func (ns *NetworkServer) handleResolveNetworkRelationship(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	var req domain.ResolveNetworkRelationshipRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+	if req.ID == "" {
+		req.ID = id
+	}
+	ns.handleResolveNetworkRelationshipRequest(w, r, req)
+}
+
+func (ns *NetworkServer) handleResolveNetworkRelationshipRequest(w http.ResponseWriter, r *http.Request, req domain.ResolveNetworkRelationshipRequest) {
+	id := strings.TrimSpace(req.ID)
+	if id == "" {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "id is required", "")
+		return
+	}
+	rel, found, err := ns.networkStore.UpdateNetworkRelationshipState(r.Context(), id, req.ResolutionState, req.Reason)
+	if err != nil {
+		ns.srv.writeStoreErr(r.Context(), w, err)
+		return
+	}
+	if !found {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "network relationship not found", "")
+		return
+	}
+	writeJSON(w, http.StatusOK, rel)
 }
 
 func (ns *NetworkServer) handleResolveNetworkConflict(w http.ResponseWriter, r *http.Request, conflictID string) {
@@ -253,6 +448,18 @@ func (ns *NetworkServer) handleNetworkConflictLinkAction(w http.ResponseWriter, 
 		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "record conflict action failed", err.Error())
 		return
 	}
+	relationships := ns.persistNetworkConflictActionRelationships(r.Context(), "link", *conflict, []domain.CreateNetworkRelationship{{
+		ID:              relationshipIDForConflict(conflict.ID, "discovered", req.DiscoveredID.String(), "pool", fmt.Sprintf("%d", req.PoolID)),
+		Type:            domain.NetworkRelationshipMatches,
+		SourceKind:      "discovered",
+		SourceID:        req.DiscoveredID.String(),
+		TargetKind:      "pool",
+		TargetID:        fmt.Sprintf("%d", req.PoolID),
+		Confidence:      1,
+		Reason:          networkActionReason("link", req.Reason, actionDetails),
+		Evidence:        append(conflict.Evidence, "action=link"),
+		ResolutionState: string(domain.DriftStatusResolved),
+	}})
 
 	updated := ns.conflictAfterAction(r.Context(), *conflict, "link")
 	writeJSON(w, http.StatusOK, domain.NetworkConflictActionResponse{
@@ -261,6 +468,7 @@ func (ns *NetworkServer) handleNetworkConflictLinkAction(w http.ResponseWriter, 
 		ResourceLinked: true,
 		DiscoveredID:   &req.DiscoveredID,
 		PoolID:         &req.PoolID,
+		Relationships:  relationships,
 	})
 }
 
@@ -377,13 +585,170 @@ func (ns *NetworkServer) handleNetworkConflictImportAction(w http.ResponseWriter
 		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "record conflict action failed", err.Error())
 		return
 	}
+	var relationshipInputs []domain.CreateNetworkRelationship
+	for _, resourceID := range importResp.LinkedResourceIDs {
+		for _, poolID := range importResp.CreatedPoolIDs {
+			relationshipInputs = append(relationshipInputs, domain.CreateNetworkRelationship{
+				ID:              relationshipIDForConflict(conflict.ID, "discovered", resourceID.String(), "pool", fmt.Sprintf("%d", poolID)),
+				Type:            domain.NetworkRelationshipImportedAs,
+				SourceKind:      "discovered",
+				SourceID:        resourceID.String(),
+				TargetKind:      "pool",
+				TargetID:        fmt.Sprintf("%d", poolID),
+				Confidence:      1,
+				Reason:          networkActionReason("import", req.Reason, actionDetails),
+				Evidence:        append(conflict.Evidence, "action=import"),
+				ResolutionState: string(domain.DriftStatusResolved),
+			})
+		}
+		if req.PoolID != nil {
+			relationshipInputs = append(relationshipInputs, domain.CreateNetworkRelationship{
+				ID:              relationshipIDForConflict(conflict.ID, "discovered", resourceID.String(), "pool", fmt.Sprintf("%d", *req.PoolID)),
+				Type:            domain.NetworkRelationshipImportedAs,
+				SourceKind:      "discovered",
+				SourceID:        resourceID.String(),
+				TargetKind:      "pool",
+				TargetID:        fmt.Sprintf("%d", *req.PoolID),
+				Confidence:      1,
+				Reason:          networkActionReason("import", req.Reason, actionDetails),
+				Evidence:        append(conflict.Evidence, "action=import"),
+				ResolutionState: string(domain.DriftStatusResolved),
+			})
+		}
+	}
+	relationships := ns.persistNetworkConflictActionRelationships(r.Context(), "import", *conflict, relationshipInputs)
 
 	updated := ns.conflictAfterAction(r.Context(), *conflict, "import")
 	writeJSON(w, http.StatusOK, domain.NetworkConflictActionResponse{
-		Conflict: updated,
-		Action:   "import",
-		PoolID:   req.PoolID,
-		Import:   &importResp,
+		Conflict:      updated,
+		Action:        "import",
+		PoolID:        req.PoolID,
+		Relationships: relationships,
+		Import:        &importResp,
+	})
+}
+
+func (ns *NetworkServer) handleNetworkConflictPlaceholderParentAction(w http.ResponseWriter, r *http.Request, conflictID string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		ns.srv.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	if ns.networkStore == nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotImplemented, "network object storage is not available", "")
+		return
+	}
+	var req domain.NetworkConflictPlaceholderParentActionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+	if req.DiscoveredID == uuid.Nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "discovered_id is required", "")
+		return
+	}
+	conflict, err := ns.findNetworkConflict(r.Context(), conflictID)
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "network conflicts failed", err.Error())
+		return
+	}
+	if conflict == nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusNotFound, "conflict not found", "")
+		return
+	}
+	if conflict.Type != "missing_parent" || !containsUUID(conflict.DiscoveredIDs, req.DiscoveredID) {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "placeholder parent can only be created for a selected missing_parent conflict resource", "")
+		return
+	}
+	res, err := ns.discStore.GetDiscoveredResource(r.Context(), req.DiscoveredID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrNotFound) {
+			status = http.StatusBadRequest
+		}
+		ns.srv.writeErr(r.Context(), w, status, "discovered resource not found", err.Error())
+		return
+	}
+	if res.ParentResourceID == nil || *res.ParentResourceID == "" {
+		ns.srv.writeErr(r.Context(), w, http.StatusBadRequest, "discovered resource does not reference a missing parent", "")
+		return
+	}
+	parentResourceID := *res.ParentResourceID
+	existing, err := ns.networkStore.ListNetworkObjects(r.Context(), domain.NetworkObjectFilters{AccountID: res.AccountID, Provider: res.Provider, Region: res.Region, ObjectType: string(domain.NetworkObjectTypeVPC)})
+	if err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "list network objects failed", err.Error())
+		return
+	}
+	var obj domain.NetworkObject
+	for _, candidate := range existing {
+		if candidate.ProviderResourceID == parentResourceID {
+			obj = candidate
+			break
+		}
+	}
+	if obj.ID == 0 {
+		name := firstNonEmpty(req.Name, parentResourceID)
+		obj, err = ns.networkStore.CreateNetworkObject(r.Context(), domain.CreateNetworkObject{
+			ObjectType:         domain.NetworkObjectTypeVPC,
+			Provider:           res.Provider,
+			AccountID:          res.AccountID,
+			Region:             res.Region,
+			Name:               name,
+			ProviderResourceID: parentResourceID,
+			State:              domain.NetworkObjectStatePlaceholder,
+			Metadata:           map[string]string{"created_from_conflict": conflict.ID},
+		})
+		if err != nil {
+			ns.srv.writeStoreErr(r.Context(), w, err)
+			return
+		}
+	}
+	actionDetails := map[string]string{
+		"network_conflict_action": "create_placeholder_parent",
+		"discovered_id":           req.DiscoveredID.String(),
+		"network_object_id":       fmt.Sprintf("%d", obj.ID),
+	}
+	resolveReq := domain.ResolveNetworkConflictRequest{
+		Decision: "defer",
+		Reason:   networkActionReason("create_placeholder_parent", req.Reason, actionDetails),
+	}
+	if err := ns.persistNetworkConflictActionResolution(r.Context(), *conflict, resolveReq, actionDetails); err != nil {
+		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "record conflict action failed", err.Error())
+		return
+	}
+	relationships := ns.persistNetworkConflictActionRelationships(r.Context(), "create_placeholder_parent", *conflict, []domain.CreateNetworkRelationship{
+		{
+			ID:              relationshipIDForConflict(conflict.ID, "network_object", fmt.Sprintf("%d", obj.ID), "discovered", req.DiscoveredID.String()),
+			Type:            domain.NetworkRelationshipContains,
+			SourceKind:      "network_object",
+			SourceID:        fmt.Sprintf("%d", obj.ID),
+			TargetKind:      "discovered",
+			TargetID:        req.DiscoveredID.String(),
+			Confidence:      0.75,
+			Reason:          networkActionReason("create_placeholder_parent", req.Reason, actionDetails),
+			Evidence:        append(conflict.Evidence, "placeholder_parent="+parentResourceID),
+			ResolutionState: "open",
+		},
+		{
+			ID:              relationshipIDForConflict(conflict.ID, "discovered", req.DiscoveredID.String(), "network_object", fmt.Sprintf("%d", obj.ID)),
+			Type:            domain.NetworkRelationshipMissingParent,
+			SourceKind:      "discovered",
+			SourceID:        req.DiscoveredID.String(),
+			TargetKind:      "network_object",
+			TargetID:        fmt.Sprintf("%d", obj.ID),
+			Confidence:      0.75,
+			Reason:          networkActionReason("create_placeholder_parent", req.Reason, actionDetails),
+			Evidence:        append(conflict.Evidence, "placeholder_parent="+parentResourceID),
+			ResolutionState: "open",
+		},
+	})
+	updated := ns.conflictAfterAction(r.Context(), *conflict, "create_placeholder_parent")
+	writeJSON(w, http.StatusOK, domain.NetworkConflictActionResponse{
+		Conflict:      updated,
+		Action:        "create_placeholder_parent",
+		DiscoveredID:  &req.DiscoveredID,
+		NetworkObject: &obj,
+		Relationships: relationships,
 	})
 }
 
@@ -395,6 +760,8 @@ type networkViewFilters struct {
 	status       string
 	conflictType string
 	query        string
+	schemaPolicy string
+	duplicates   string
 }
 
 type builtNetworkView struct {
@@ -412,6 +779,8 @@ func networkFiltersFromRequest(r *http.Request) networkViewFilters {
 		status:       q.Get("status"),
 		conflictType: q.Get("conflict_type"),
 		query:        strings.ToLower(strings.TrimSpace(q.Get("q"))),
+		schemaPolicy: strings.TrimSpace(q.Get("schema_policy")),
+		duplicates:   strings.TrimSpace(q.Get("duplicates")),
 	}
 	if idText := q.Get("account_id"); idText != "" {
 		if id, err := strconv.ParseInt(idText, 10, 64); err == nil {
@@ -419,6 +788,111 @@ func networkFiltersFromRequest(r *http.Request) networkViewFilters {
 		}
 	}
 	return filters
+}
+
+func networkObjectFiltersFromRequest(r *http.Request) domain.NetworkObjectFilters {
+	q := r.URL.Query()
+	filters := domain.NetworkObjectFilters{
+		Provider:   q.Get("provider"),
+		Region:     q.Get("region"),
+		ObjectType: q.Get("object_type"),
+		State:      q.Get("state"),
+		Query:      strings.ToLower(strings.TrimSpace(q.Get("q"))),
+	}
+	if idText := q.Get("account_id"); idText != "" {
+		if id, err := strconv.ParseInt(idText, 10, 64); err == nil {
+			filters.AccountID = id
+		}
+	}
+	return filters
+}
+
+func networkRelationshipFiltersFromRequest(r *http.Request) domain.NetworkRelationshipFilters {
+	q := r.URL.Query()
+	return domain.NetworkRelationshipFilters{
+		Type:            q.Get("type"),
+		SourceKind:      q.Get("source_kind"),
+		SourceID:        q.Get("source_id"),
+		TargetKind:      q.Get("target_kind"),
+		TargetID:        q.Get("target_id"),
+		ResolutionState: q.Get("resolution_state"),
+	}
+}
+
+func schemaPolicyFromFilters(filters networkViewFilters) domain.NetworkSchemaPolicy {
+	name := filters.schemaPolicy
+	if name == "" {
+		name = "account_level"
+	}
+	switch name {
+	case "region_level":
+		return domain.NetworkSchemaPolicy{Name: name, OwnershipStrategy: "region", DuplicateScope: "region", HierarchyScope: "region"}
+	case "global":
+		return domain.NetworkSchemaPolicy{Name: name, OwnershipStrategy: "global", DuplicateScope: "global", HierarchyScope: "global"}
+	case "custom", "manual":
+		policy := domain.NetworkSchemaPolicy{Name: name, OwnershipStrategy: "manual", DuplicateScope: "manual", HierarchyScope: "manual", ManualRelationships: true}
+		if filters.duplicates == "global" {
+			policy.DuplicateScope = "global"
+		}
+		return policy
+	default:
+		return domain.NetworkSchemaPolicy{Name: "account_level", OwnershipStrategy: "account", DuplicateScope: "account", HierarchyScope: "account"}
+	}
+}
+
+func duplicatePolicyKey(res domain.DiscoveredResource, policy domain.NetworkSchemaPolicy) string {
+	switch policy.DuplicateScope {
+	case "manual":
+		return ""
+	case "region":
+		return strings.Join([]string{res.CIDR, res.Region}, "|")
+	case "global":
+		return res.CIDR
+	default:
+		return res.CIDR
+	}
+}
+
+func duplicatePolicyConflict(matches []domain.DiscoveredResource, policy domain.NetworkSchemaPolicy) bool {
+	if len(matches) < 2 {
+		return false
+	}
+	switch policy.DuplicateScope {
+	case "manual":
+		return false
+	case "global", "region":
+		return true
+	default:
+		accountsSeen := map[int64]bool{}
+		for _, res := range matches {
+			accountsSeen[res.AccountID] = true
+		}
+		return len(accountsSeen) > 1
+	}
+}
+
+func relationshipsByEntity(relationships []domain.NetworkRelationship) map[string][]domain.NetworkRelationship {
+	out := map[string][]domain.NetworkRelationship{}
+	for _, rel := range relationships {
+		sourceKey := rel.SourceKind + ":" + rel.SourceID
+		targetKey := rel.TargetKind + ":" + rel.TargetID
+		out[sourceKey] = append(out[sourceKey], rel)
+		out[targetKey] = append(out[targetKey], rel)
+	}
+	return out
+}
+
+func attachRelationshipsToConflicts(conflicts []domain.NetworkConflict, relationships []domain.NetworkRelationship) []domain.NetworkConflict {
+	byConflictID := map[string][]domain.NetworkRelationship{}
+	for _, rel := range relationships {
+		if rel.TargetKind == "conflict" {
+			byConflictID[rel.TargetID] = append(byConflictID[rel.TargetID], rel)
+		}
+	}
+	for i := range conflicts {
+		conflicts[i].Relationships = append(conflicts[i].Relationships, byConflictID[conflicts[i].ID]...)
+	}
+	return conflicts
 }
 
 func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkViewFilters) (builtNetworkView, error) {
@@ -444,16 +918,32 @@ func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkVi
 	if err != nil {
 		return builtNetworkView{}, err
 	}
+	var networkObjects []domain.NetworkObject
+	var relationships []domain.NetworkRelationship
+	if ns.networkStore != nil {
+		networkObjects, err = ns.networkStore.ListNetworkObjects(ctx, domain.NetworkObjectFilters{})
+		if err != nil {
+			return builtNetworkView{}, err
+		}
+		relationships, err = ns.networkStore.ListNetworkRelationships(ctx, domain.NetworkRelationshipFilters{})
+		if err != nil {
+			return builtNetworkView{}, err
+		}
+	}
+	relsByEntity := relationshipsByEntity(relationships)
 	resourceByProvider := make(map[string]domain.DiscoveredResource, len(resources))
 	for _, res := range resources {
 		resourceByProvider[resourceKey(res.AccountID, res.ResourceID)] = res
 	}
 
-	issuesByNode, conflicts := ns.computeNetworkConflicts(resources, pools, accountByID, poolByID, resourceByProvider)
+	issuesByNode, conflicts := ns.computeNetworkConflicts(resources, pools, accountByID, poolByID, resourceByProvider, schemaPolicyFromFilters(filters))
+	ns.persistComputedNetworkRelationships(ctx, conflicts)
 	conflicts = ns.applyStoredConflictResolutions(ctx, conflicts)
-	nodes := make([]domain.NetworkNode, 0, len(pools)+len(resources)+len(accounts))
+	conflicts = attachRelationshipsToConflicts(conflicts, relationships)
+	nodes := make([]domain.NetworkNode, 0, len(pools)+len(resources)+len(networkObjects)+len(accounts))
 	for _, pool := range pools {
 		node := networkNodeFromPool(pool, accountByID)
+		node.Relationships = relsByEntity["pool:"+fmt.Sprintf("%d", pool.ID)]
 		if nodeIssues := issuesByNode[node.ID]; len(nodeIssues) > 0 {
 			node.Issues = append(node.Issues, nodeIssues...)
 			node.State = "conflict"
@@ -462,10 +952,16 @@ func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkVi
 	}
 	for _, res := range resources {
 		node := ns.networkNodeFromResource(res, accountByID, poolByID, resourceByProvider)
+		node.Relationships = relsByEntity["discovered:"+res.ID.String()]
 		if nodeIssues := issuesByNode[node.ID]; len(nodeIssues) > 0 {
 			node.Issues = append(node.Issues, nodeIssues...)
 			node.State = worstNodeState(node.State, nodeIssues)
 		}
+		nodes = append(nodes, node)
+	}
+	for _, obj := range networkObjects {
+		node := networkNodeFromNetworkObject(obj, accountByID)
+		node.Relationships = relsByEntity["network_object:"+fmt.Sprintf("%d", obj.ID)]
 		nodes = append(nodes, node)
 	}
 
@@ -589,7 +1085,41 @@ func (ns *NetworkServer) networkNodeFromResource(res domain.DiscoveredResource, 
 	return node
 }
 
-func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredResource, pools []domain.Pool, accounts map[int64]domain.Account, poolByID map[int64]domain.Pool, resourceByProvider map[string]domain.DiscoveredResource) (map[string][]domain.NetworkIssue, []domain.NetworkConflict) {
+func networkNodeFromNetworkObject(obj domain.NetworkObject, accounts map[int64]domain.Account) domain.NetworkNode {
+	nodeID := networkObjectNodeID(obj.ID)
+	node := domain.NetworkNode{
+		ID:                 nodeID,
+		Kind:               "network_object",
+		ObjectType:         string(obj.ObjectType),
+		Name:               obj.Name,
+		CIDR:               obj.CIDR,
+		IPAddress:          obj.IPAddress,
+		Provider:           obj.Provider,
+		AccountID:          &obj.AccountID,
+		Region:             obj.Region,
+		ProviderResourceID: obj.ProviderResourceID,
+		LinkedPoolID:       obj.PoolID,
+		Source:             "managed",
+		State:              string(obj.State),
+		Evidence:           []string{"managed_network_object=true"},
+	}
+	if account, ok := accounts[obj.AccountID]; ok {
+		node.AccountName = account.Name
+		if node.Provider == "" {
+			node.Provider = account.Provider
+		}
+	}
+	if obj.ParentObjectID != nil {
+		parentID := networkObjectNodeID(*obj.ParentObjectID)
+		node.ParentID = &parentID
+	} else if obj.PoolID != nil {
+		parentID := poolNodeID(*obj.PoolID)
+		node.ParentID = &parentID
+	}
+	return node
+}
+
+func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredResource, pools []domain.Pool, accounts map[int64]domain.Account, poolByID map[int64]domain.Pool, resourceByProvider map[string]domain.DiscoveredResource, policy domain.NetworkSchemaPolicy) (map[string][]domain.NetworkIssue, []domain.NetworkConflict) {
 	issuesByNode := map[string][]domain.NetworkIssue{}
 	var conflicts []domain.NetworkConflict
 	add := func(conflict domain.NetworkConflict) {
@@ -601,10 +1131,12 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 		}
 	}
 
-	resourcesByCIDR := map[string][]domain.DiscoveredResource{}
+	resourcesByDuplicateKey := map[string][]domain.DiscoveredResource{}
 	for _, res := range resources {
 		if res.CIDR != "" {
-			resourcesByCIDR[res.CIDR] = append(resourcesByCIDR[res.CIDR], res)
+			if key := duplicatePolicyKey(res, policy); key != "" {
+				resourcesByDuplicateKey[key] = append(resourcesByDuplicateKey[key], res)
+			}
 		}
 	}
 
@@ -647,7 +1179,7 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 					Regions:           []string{res.Region},
 					ObjectTypes:       []string{string(res.ResourceType)},
 					CIDR:              res.CIDR,
-					Evidence:          []string{"parent_provider_resource_id=" + *res.ParentResourceID},
+					Evidence:          []string{"parent_provider_resource_id=" + *res.ParentResourceID, "policy=" + policy.Name},
 				})
 			} else if res.CIDR != "" && parent.CIDR != "" && !networkCIDRContains(parent.CIDR, res.CIDR) {
 				add(domain.NetworkConflict{
@@ -664,7 +1196,7 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 					Regions:           []string{res.Region},
 					ObjectTypes:       []string{string(res.ResourceType), string(parent.ResourceType)},
 					CIDR:              res.CIDR,
-					Evidence:          []string{fmt.Sprintf("parent_cidr=%s", parent.CIDR)},
+					Evidence:          []string{fmt.Sprintf("parent_cidr=%s", parent.CIDR), "policy=" + policy.Name},
 				})
 			}
 		}
@@ -750,12 +1282,16 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 		}
 	}
 
-	for cidr, matches := range resourcesByCIDR {
+	for duplicateKey, matches := range resourcesByDuplicateKey {
+		if !duplicatePolicyConflict(matches, policy) {
+			continue
+		}
+		cidr := matches[0].CIDR
 		accountsSeen := map[int64]bool{}
 		for _, res := range matches {
 			accountsSeen[res.AccountID] = true
 		}
-		if len(accountsSeen) < 2 {
+		if len(matches) < 2 {
 			continue
 		}
 		nodeIDs := make([]string, 0, len(matches))
@@ -776,8 +1312,9 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 			accountName := accounts[res.AccountID].Name
 			evidence = append(evidence, fmt.Sprintf("%s in %s (%s)", res.ResourceID, firstNonEmpty(accountName, fmt.Sprintf("account %d", res.AccountID)), res.Region))
 		}
+		evidence = append(evidence, "policy="+policy.Name, "duplicate_scope="+policy.DuplicateScope)
 		add(domain.NetworkConflict{
-			ID:                "duplicate-cidr:" + strings.ReplaceAll(cidr, "/", "_"),
+			ID:                "duplicate-cidr:" + policy.DuplicateScope + ":" + strings.NewReplacer("/", "_", "|", ":").Replace(duplicateKey),
 			Type:              "duplicate_cidr",
 			Severity:          "critical",
 			Status:            "open",
@@ -969,6 +1506,113 @@ func (ns *NetworkServer) conflictAfterAction(ctx context.Context, fallback domai
 	fallback.ResolutionState = fallback.Status
 	fallback.ResolutionRequested = action
 	return fallback
+}
+
+func (ns *NetworkServer) persistComputedNetworkRelationships(ctx context.Context, conflicts []domain.NetworkConflict) {
+	if ns.networkStore == nil {
+		return
+	}
+	for _, conflict := range conflicts {
+		for _, rel := range relationshipsFromConflict(conflict) {
+			_, _ = ns.networkStore.UpsertNetworkRelationship(ctx, rel)
+		}
+	}
+}
+
+func relationshipsFromConflict(conflict domain.NetworkConflict) []domain.CreateNetworkRelationship {
+	relationshipType := domain.NetworkRelationshipConflicts
+	switch conflict.Type {
+	case "missing_parent":
+		relationshipType = domain.NetworkRelationshipMissingParent
+	case "duplicate_cidr":
+		relationshipType = domain.NetworkRelationshipDuplicateOf
+	case "unlinked_exact_pool":
+		relationshipType = domain.NetworkRelationshipMatches
+	case "managed_overlap", "linked_pool_mismatch", "outside_pool", "invalid_nesting", "invalid_cidr":
+		relationshipType = domain.NetworkRelationshipConflicts
+	}
+	var rels []domain.CreateNetworkRelationship
+	for _, discoveredID := range conflict.DiscoveredIDs {
+		if len(conflict.PoolIDs) == 0 {
+			rels = append(rels, domain.CreateNetworkRelationship{
+				ID:         relationshipIDForConflict(conflict.ID, "discovered", discoveredID.String(), "conflict", conflict.ID),
+				Type:       relationshipType,
+				SourceKind: "discovered",
+				SourceID:   discoveredID.String(),
+				TargetKind: "conflict",
+				TargetID:   conflict.ID,
+				Confidence: 1,
+				Reason:     conflict.Title,
+				Evidence:   conflict.Evidence,
+			})
+			continue
+		}
+		for _, poolID := range conflict.PoolIDs {
+			rels = append(rels, domain.CreateNetworkRelationship{
+				ID:         relationshipIDForConflict(conflict.ID, "discovered", discoveredID.String(), "pool", fmt.Sprintf("%d", poolID)),
+				Type:       relationshipType,
+				SourceKind: "discovered",
+				SourceID:   discoveredID.String(),
+				TargetKind: "pool",
+				TargetID:   fmt.Sprintf("%d", poolID),
+				Confidence: 1,
+				Reason:     conflict.Title,
+				Evidence:   conflict.Evidence,
+			})
+		}
+	}
+	if conflict.Type == "duplicate_cidr" {
+		for i := 0; i < len(conflict.DiscoveredIDs); i++ {
+			for j := i + 1; j < len(conflict.DiscoveredIDs); j++ {
+				rels = append(rels, domain.CreateNetworkRelationship{
+					ID:         relationshipIDForConflict(conflict.ID, "discovered", conflict.DiscoveredIDs[i].String(), "discovered", conflict.DiscoveredIDs[j].String()),
+					Type:       domain.NetworkRelationshipDuplicateOf,
+					SourceKind: "discovered",
+					SourceID:   conflict.DiscoveredIDs[i].String(),
+					TargetKind: "discovered",
+					TargetID:   conflict.DiscoveredIDs[j].String(),
+					Confidence: 1,
+					Reason:     conflict.Title,
+					Evidence:   conflict.Evidence,
+				})
+			}
+		}
+	}
+	return rels
+}
+
+func relationshipIDForConflict(conflictID, sourceKind, sourceID, targetKind, targetID string) string {
+	raw := strings.Join([]string{"conflict", conflictID, sourceKind, sourceID, targetKind, targetID}, "\x00")
+	sum := sha1.Sum([]byte(raw))
+	return "rel-" + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func (ns *NetworkServer) persistNetworkConflictActionRelationships(ctx context.Context, action string, conflict domain.NetworkConflict, inputs []domain.CreateNetworkRelationship) []domain.NetworkRelationship {
+	if ns.networkStore == nil {
+		return nil
+	}
+	if len(inputs) == 0 {
+		inputs = []domain.CreateNetworkRelationship{{
+			ID:              relationshipIDForConflict(conflict.ID, "conflict", conflict.ID, "action", action),
+			Type:            domain.NetworkRelationshipConflicts,
+			SourceKind:      "conflict",
+			SourceID:        conflict.ID,
+			TargetKind:      "action",
+			TargetID:        action,
+			Confidence:      1,
+			Reason:          "action=" + action,
+			Evidence:        conflict.Evidence,
+			ResolutionState: conflict.Status,
+		}}
+	}
+	out := make([]domain.NetworkRelationship, 0, len(inputs))
+	for _, in := range inputs {
+		rel, err := ns.networkStore.UpsertNetworkRelationship(ctx, in)
+		if err == nil {
+			out = append(out, rel)
+		}
+	}
+	return out
 }
 
 func validateNetworkConflictLinkAction(conflict domain.NetworkConflict, res domain.DiscoveredResource, pool domain.Pool, req domain.NetworkConflictLinkActionRequest) error {
@@ -1253,6 +1897,8 @@ func driftSeverityFromNetwork(severity string) domain.DriftSeverity {
 func poolNodeID(id int64) string { return fmt.Sprintf("pool:%d", id) }
 
 func resourceNodeID(id uuid.UUID) string { return "discovered:" + id.String() }
+
+func networkObjectNodeID(id int64) string { return fmt.Sprintf("network_object:%d", id) }
 
 func resourceKey(accountID int64, providerResourceID string) string {
 	return fmt.Sprintf("%d:%s", accountID, providerResourceID)

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -883,16 +883,38 @@ func relationshipsByEntity(relationships []domain.NetworkRelationship) map[strin
 }
 
 func attachRelationshipsToConflicts(conflicts []domain.NetworkConflict, relationships []domain.NetworkRelationship) []domain.NetworkConflict {
-	byConflictID := map[string][]domain.NetworkRelationship{}
-	for _, rel := range relationships {
-		if rel.TargetKind == "conflict" {
-			byConflictID[rel.TargetID] = append(byConflictID[rel.TargetID], rel)
+	for i := range conflicts {
+		for _, rel := range relationships {
+			if relationshipMatchesConflict(rel, conflicts[i]) {
+				conflicts[i].Relationships = append(conflicts[i].Relationships, rel)
+			}
 		}
 	}
-	for i := range conflicts {
-		conflicts[i].Relationships = append(conflicts[i].Relationships, byConflictID[conflicts[i].ID]...)
-	}
 	return conflicts
+}
+
+func relationshipMatchesConflict(rel domain.NetworkRelationship, conflict domain.NetworkConflict) bool {
+	if rel.TargetKind == "conflict" && rel.TargetID == conflict.ID {
+		return true
+	}
+	matches := func(kind string, id string) bool {
+		switch kind {
+		case "discovered":
+			for _, discoveredID := range conflict.DiscoveredIDs {
+				if id == discoveredID.String() {
+					return true
+				}
+			}
+		case "pool":
+			for _, poolID := range conflict.PoolIDs {
+				if id == fmt.Sprintf("%d", poolID) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return matches(rel.SourceKind, rel.SourceID) || matches(rel.TargetKind, rel.TargetID)
 }
 
 func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkViewFilters) (builtNetworkView, error) {
@@ -919,18 +941,12 @@ func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkVi
 		return builtNetworkView{}, err
 	}
 	var networkObjects []domain.NetworkObject
-	var relationships []domain.NetworkRelationship
 	if ns.networkStore != nil {
 		networkObjects, err = ns.networkStore.ListNetworkObjects(ctx, domain.NetworkObjectFilters{})
 		if err != nil {
 			return builtNetworkView{}, err
 		}
-		relationships, err = ns.networkStore.ListNetworkRelationships(ctx, domain.NetworkRelationshipFilters{})
-		if err != nil {
-			return builtNetworkView{}, err
-		}
 	}
-	relsByEntity := relationshipsByEntity(relationships)
 	resourceByProvider := make(map[string]domain.DiscoveredResource, len(resources))
 	for _, res := range resources {
 		resourceByProvider[resourceKey(res.AccountID, res.ResourceID)] = res
@@ -939,6 +955,14 @@ func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkVi
 	issuesByNode, conflicts := ns.computeNetworkConflicts(resources, pools, accountByID, poolByID, resourceByProvider, schemaPolicyFromFilters(filters))
 	ns.persistComputedNetworkRelationships(ctx, conflicts)
 	conflicts = ns.applyStoredConflictResolutions(ctx, conflicts)
+	var relationships []domain.NetworkRelationship
+	if ns.networkStore != nil {
+		relationships, err = ns.networkStore.ListNetworkRelationships(ctx, domain.NetworkRelationshipFilters{})
+		if err != nil {
+			return builtNetworkView{}, err
+		}
+	}
+	relsByEntity := relationshipsByEntity(relationships)
 	conflicts = attachRelationshipsToConflicts(conflicts, relationships)
 	nodes := make([]domain.NetworkNode, 0, len(pools)+len(resources)+len(networkObjects)+len(accounts))
 	for _, pool := range pools {

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -884,8 +884,13 @@ func relationshipsByEntity(relationships []domain.NetworkRelationship) map[strin
 
 func attachRelationshipsToConflicts(conflicts []domain.NetworkConflict, relationships []domain.NetworkRelationship) []domain.NetworkConflict {
 	for i := range conflicts {
+		expectedIDs := relationshipIDsForConflict(conflicts[i])
 		for _, rel := range relationships {
-			if relationshipMatchesConflict(rel, conflicts[i]) {
+			if rel.TargetKind == "conflict" && rel.TargetID == conflicts[i].ID {
+				conflicts[i].Relationships = append(conflicts[i].Relationships, rel)
+				continue
+			}
+			if _, ok := expectedIDs[rel.ID]; ok {
 				conflicts[i].Relationships = append(conflicts[i].Relationships, rel)
 			}
 		}
@@ -893,28 +898,14 @@ func attachRelationshipsToConflicts(conflicts []domain.NetworkConflict, relation
 	return conflicts
 }
 
-func relationshipMatchesConflict(rel domain.NetworkRelationship, conflict domain.NetworkConflict) bool {
-	if rel.TargetKind == "conflict" && rel.TargetID == conflict.ID {
-		return true
-	}
-	matches := func(kind string, id string) bool {
-		switch kind {
-		case "discovered":
-			for _, discoveredID := range conflict.DiscoveredIDs {
-				if id == discoveredID.String() {
-					return true
-				}
-			}
-		case "pool":
-			for _, poolID := range conflict.PoolIDs {
-				if id == fmt.Sprintf("%d", poolID) {
-					return true
-				}
-			}
+func relationshipIDsForConflict(conflict domain.NetworkConflict) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, rel := range relationshipsFromConflict(conflict) {
+		if rel.ID != "" {
+			out[rel.ID] = struct{}{}
 		}
-		return false
 	}
-	return matches(rel.SourceKind, rel.SourceID) || matches(rel.TargetKind, rel.TargetID)
+	return out
 }
 
 func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkViewFilters) (builtNetworkView, error) {

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -62,6 +62,184 @@ func TestNetworkFlatShowsDiscoveredObjectsAndDuplicateConflict(t *testing.T) {
 	}
 }
 
+func TestNetworkObjectsCreateUpdateAndAppearInMergedView(t *testing.T) {
+	discSrv, st, _, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"object_type":"vpc","provider":"aws","account_id":%d,"region":"us-east-1","name":"managed-vpc","cidr":"10.60.0.0/16","provider_resource_id":"vpc-managed"}`, account.ID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/objects", body, http.StatusCreated)
+	var obj domain.NetworkObject
+	if err := json.Unmarshal(rr.Body.Bytes(), &obj); err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+	if obj.ID == 0 || obj.ObjectType != domain.NetworkObjectTypeVPC || obj.State != domain.NetworkObjectStateManaged {
+		t.Fatalf("unexpected created object: %+v", obj)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPatch, fmt.Sprintf("/api/v1/network/objects/%d", obj.ID), `{"state":"imported","name":"renamed-vpc"}`, http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &obj); err != nil {
+		t.Fatalf("unmarshal updated object: %v", err)
+	}
+	if obj.Name != "renamed-vpc" || obj.State != domain.NetworkObjectStateImported {
+		t.Fatalf("object update did not apply: %+v", obj)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/flat?object_type=vpc", "", http.StatusOK)
+	var view domain.NetworkViewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &view); err != nil {
+		t.Fatalf("unmarshal view: %v", err)
+	}
+	var sawManaged bool
+	for _, item := range view.Items {
+		if item.Kind == "network_object" && item.Name == "renamed-vpc" && item.CIDR == "10.60.0.0/16" {
+			sawManaged = true
+		}
+	}
+	if !sawManaged {
+		t.Fatalf("managed network object missing from merged view: %+v", view.Items)
+	}
+}
+
+func TestNetworkRelationshipsCreateFilterResolveAndAttachToMergedView(t *testing.T) {
+	discSrv, st, _, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	objBody := fmt.Sprintf(`{"object_type":"network","provider":"aws","account_id":%d,"name":"managed-net"}`, account.ID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/objects", objBody, http.StatusCreated)
+	var obj domain.NetworkObject
+	if err := json.Unmarshal(rr.Body.Bytes(), &obj); err != nil {
+		t.Fatalf("unmarshal object: %v", err)
+	}
+
+	relBody := fmt.Sprintf(`{"id":"rel-test","type":"contains","source_kind":"network_object","source_id":"%d","target_kind":"pool","target_id":"42","confidence":0.5,"evidence":["manual"]}`, obj.ID)
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/relationships", relBody, http.StatusCreated)
+	var rel domain.NetworkRelationship
+	if err := json.Unmarshal(rr.Body.Bytes(), &rel); err != nil {
+		t.Fatalf("unmarshal relationship: %v", err)
+	}
+	if rel.ID != "rel-test" || rel.ResolutionState != "open" {
+		t.Fatalf("unexpected relationship: %+v", rel)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/relationships?type=contains&source_kind=network_object", "", http.StatusOK)
+	var rels domain.NetworkRelationshipListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &rels); err != nil {
+		t.Fatalf("unmarshal relationships: %v", err)
+	}
+	if rels.Total != 1 {
+		t.Fatalf("relationship filter returned %+v", rels)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/relationships/rel-test/resolve", `{"resolution_state":"resolved","reason":"accepted"}`, http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &rel); err != nil {
+		t.Fatalf("unmarshal resolved relationship: %v", err)
+	}
+	if rel.ResolutionState != "resolved" || rel.Reason != "accepted" {
+		t.Fatalf("relationship resolution did not persist: %+v", rel)
+	}
+
+	slashIDBody := fmt.Sprintf(`{"id":"tenant/a","type":"contains","source_kind":"network_object","source_id":"%d","target_kind":"pool","target_id":"43","confidence":0.5}`, obj.ID)
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/relationships", slashIDBody, http.StatusCreated)
+	if err := json.Unmarshal(rr.Body.Bytes(), &rel); err != nil {
+		t.Fatalf("unmarshal slash relationship: %v", err)
+	}
+	if rel.ID != "tenant/a" {
+		t.Fatalf("caller relationship ID with slash was not preserved: %+v", rel)
+	}
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/relationships/resolve", `{"id":"tenant/a","resolution_state":"ignored","reason":"body lookup"}`, http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &rel); err != nil {
+		t.Fatalf("unmarshal body-resolved relationship: %v", err)
+	}
+	if rel.ResolutionState != "ignored" || rel.Reason != "body lookup" {
+		t.Fatalf("body relationship resolution did not persist: %+v", rel)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/flat?q=managed-net", "", http.StatusOK)
+	var view domain.NetworkViewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &view); err != nil {
+		t.Fatalf("unmarshal view: %v", err)
+	}
+	if len(view.Items) != 1 {
+		t.Fatalf("relationship not attached to merged node: %+v", view.Items)
+	}
+	var sawResolved, sawIgnored bool
+	for _, rel := range view.Items[0].Relationships {
+		if rel.ID == "rel-test" && rel.ResolutionState == "resolved" {
+			sawResolved = true
+		}
+		if rel.ID == "tenant/a" && rel.ResolutionState == "ignored" {
+			sawIgnored = true
+		}
+	}
+	if !sawResolved || !sawIgnored {
+		t.Fatalf("relationships not attached to merged node: %+v", view.Items[0].Relationships)
+	}
+}
+
+func TestComputedNetworkRelationshipResolutionSurvivesRecompute(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	_, err = st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-vpc", CIDR: "10.61.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	vpcID := uuid.New()
+	now := time.Now().UTC()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-prod",
+		CIDR:         "10.61.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+
+	doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/relationships?source_kind=discovered&source_id="+vpcID.String(), "", http.StatusOK)
+	var rels domain.NetworkRelationshipListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &rels); err != nil {
+		t.Fatalf("unmarshal relationships: %v", err)
+	}
+	if rels.Total == 0 {
+		t.Fatalf("expected computed relationship")
+	}
+	relID := rels.Items[0].ID
+	if strings.ContainsAny(relID, "/?#") {
+		t.Fatalf("server-generated relationship ID is not URL-safe: %q", relID)
+	}
+	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/relationships/"+relID+"/resolve", `{"resolution_state":"resolved","reason":"accepted"}`, http.StatusOK)
+	doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/relationships?source_kind=discovered&source_id="+vpcID.String(), "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &rels); err != nil {
+		t.Fatalf("unmarshal relationships after recompute: %v", err)
+	}
+	var found bool
+	for _, rel := range rels.Items {
+		if rel.ID == relID {
+			found = true
+			if rel.ResolutionState != "resolved" {
+				t.Fatalf("computed relationship state was overwritten: %+v", rel)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("computed relationship not found after recompute: %+v", rels.Items)
+	}
+}
+
 func TestNetworkHierarchyPlacesVPCUnderPoolAndSubnetUnderVPC(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
@@ -151,6 +329,103 @@ func TestNetworkConflictsExposeMissingParentAndResolveRequest(t *testing.T) {
 	}
 }
 
+func TestNetworkConflictCreatePlaceholderParentAction(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	now := time.Now().UTC()
+	subnetID := uuid.New()
+	parent := "vpc-placeholder"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:               subnetID,
+		AccountID:        account.ID,
+		Provider:         "aws",
+		Region:           "us-east-1",
+		ResourceType:     domain.ResourceTypeSubnet,
+		ResourceID:       "subnet-1",
+		Name:             "orphan-subnet",
+		CIDR:             "10.91.1.0/24",
+		ParentResourceID: &parent,
+		Status:           domain.DiscoveryStatusActive,
+		DiscoveredAt:     now,
+		LastSeenAt:       now,
+	})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected missing-parent conflict, got %+v", conflicts)
+	}
+
+	body := fmt.Sprintf(`{"discovered_id":"%s","name":"placeholder-vpc","reason":"parent not yet scanned"}`, subnetID)
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/create_placeholder_parent", conflicts.Items[0].ID), body, http.StatusOK)
+	var action domain.NetworkConflictActionResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &action); err != nil {
+		t.Fatalf("unmarshal action: %v", err)
+	}
+	if action.Action != "create_placeholder_parent" || action.NetworkObject == nil || action.NetworkObject.State != domain.NetworkObjectStatePlaceholder {
+		t.Fatalf("unexpected placeholder action: %+v", action)
+	}
+	if len(action.Relationships) != 2 {
+		t.Fatalf("expected placeholder relationships, got %+v", action.Relationships)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/objects?state=placeholder", "", http.StatusOK)
+	var objects domain.NetworkObjectListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &objects); err != nil {
+		t.Fatalf("unmarshal objects: %v", err)
+	}
+	if objects.Total != 1 || objects.Items[0].ProviderResourceID != parent {
+		t.Fatalf("placeholder object not durable/listable: %+v", objects)
+	}
+}
+
+func TestNetworkSchemaPolicyChangesDuplicateDetection(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	now := time.Now().UTC()
+	for _, res := range []domain.DiscoveredResource{
+		{ID: uuid.New(), AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-east", CIDR: "10.92.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
+		{ID: uuid.New(), AccountID: account.ID, Provider: "aws", Region: "us-west-2", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-west", CIDR: "10.92.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
+	} {
+		upsertDiscoveredForImportTest(t, ds, res)
+	}
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=duplicate_cidr", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal default conflicts: %v", err)
+	}
+	if conflicts.Total != 0 {
+		t.Fatalf("account-level policy should allow same-CIDR reuse inside one account, got %+v", conflicts)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=duplicate_cidr&schema_policy=global", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal global conflicts: %v", err)
+	}
+	if conflicts.Total != 1 || !strings.Contains(strings.Join(conflicts.Items[0].Evidence, ","), "policy=global") {
+		t.Fatalf("global policy should flag duplicate with evidence, got %+v", conflicts)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=duplicate_cidr&schema_policy=manual", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal manual conflicts: %v", err)
+	}
+	if conflicts.Total != 0 {
+		t.Fatalf("manual policy should suppress duplicate conflicts, got %+v", conflicts)
+	}
+}
+
 func TestNetworkConflictRoutesAppearInOpenAPISpec(t *testing.T) {
 	discSrv, _, _, _ := setupDiscoveryTestServer()
 
@@ -166,9 +441,14 @@ func TestNetworkConflictRoutesAppearInOpenAPISpec(t *testing.T) {
 		`"/api/v1/network/conflicts/{conflictId}/resolve":`,
 		`"/api/v1/network/conflicts/{conflictId}/actions/link":`,
 		`"/api/v1/network/conflicts/{conflictId}/actions/import":`,
+		`"/api/v1/network/conflicts/{conflictId}/actions/create_placeholder_parent":`,
+		`"/api/v1/network/objects":`,
+		`"/api/v1/network/relationships":`,
+		`"/api/v1/network/relationships/resolve":`,
 		`$ref: '#/components/schemas/ResolveNetworkConflictRequest'`,
 		`$ref: '#/components/schemas/NetworkConflictLinkActionRequest'`,
 		`$ref: '#/components/schemas/NetworkConflictImportActionRequest'`,
+		`$ref: '#/components/schemas/NetworkConflictPlaceholderParentActionRequest'`,
 		`$ref: '#/components/schemas/NetworkConflictActionResponse'`,
 	} {
 		if !strings.Contains(body, want) {

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -247,6 +247,71 @@ func TestComputedNetworkRelationshipResolutionSurvivesRecompute(t *testing.T) {
 	}
 }
 
+func TestNetworkConflictResponseExcludesUnrelatedEntityRelationships(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	pool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-vpc", CIDR: "10.62.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	vpcID := uuid.New()
+	now := time.Now().UTC()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-prod",
+		CIDR:         "10.62.0.0/16",
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+
+	unrelated := fmt.Sprintf(`{"id":"manual-rel","type":"contains","source_kind":"discovered","source_id":"%s","target_kind":"pool","target_id":"%d","reason":"manual note"}`, vpcID, pool.ID)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/relationships", unrelated, http.StatusCreated)
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected conflict, got %+v", conflicts)
+	}
+	if len(conflicts.Items[0].Relationships) == 0 {
+		t.Fatalf("expected computed conflict relationship")
+	}
+	for _, rel := range conflicts.Items[0].Relationships {
+		if rel.ID == "manual-rel" {
+			t.Fatalf("unrelated manual relationship attached to conflict response: %+v", conflicts.Items[0].Relationships)
+		}
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/flat?q=vpc-prod", "", http.StatusOK)
+	var view domain.NetworkViewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &view); err != nil {
+		t.Fatalf("unmarshal flat view: %v", err)
+	}
+	var sawManualOnNode bool
+	for _, item := range view.Items {
+		if item.DiscoveredID != nil && *item.DiscoveredID == vpcID {
+			for _, rel := range item.Relationships {
+				if rel.ID == "manual-rel" {
+					sawManualOnNode = true
+				}
+			}
+		}
+	}
+	if !sawManualOnNode {
+		t.Fatalf("node-level relationship attachment should still include manual relationship: %+v", view.Items)
+	}
+}
+
 func TestNetworkHierarchyPlacesVPCUnderPoolAndSubnetUnderVPC(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -206,8 +206,15 @@ func TestComputedNetworkRelationshipResolutionSurvivesRecompute(t *testing.T) {
 		LastSeenAt:   now,
 	})
 
-	doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
-	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/relationships?source_kind=discovered&source_id="+vpcID.String(), "", http.StatusOK)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 || len(conflicts.Items[0].Relationships) == 0 {
+		t.Fatalf("computed relationships missing from first conflict response: %+v", conflicts)
+	}
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/relationships?source_kind=discovered&source_id="+vpcID.String(), "", http.StatusOK)
 	var rels domain.NetworkRelationshipListResponse
 	if err := json.Unmarshal(rr.Body.Bytes(), &rels); err != nil {
 		t.Fatalf("unmarshal relationships: %v", err)

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -793,6 +793,21 @@ func openAPIRoutesForPattern(pattern string) []openAPIRoute {
 			{http.MethodPost, "/api/v1/network/conflicts/{conflictId}/resolve"},
 			{http.MethodPost, "/api/v1/network/conflicts/{conflictId}/actions/link"},
 			{http.MethodPost, "/api/v1/network/conflicts/{conflictId}/actions/import"},
+			{http.MethodPost, "/api/v1/network/conflicts/{conflictId}/actions/create_placeholder_parent"},
+		})
+	case "/api/v1/network/objects":
+		return routesForMethodsPath([]string{http.MethodGet, http.MethodPost}, "/api/v1/network/objects")
+	case "/api/v1/network/objects/":
+		return routesForKnown([][2]string{
+			{http.MethodGet, "/api/v1/network/objects/{objectId}"},
+			{http.MethodPatch, "/api/v1/network/objects/{objectId}"},
+		})
+	case "/api/v1/network/relationships":
+		return routesForMethodsPath([]string{http.MethodGet, http.MethodPost}, "/api/v1/network/relationships")
+	case "/api/v1/network/relationships/":
+		return routesForKnown([][2]string{
+			{http.MethodPost, "/api/v1/network/relationships/resolve"},
+			{http.MethodPost, "/api/v1/network/relationships/{relationshipId}/resolve"},
 		})
 	case "/api/v1/analysis":
 		return routesForMethodPath(http.MethodPost, "/api/v1/analysis")
@@ -906,16 +921,23 @@ func splitMethodPattern(pattern string) (string, string, bool) {
 	if len(parts) != 2 {
 		return "", "", false
 	}
-	path := normalizeOpenAPIPath(parts[1])
+	rawPath := strings.TrimSpace(parts[1])
+	path := normalizeOpenAPIPath(rawPath)
 	switch path {
 	case "/api/v1/ai/sessions/{id}/apply-plan":
 		path = "/api/v1/ai/sessions/{sessionId}/apply-plan"
+	case "/api/v1/network/objects":
+		if strings.HasSuffix(rawPath, "/") {
+			path = "/api/v1/network/objects/{objectId}"
+		}
 	case "/api/v1/network/conflicts/{id}/resolve":
 		path = "/api/v1/network/conflicts/{conflictId}/resolve"
 	case "/api/v1/network/conflicts/{id}/actions/link":
 		path = "/api/v1/network/conflicts/{conflictId}/actions/link"
 	case "/api/v1/network/conflicts/{id}/actions/import":
 		path = "/api/v1/network/conflicts/{conflictId}/actions/import"
+	case "/api/v1/network/conflicts/{id}/actions/create_placeholder_parent":
+		path = "/api/v1/network/conflicts/{conflictId}/actions/create_placeholder_parent"
 	case "/api/v1/settings/oidc/providers/{id}":
 		path = "/api/v1/settings/oidc/providers/{providerId}"
 	case "/api/v1/settings/oidc/providers/{id}/test":
@@ -1027,6 +1049,15 @@ func openAPIOperationCatalog() map[string]openAPIRoute {
 		{Method: "POST", Path: "/api/v1/network/conflicts/{conflictId}/resolve", Summary: "Record passive network conflict decision", Tag: "Network", RequestSchema: "ResolveNetworkConflictRequest", ResponseSchema: "NetworkConflict"},
 		{Method: "POST", Path: "/api/v1/network/conflicts/{conflictId}/actions/link", Summary: "Link network conflict resource to pool", Tag: "Network", RequestSchema: "NetworkConflictLinkActionRequest", ResponseSchema: "NetworkConflictActionResponse"},
 		{Method: "POST", Path: "/api/v1/network/conflicts/{conflictId}/actions/import", Summary: "Import network conflict resources as pools", Tag: "Network", RequestSchema: "NetworkConflictImportActionRequest", ResponseSchema: "NetworkConflictActionResponse"},
+		{Method: "POST", Path: "/api/v1/network/conflicts/{conflictId}/actions/create_placeholder_parent", Summary: "Create placeholder parent network object", Tag: "Network", RequestSchema: "NetworkConflictPlaceholderParentActionRequest", ResponseSchema: "NetworkConflictActionResponse"},
+		{Method: "GET", Path: "/api/v1/network/objects", Summary: "List managed network objects", Tag: "Network", ResponseSchema: "NetworkObjectListResponse", Parameters: networkObjectQueryParams()},
+		{Method: "POST", Path: "/api/v1/network/objects", Summary: "Create managed network object", Tag: "Network", RequestSchema: "CreateNetworkObject", SuccessStatus: "201", ResponseSchema: "NetworkObject"},
+		{Method: "GET", Path: "/api/v1/network/objects/{objectId}", Summary: "Get managed network object", Tag: "Network", ResponseSchema: "NetworkObject"},
+		{Method: "PATCH", Path: "/api/v1/network/objects/{objectId}", Summary: "Update managed network object", Tag: "Network", RequestSchema: "UpdateNetworkObject", ResponseSchema: "NetworkObject"},
+		{Method: "GET", Path: "/api/v1/network/relationships", Summary: "List network relationships", Tag: "Network", ResponseSchema: "NetworkRelationshipListResponse", Parameters: networkRelationshipQueryParams()},
+		{Method: "POST", Path: "/api/v1/network/relationships", Summary: "Create or update network relationship", Tag: "Network", RequestSchema: "CreateNetworkRelationship", SuccessStatus: "201", ResponseSchema: "NetworkRelationship"},
+		{Method: "POST", Path: "/api/v1/network/relationships/resolve", Summary: "Update network relationship resolution state by request body", Tag: "Network", RequestSchema: "ResolveNetworkRelationshipRequest", ResponseSchema: "NetworkRelationship"},
+		{Method: "POST", Path: "/api/v1/network/relationships/{relationshipId}/resolve", Summary: "Update network relationship resolution state", Tag: "Network", RequestSchema: "ResolveNetworkRelationshipRequest", ResponseSchema: "NetworkRelationship"},
 		{Method: "POST", Path: "/api/v1/analysis", Summary: "Run full network analysis", Tag: "Analysis", RequestSchema: "AnalysisRequest", ResponseSchema: "Object"},
 		{Method: "POST", Path: "/api/v1/analysis/gaps", Summary: "Run gap analysis", Tag: "Analysis", RequestSchema: "GapAnalysisRequest", ResponseSchema: "Object"},
 		{Method: "POST", Path: "/api/v1/analysis/fragmentation", Summary: "Run fragmentation analysis", Tag: "Analysis", RequestSchema: "AnalysisRequest", ResponseSchema: "Object"},
@@ -1140,7 +1171,31 @@ func networkViewQueryParams() []openAPIParameter {
 		queryParam("object_type", "Network object type", "string"),
 		queryParam("status", "Network object status", "string"),
 		queryParam("conflict_type", "Network conflict type", "string"),
+		queryParam("schema_policy", "Schema policy name", "string"),
+		queryParam("duplicates", "Duplicate handling override", "string"),
 		queryParam("q", "Search query", "string"),
+	}
+}
+
+func networkObjectQueryParams() []openAPIParameter {
+	return []openAPIParameter{
+		queryParam("account_id", "Account ID", "integer"),
+		queryParam("provider", "Cloud provider", "string"),
+		queryParam("region", "Cloud region", "string"),
+		queryParam("object_type", "Network object type", "string"),
+		queryParam("state", "Network object state", "string"),
+		queryParam("q", "Search query", "string"),
+	}
+}
+
+func networkRelationshipQueryParams() []openAPIParameter {
+	return []openAPIParameter{
+		queryParam("type", "Relationship type", "string"),
+		queryParam("source_kind", "Source entity kind", "string"),
+		queryParam("source_id", "Source entity ID", "string"),
+		queryParam("target_kind", "Target entity kind", "string"),
+		queryParam("target_id", "Target entity ID", "string"),
+		queryParam("resolution_state", "Resolution state", "string"),
 	}
 }
 

--- a/internal/domain/network.go
+++ b/internal/domain/network.go
@@ -1,6 +1,168 @@
 package domain
 
-import "github.com/google/uuid"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// NetworkObjectType is the provider-neutral type of a managed network object.
+type NetworkObjectType string
+
+const (
+	NetworkObjectTypeVPC      NetworkObjectType = "vpc"
+	NetworkObjectTypeSubnet   NetworkObjectType = "subnet"
+	NetworkObjectTypeEIP      NetworkObjectType = "eip"
+	NetworkObjectTypePublicIP NetworkObjectType = "public_ip"
+	NetworkObjectTypeNetwork  NetworkObjectType = "network"
+	NetworkObjectTypeOther    NetworkObjectType = "other"
+)
+
+// NetworkObjectState is the managed lifecycle state for a network object.
+type NetworkObjectState string
+
+const (
+	NetworkObjectStateManaged     NetworkObjectState = "managed"
+	NetworkObjectStatePlaceholder NetworkObjectState = "placeholder"
+	NetworkObjectStateImported    NetworkObjectState = "imported"
+	NetworkObjectStateIgnored     NetworkObjectState = "ignored"
+)
+
+// NetworkObject is a durable provider-neutral object such as a VPC, subnet,
+// EIP/public IP, network, or future provider-specific object.
+type NetworkObject struct {
+	ID                 int64              `json:"id"`
+	ObjectType         NetworkObjectType  `json:"object_type"`
+	Provider           string             `json:"provider,omitempty"`
+	AccountID          int64              `json:"account_id"`
+	Region             string             `json:"region,omitempty"`
+	Name               string             `json:"name"`
+	CIDR               string             `json:"cidr,omitempty"`
+	IPAddress          string             `json:"ip_address,omitempty"`
+	ProviderResourceID string             `json:"provider_resource_id,omitempty"`
+	ParentObjectID     *int64             `json:"parent_object_id,omitempty"`
+	PoolID             *int64             `json:"pool_id,omitempty"`
+	SourceDiscoveredID *uuid.UUID         `json:"source_discovered_id,omitempty"`
+	State              NetworkObjectState `json:"state"`
+	Metadata           map[string]string  `json:"metadata,omitempty"`
+	CreatedAt          time.Time          `json:"created_at"`
+	UpdatedAt          time.Time          `json:"updated_at"`
+}
+
+type CreateNetworkObject struct {
+	ObjectType         NetworkObjectType  `json:"object_type"`
+	Provider           string             `json:"provider,omitempty"`
+	AccountID          int64              `json:"account_id"`
+	Region             string             `json:"region,omitempty"`
+	Name               string             `json:"name"`
+	CIDR               string             `json:"cidr,omitempty"`
+	IPAddress          string             `json:"ip_address,omitempty"`
+	ProviderResourceID string             `json:"provider_resource_id,omitempty"`
+	ParentObjectID     *int64             `json:"parent_object_id,omitempty"`
+	PoolID             *int64             `json:"pool_id,omitempty"`
+	SourceDiscoveredID *uuid.UUID         `json:"source_discovered_id,omitempty"`
+	State              NetworkObjectState `json:"state,omitempty"`
+	Metadata           map[string]string  `json:"metadata,omitempty"`
+}
+
+type UpdateNetworkObject struct {
+	ObjectType         *NetworkObjectType  `json:"object_type,omitempty"`
+	Provider           *string             `json:"provider,omitempty"`
+	AccountID          *int64              `json:"account_id,omitempty"`
+	Region             *string             `json:"region,omitempty"`
+	Name               *string             `json:"name,omitempty"`
+	CIDR               *string             `json:"cidr,omitempty"`
+	IPAddress          *string             `json:"ip_address,omitempty"`
+	ProviderResourceID *string             `json:"provider_resource_id,omitempty"`
+	ParentObjectID     *int64              `json:"parent_object_id,omitempty"`
+	PoolID             *int64              `json:"pool_id,omitempty"`
+	SourceDiscoveredID *uuid.UUID          `json:"source_discovered_id,omitempty"`
+	State              *NetworkObjectState `json:"state,omitempty"`
+	Metadata           *map[string]string  `json:"metadata,omitempty"`
+}
+
+type NetworkObjectFilters struct {
+	AccountID  int64
+	Provider   string
+	Region     string
+	ObjectType string
+	State      string
+	Query      string
+}
+
+type NetworkObjectListResponse struct {
+	Items []NetworkObject `json:"items"`
+	Total int             `json:"total"`
+}
+
+// NetworkRelationshipType is a durable link between merged-network entities.
+type NetworkRelationshipType string
+
+const (
+	NetworkRelationshipContains        NetworkRelationshipType = "contains"
+	NetworkRelationshipMatches         NetworkRelationshipType = "matches"
+	NetworkRelationshipConflicts       NetworkRelationshipType = "conflicts"
+	NetworkRelationshipMissingParent   NetworkRelationshipType = "missing_parent"
+	NetworkRelationshipCandidateImport NetworkRelationshipType = "candidate_import"
+	NetworkRelationshipImportedAs      NetworkRelationshipType = "imported_as"
+	NetworkRelationshipDuplicateOf     NetworkRelationshipType = "duplicate_of"
+)
+
+type NetworkRelationship struct {
+	ID              string                  `json:"id"`
+	Type            NetworkRelationshipType `json:"type"`
+	SourceKind      string                  `json:"source_kind"`
+	SourceID        string                  `json:"source_id"`
+	TargetKind      string                  `json:"target_kind"`
+	TargetID        string                  `json:"target_id"`
+	Confidence      float64                 `json:"confidence"`
+	Reason          string                  `json:"reason,omitempty"`
+	Evidence        []string                `json:"evidence,omitempty"`
+	ResolutionState string                  `json:"resolution_state"`
+	CreatedAt       time.Time               `json:"created_at"`
+	UpdatedAt       time.Time               `json:"updated_at"`
+}
+
+type CreateNetworkRelationship struct {
+	ID              string                  `json:"id,omitempty"`
+	Type            NetworkRelationshipType `json:"type"`
+	SourceKind      string                  `json:"source_kind"`
+	SourceID        string                  `json:"source_id"`
+	TargetKind      string                  `json:"target_kind"`
+	TargetID        string                  `json:"target_id"`
+	Confidence      float64                 `json:"confidence,omitempty"`
+	Reason          string                  `json:"reason,omitempty"`
+	Evidence        []string                `json:"evidence,omitempty"`
+	ResolutionState string                  `json:"resolution_state,omitempty"`
+}
+
+type NetworkRelationshipFilters struct {
+	Type            string
+	SourceKind      string
+	SourceID        string
+	TargetKind      string
+	TargetID        string
+	ResolutionState string
+}
+
+type NetworkRelationshipListResponse struct {
+	Items []NetworkRelationship `json:"items"`
+	Total int                   `json:"total"`
+}
+
+type ResolveNetworkRelationshipRequest struct {
+	ID              string `json:"id,omitempty"`
+	ResolutionState string `json:"resolution_state"`
+	Reason          string `json:"reason,omitempty"`
+}
+
+type NetworkSchemaPolicy struct {
+	Name                string `json:"name"`
+	OwnershipStrategy   string `json:"ownership_strategy"`
+	DuplicateScope      string `json:"duplicate_scope"`
+	HierarchyScope      string `json:"hierarchy_scope"`
+	ManualRelationships bool   `json:"manual_relationships,omitempty"`
+}
 
 // NetworkIssue describes an actionable issue attached to a merged network row
 // or hierarchy node.
@@ -14,49 +176,51 @@ type NetworkIssue struct {
 // NetworkNode is the provider-neutral representation used by merged flat and
 // hierarchy network views.
 type NetworkNode struct {
-	ID                 string         `json:"id"`
-	ParentID           *string        `json:"parent_id,omitempty"`
-	Kind               string         `json:"kind"`
-	ObjectType         string         `json:"object_type"`
-	Name               string         `json:"name"`
-	CIDR               string         `json:"cidr,omitempty"`
-	IPAddress          string         `json:"ip_address,omitempty"`
-	Provider           string         `json:"provider,omitempty"`
-	AccountID          *int64         `json:"account_id,omitempty"`
-	AccountName        string         `json:"account_name,omitempty"`
-	Region             string         `json:"region,omitempty"`
-	ProviderResourceID string         `json:"provider_resource_id,omitempty"`
-	DiscoveredID       *uuid.UUID     `json:"discovered_id,omitempty"`
-	LinkedPoolID       *int64         `json:"linked_pool_id,omitempty"`
-	Source             string         `json:"source"`
-	State              string         `json:"state"`
-	Issues             []NetworkIssue `json:"issues,omitempty"`
-	Evidence           []string       `json:"evidence,omitempty"`
-	Children           []NetworkNode  `json:"children,omitempty"`
+	ID                 string                `json:"id"`
+	ParentID           *string               `json:"parent_id,omitempty"`
+	Kind               string                `json:"kind"`
+	ObjectType         string                `json:"object_type"`
+	Name               string                `json:"name"`
+	CIDR               string                `json:"cidr,omitempty"`
+	IPAddress          string                `json:"ip_address,omitempty"`
+	Provider           string                `json:"provider,omitempty"`
+	AccountID          *int64                `json:"account_id,omitempty"`
+	AccountName        string                `json:"account_name,omitempty"`
+	Region             string                `json:"region,omitempty"`
+	ProviderResourceID string                `json:"provider_resource_id,omitempty"`
+	DiscoveredID       *uuid.UUID            `json:"discovered_id,omitempty"`
+	LinkedPoolID       *int64                `json:"linked_pool_id,omitempty"`
+	Source             string                `json:"source"`
+	State              string                `json:"state"`
+	Issues             []NetworkIssue        `json:"issues,omitempty"`
+	Evidence           []string              `json:"evidence,omitempty"`
+	Relationships      []NetworkRelationship `json:"relationships,omitempty"`
+	Children           []NetworkNode         `json:"children,omitempty"`
 }
 
 // NetworkConflict is a computed conflict/drift/duplicate record shown in the
 // network conflict panel.
 type NetworkConflict struct {
-	ID                  string      `json:"id"`
-	Type                string      `json:"type"`
-	Severity            string      `json:"severity"`
-	Status              string      `json:"status"`
-	Title               string      `json:"title"`
-	Description         string      `json:"description"`
-	RecommendedAction   string      `json:"recommended_action,omitempty"`
-	NodeIDs             []string    `json:"node_ids,omitempty"`
-	DiscoveredIDs       []uuid.UUID `json:"discovered_ids,omitempty"`
-	PoolIDs             []int64     `json:"pool_ids,omitempty"`
-	Provider            string      `json:"provider,omitempty"`
-	AccountIDs          []int64     `json:"account_ids,omitempty"`
-	Regions             []string    `json:"regions,omitempty"`
-	ObjectTypes         []string    `json:"object_types,omitempty"`
-	CIDR                string      `json:"cidr,omitempty"`
-	Evidence            []string    `json:"evidence,omitempty"`
-	AvailableDecisions  []string    `json:"available_decisions,omitempty"`
-	ResolutionState     string      `json:"resolution_state,omitempty"`
-	ResolutionRequested string      `json:"resolution_requested,omitempty"`
+	ID                  string                `json:"id"`
+	Type                string                `json:"type"`
+	Severity            string                `json:"severity"`
+	Status              string                `json:"status"`
+	Title               string                `json:"title"`
+	Description         string                `json:"description"`
+	RecommendedAction   string                `json:"recommended_action,omitempty"`
+	NodeIDs             []string              `json:"node_ids,omitempty"`
+	DiscoveredIDs       []uuid.UUID           `json:"discovered_ids,omitempty"`
+	PoolIDs             []int64               `json:"pool_ids,omitempty"`
+	Provider            string                `json:"provider,omitempty"`
+	AccountIDs          []int64               `json:"account_ids,omitempty"`
+	Regions             []string              `json:"regions,omitempty"`
+	ObjectTypes         []string              `json:"object_types,omitempty"`
+	CIDR                string                `json:"cidr,omitempty"`
+	Evidence            []string              `json:"evidence,omitempty"`
+	Relationships       []NetworkRelationship `json:"relationships,omitempty"`
+	AvailableDecisions  []string              `json:"available_decisions,omitempty"`
+	ResolutionState     string                `json:"resolution_state,omitempty"`
+	ResolutionRequested string                `json:"resolution_requested,omitempty"`
 }
 
 // NetworkViewResponse returns the flat or hierarchical merged network view.
@@ -99,6 +263,14 @@ type NetworkConflictImportActionRequest struct {
 	Override    bool        `json:"override,omitempty"`
 }
 
+// NetworkConflictPlaceholderParentActionRequest creates a durable placeholder
+// parent object for a missing-parent conflict.
+type NetworkConflictPlaceholderParentActionRequest struct {
+	DiscoveredID uuid.UUID `json:"discovered_id"`
+	Name         string    `json:"name,omitempty"`
+	Reason       string    `json:"reason,omitempty"`
+}
+
 // NetworkConflictActionResponse reports the mutation performed for a conflict
 // action and the conflict state after persistence.
 type NetworkConflictActionResponse struct {
@@ -107,5 +279,7 @@ type NetworkConflictActionResponse struct {
 	ResourceLinked bool                          `json:"resource_linked,omitempty"`
 	DiscoveredID   *uuid.UUID                    `json:"discovered_id,omitempty"`
 	PoolID         *int64                        `json:"pool_id,omitempty"`
+	NetworkObject  *NetworkObject                `json:"network_object,omitempty"`
+	Relationships  []NetworkRelationship         `json:"relationships,omitempty"`
 	Import         *DiscoveryImportApplyResponse `json:"import,omitempty"`
 }

--- a/internal/storage/network.go
+++ b/internal/storage/network.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"context"
+
+	"cloudpam/internal/domain"
+)
+
+// NetworkStore persists managed network objects and explicit relationships
+// between pools, discovered resources, and managed network objects.
+type NetworkStore interface {
+	ListNetworkObjects(ctx context.Context, filters domain.NetworkObjectFilters) ([]domain.NetworkObject, error)
+	GetNetworkObject(ctx context.Context, id int64) (domain.NetworkObject, bool, error)
+	CreateNetworkObject(ctx context.Context, in domain.CreateNetworkObject) (domain.NetworkObject, error)
+	UpdateNetworkObject(ctx context.Context, id int64, update domain.UpdateNetworkObject) (domain.NetworkObject, bool, error)
+
+	ListNetworkRelationships(ctx context.Context, filters domain.NetworkRelationshipFilters) ([]domain.NetworkRelationship, error)
+	UpsertNetworkRelationship(ctx context.Context, in domain.CreateNetworkRelationship) (domain.NetworkRelationship, error)
+	UpdateNetworkRelationshipState(ctx context.Context, id string, state string, reason string) (domain.NetworkRelationship, bool, error)
+}

--- a/internal/storage/network_memory.go
+++ b/internal/storage/network_memory.go
@@ -1,0 +1,298 @@
+package storage
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"cloudpam/internal/domain"
+)
+
+// MemoryNetworkStore stores managed network objects and relationships in memory.
+type MemoryNetworkStore struct {
+	store         *MemoryStore
+	objects       map[int64]domain.NetworkObject
+	relationships map[string]domain.NetworkRelationship
+	nextObjectID  int64
+}
+
+func NewMemoryNetworkStore(store *MemoryStore) *MemoryNetworkStore {
+	if store == nil {
+		store = NewMemoryStore()
+	}
+	return &MemoryNetworkStore{
+		store:         store,
+		objects:       make(map[int64]domain.NetworkObject),
+		relationships: make(map[string]domain.NetworkRelationship),
+		nextObjectID:  1,
+	}
+}
+
+func (m *MemoryNetworkStore) ListNetworkObjects(_ context.Context, filters domain.NetworkObjectFilters) ([]domain.NetworkObject, error) {
+	m.store.mu.RLock()
+	defer m.store.mu.RUnlock()
+
+	out := make([]domain.NetworkObject, 0, len(m.objects))
+	for _, obj := range m.objects {
+		if filters.AccountID > 0 && obj.AccountID != filters.AccountID {
+			continue
+		}
+		if filters.Provider != "" && obj.Provider != filters.Provider {
+			continue
+		}
+		if filters.Region != "" && obj.Region != filters.Region {
+			continue
+		}
+		if filters.ObjectType != "" && string(obj.ObjectType) != filters.ObjectType {
+			continue
+		}
+		if filters.State != "" && string(obj.State) != filters.State {
+			continue
+		}
+		if filters.Query != "" {
+			q := strings.ToLower(filters.Query)
+			haystack := strings.ToLower(strings.Join([]string{obj.Name, obj.CIDR, obj.IPAddress, obj.ProviderResourceID}, " "))
+			if !strings.Contains(haystack, q) {
+				continue
+			}
+		}
+		out = append(out, cloneNetworkObject(obj))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].AccountID == out[j].AccountID {
+			if out[i].Region == out[j].Region {
+				return out[i].Name < out[j].Name
+			}
+			return out[i].Region < out[j].Region
+		}
+		return out[i].AccountID < out[j].AccountID
+	})
+	return out, nil
+}
+
+func (m *MemoryNetworkStore) GetNetworkObject(_ context.Context, id int64) (domain.NetworkObject, bool, error) {
+	m.store.mu.RLock()
+	defer m.store.mu.RUnlock()
+	obj, ok := m.objects[id]
+	return cloneNetworkObject(obj), ok, nil
+}
+
+func (m *MemoryNetworkStore) CreateNetworkObject(_ context.Context, in domain.CreateNetworkObject) (domain.NetworkObject, error) {
+	if in.AccountID < 1 {
+		return domain.NetworkObject{}, fmt.Errorf("account_id is required: %w", ErrValidation)
+	}
+	if strings.TrimSpace(in.Name) == "" {
+		return domain.NetworkObject{}, fmt.Errorf("name is required: %w", ErrValidation)
+	}
+	objectType := in.ObjectType
+	if objectType == "" {
+		objectType = domain.NetworkObjectTypeOther
+	}
+	state := in.State
+	if state == "" {
+		state = domain.NetworkObjectStateManaged
+	}
+
+	m.store.mu.Lock()
+	defer m.store.mu.Unlock()
+
+	now := time.Now().UTC()
+	obj := domain.NetworkObject{
+		ID:                 m.nextObjectID,
+		ObjectType:         objectType,
+		Provider:           in.Provider,
+		AccountID:          in.AccountID,
+		Region:             in.Region,
+		Name:               in.Name,
+		CIDR:               in.CIDR,
+		IPAddress:          in.IPAddress,
+		ProviderResourceID: in.ProviderResourceID,
+		ParentObjectID:     in.ParentObjectID,
+		PoolID:             in.PoolID,
+		SourceDiscoveredID: in.SourceDiscoveredID,
+		State:              state,
+		Metadata:           cloneStringMap(in.Metadata),
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	m.nextObjectID++
+	m.objects[obj.ID] = obj
+	return cloneNetworkObject(obj), nil
+}
+
+func (m *MemoryNetworkStore) UpdateNetworkObject(_ context.Context, id int64, update domain.UpdateNetworkObject) (domain.NetworkObject, bool, error) {
+	m.store.mu.Lock()
+	defer m.store.mu.Unlock()
+
+	obj, ok := m.objects[id]
+	if !ok {
+		return domain.NetworkObject{}, false, nil
+	}
+	if update.ObjectType != nil {
+		obj.ObjectType = *update.ObjectType
+	}
+	if update.Provider != nil {
+		obj.Provider = *update.Provider
+	}
+	if update.AccountID != nil {
+		obj.AccountID = *update.AccountID
+	}
+	if update.Region != nil {
+		obj.Region = *update.Region
+	}
+	if update.Name != nil {
+		obj.Name = *update.Name
+	}
+	if update.CIDR != nil {
+		obj.CIDR = *update.CIDR
+	}
+	if update.IPAddress != nil {
+		obj.IPAddress = *update.IPAddress
+	}
+	if update.ProviderResourceID != nil {
+		obj.ProviderResourceID = *update.ProviderResourceID
+	}
+	if update.ParentObjectID != nil {
+		obj.ParentObjectID = update.ParentObjectID
+	}
+	if update.PoolID != nil {
+		obj.PoolID = update.PoolID
+	}
+	if update.SourceDiscoveredID != nil {
+		obj.SourceDiscoveredID = update.SourceDiscoveredID
+	}
+	if update.State != nil {
+		obj.State = *update.State
+	}
+	if update.Metadata != nil {
+		obj.Metadata = cloneStringMap(*update.Metadata)
+	}
+	obj.UpdatedAt = time.Now().UTC()
+	m.objects[id] = obj
+	return cloneNetworkObject(obj), true, nil
+}
+
+func (m *MemoryNetworkStore) ListNetworkRelationships(_ context.Context, filters domain.NetworkRelationshipFilters) ([]domain.NetworkRelationship, error) {
+	m.store.mu.RLock()
+	defer m.store.mu.RUnlock()
+
+	out := make([]domain.NetworkRelationship, 0, len(m.relationships))
+	for _, rel := range m.relationships {
+		if filters.Type != "" && string(rel.Type) != filters.Type {
+			continue
+		}
+		if filters.SourceKind != "" && rel.SourceKind != filters.SourceKind {
+			continue
+		}
+		if filters.SourceID != "" && rel.SourceID != filters.SourceID {
+			continue
+		}
+		if filters.TargetKind != "" && rel.TargetKind != filters.TargetKind {
+			continue
+		}
+		if filters.TargetID != "" && rel.TargetID != filters.TargetID {
+			continue
+		}
+		if filters.ResolutionState != "" && rel.ResolutionState != filters.ResolutionState {
+			continue
+		}
+		out = append(out, cloneNetworkRelationship(rel))
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+func (m *MemoryNetworkStore) UpsertNetworkRelationship(_ context.Context, in domain.CreateNetworkRelationship) (domain.NetworkRelationship, error) {
+	if in.Type == "" || in.SourceKind == "" || in.SourceID == "" || in.TargetKind == "" || in.TargetID == "" {
+		return domain.NetworkRelationship{}, fmt.Errorf("relationship type, source, and target are required: %w", ErrValidation)
+	}
+	id := in.ID
+	if id == "" {
+		id = networkRelationshipID(in)
+	}
+	confidence := in.Confidence
+	if confidence == 0 {
+		confidence = 1
+	}
+	state := in.ResolutionState
+	if state == "" {
+		state = "open"
+	}
+
+	m.store.mu.Lock()
+	defer m.store.mu.Unlock()
+
+	now := time.Now().UTC()
+	rel := domain.NetworkRelationship{
+		ID:              id,
+		Type:            in.Type,
+		SourceKind:      in.SourceKind,
+		SourceID:        in.SourceID,
+		TargetKind:      in.TargetKind,
+		TargetID:        in.TargetID,
+		Confidence:      confidence,
+		Reason:          in.Reason,
+		Evidence:        append([]string(nil), in.Evidence...),
+		ResolutionState: state,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	if existing, ok := m.relationships[id]; ok {
+		rel.CreatedAt = existing.CreatedAt
+		if in.ResolutionState == "" {
+			rel.ResolutionState = existing.ResolutionState
+		}
+	}
+	m.relationships[id] = rel
+	return cloneNetworkRelationship(rel), nil
+}
+
+func (m *MemoryNetworkStore) UpdateNetworkRelationshipState(_ context.Context, id string, state string, reason string) (domain.NetworkRelationship, bool, error) {
+	if strings.TrimSpace(state) == "" {
+		return domain.NetworkRelationship{}, false, fmt.Errorf("resolution_state is required: %w", ErrValidation)
+	}
+	m.store.mu.Lock()
+	defer m.store.mu.Unlock()
+
+	rel, ok := m.relationships[id]
+	if !ok {
+		return domain.NetworkRelationship{}, false, nil
+	}
+	rel.ResolutionState = state
+	if reason != "" {
+		rel.Reason = reason
+	}
+	rel.UpdatedAt = time.Now().UTC()
+	m.relationships[id] = rel
+	return cloneNetworkRelationship(rel), true, nil
+}
+
+func networkRelationshipID(in domain.CreateNetworkRelationship) string {
+	sum := sha1.Sum([]byte(strings.Join([]string{string(in.Type), in.SourceKind, in.SourceID, in.TargetKind, in.TargetID}, "|")))
+	return "rel-" + hex.EncodeToString(sum[:])[:20]
+}
+
+func cloneNetworkObject(obj domain.NetworkObject) domain.NetworkObject {
+	obj.Metadata = cloneStringMap(obj.Metadata)
+	return obj
+}
+
+func cloneNetworkRelationship(rel domain.NetworkRelationship) domain.NetworkRelationship {
+	rel.Evidence = append([]string(nil), rel.Evidence...)
+	return rel
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/storage/postgres/network.go
+++ b/internal/storage/postgres/network.go
@@ -1,0 +1,330 @@
+//go:build postgres
+
+package postgres
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"cloudpam/internal/domain"
+	"cloudpam/internal/storage"
+)
+
+var _ storage.NetworkStore = (*Store)(nil)
+
+func (s *Store) ListNetworkObjects(ctx context.Context, filters domain.NetworkObjectFilters) ([]domain.NetworkObject, error) {
+	where := []string{"organization_id = $1"}
+	args := []any{s.orgID}
+	addArg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+	if filters.AccountID > 0 {
+		where = append(where, "account_id = "+addArg(filters.AccountID))
+	}
+	if filters.Provider != "" {
+		where = append(where, "provider = "+addArg(filters.Provider))
+	}
+	if filters.Region != "" {
+		where = append(where, "region = "+addArg(filters.Region))
+	}
+	if filters.ObjectType != "" {
+		where = append(where, "object_type = "+addArg(filters.ObjectType))
+	}
+	if filters.State != "" {
+		where = append(where, "state = "+addArg(filters.State))
+	}
+	if filters.Query != "" {
+		q := "%" + strings.ToLower(filters.Query) + "%"
+		where = append(where, fmt.Sprintf("(LOWER(name) LIKE %s OR LOWER(cidr) LIKE %s OR LOWER(ip_address) LIKE %s OR LOWER(provider_resource_id) LIKE %s)", addArg(q), addArg(q), addArg(q), addArg(q)))
+	}
+	rows, err := s.pool.Query(ctx, `SELECT id, object_type, provider, account_id, region, name, cidr, ip_address, provider_resource_id, parent_object_id, pool_id, source_discovered_id, state, metadata, created_at, updated_at
+		FROM network_objects WHERE `+strings.Join(where, " AND ")+` ORDER BY account_id ASC, region ASC, name ASC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []domain.NetworkObject
+	for rows.Next() {
+		obj, err := scanPostgresNetworkObject(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, obj)
+	}
+	if out == nil {
+		out = []domain.NetworkObject{}
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetNetworkObject(ctx context.Context, id int64) (domain.NetworkObject, bool, error) {
+	row := s.pool.QueryRow(ctx, `SELECT id, object_type, provider, account_id, region, name, cidr, ip_address, provider_resource_id, parent_object_id, pool_id, source_discovered_id, state, metadata, created_at, updated_at
+		FROM network_objects WHERE id = $1 AND organization_id = $2`, id, s.orgID)
+	obj, err := scanPostgresNetworkObject(row)
+	if err != nil {
+		if err == storage.ErrNotFound {
+			return domain.NetworkObject{}, false, nil
+		}
+		return domain.NetworkObject{}, false, err
+	}
+	return obj, true, nil
+}
+
+func (s *Store) CreateNetworkObject(ctx context.Context, in domain.CreateNetworkObject) (domain.NetworkObject, error) {
+	if in.AccountID < 1 {
+		return domain.NetworkObject{}, fmt.Errorf("account_id is required: %w", storage.ErrValidation)
+	}
+	if strings.TrimSpace(in.Name) == "" {
+		return domain.NetworkObject{}, fmt.Errorf("name is required: %w", storage.ErrValidation)
+	}
+	objectType := in.ObjectType
+	if objectType == "" {
+		objectType = domain.NetworkObjectTypeOther
+	}
+	state := in.State
+	if state == "" {
+		state = domain.NetworkObjectStateManaged
+	}
+	metadata, _ := json.Marshal(in.Metadata)
+	if in.Metadata == nil {
+		metadata = []byte("{}")
+	}
+	now := time.Now().UTC()
+	var id int64
+	err := s.pool.QueryRow(ctx, `INSERT INTO network_objects
+		(organization_id, object_type, provider, account_id, region, name, cidr, ip_address, provider_resource_id, parent_object_id, pool_id, source_discovered_id, state, metadata, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14::jsonb, $15, $16)
+		RETURNING id`,
+		s.orgID, string(objectType), in.Provider, in.AccountID, in.Region, in.Name, in.CIDR, in.IPAddress, in.ProviderResourceID,
+		in.ParentObjectID, in.PoolID, in.SourceDiscoveredID, string(state), string(metadata), now, now).Scan(&id)
+	if err != nil {
+		return domain.NetworkObject{}, err
+	}
+	obj, _, err := s.GetNetworkObject(ctx, id)
+	return obj, err
+}
+
+func (s *Store) UpdateNetworkObject(ctx context.Context, id int64, update domain.UpdateNetworkObject) (domain.NetworkObject, bool, error) {
+	obj, found, err := s.GetNetworkObject(ctx, id)
+	if err != nil || !found {
+		return domain.NetworkObject{}, found, err
+	}
+	if update.ObjectType != nil {
+		obj.ObjectType = *update.ObjectType
+	}
+	if update.Provider != nil {
+		obj.Provider = *update.Provider
+	}
+	if update.AccountID != nil {
+		obj.AccountID = *update.AccountID
+	}
+	if update.Region != nil {
+		obj.Region = *update.Region
+	}
+	if update.Name != nil {
+		obj.Name = *update.Name
+	}
+	if update.CIDR != nil {
+		obj.CIDR = *update.CIDR
+	}
+	if update.IPAddress != nil {
+		obj.IPAddress = *update.IPAddress
+	}
+	if update.ProviderResourceID != nil {
+		obj.ProviderResourceID = *update.ProviderResourceID
+	}
+	if update.ParentObjectID != nil {
+		obj.ParentObjectID = update.ParentObjectID
+	}
+	if update.PoolID != nil {
+		obj.PoolID = update.PoolID
+	}
+	if update.SourceDiscoveredID != nil {
+		obj.SourceDiscoveredID = update.SourceDiscoveredID
+	}
+	if update.State != nil {
+		obj.State = *update.State
+	}
+	if update.Metadata != nil {
+		obj.Metadata = *update.Metadata
+	}
+	metadata, _ := json.Marshal(obj.Metadata)
+	if obj.Metadata == nil {
+		metadata = []byte("{}")
+	}
+	tag, err := s.pool.Exec(ctx, `UPDATE network_objects SET
+		object_type = $1, provider = $2, account_id = $3, region = $4, name = $5, cidr = $6, ip_address = $7, provider_resource_id = $8,
+		parent_object_id = $9, pool_id = $10, source_discovered_id = $11, state = $12, metadata = $13::jsonb, updated_at = $14
+		WHERE id = $15 AND organization_id = $16`,
+		string(obj.ObjectType), obj.Provider, obj.AccountID, obj.Region, obj.Name, obj.CIDR, obj.IPAddress, obj.ProviderResourceID,
+		obj.ParentObjectID, obj.PoolID, obj.SourceDiscoveredID, string(obj.State), string(metadata), time.Now().UTC(), id, s.orgID)
+	if err != nil {
+		return domain.NetworkObject{}, false, err
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.NetworkObject{}, false, nil
+	}
+	obj, _, err = s.GetNetworkObject(ctx, id)
+	return obj, true, err
+}
+
+func (s *Store) ListNetworkRelationships(ctx context.Context, filters domain.NetworkRelationshipFilters) ([]domain.NetworkRelationship, error) {
+	where := []string{"organization_id = $1"}
+	args := []any{s.orgID}
+	addArg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+	if filters.Type != "" {
+		where = append(where, "type = "+addArg(filters.Type))
+	}
+	if filters.SourceKind != "" {
+		where = append(where, "source_kind = "+addArg(filters.SourceKind))
+	}
+	if filters.SourceID != "" {
+		where = append(where, "source_id = "+addArg(filters.SourceID))
+	}
+	if filters.TargetKind != "" {
+		where = append(where, "target_kind = "+addArg(filters.TargetKind))
+	}
+	if filters.TargetID != "" {
+		where = append(where, "target_id = "+addArg(filters.TargetID))
+	}
+	if filters.ResolutionState != "" {
+		where = append(where, "resolution_state = "+addArg(filters.ResolutionState))
+	}
+	rows, err := s.pool.Query(ctx, `SELECT id, type, source_kind, source_id, target_kind, target_id, confidence, reason, evidence, resolution_state, created_at, updated_at
+		FROM network_relationships WHERE `+strings.Join(where, " AND ")+` ORDER BY id ASC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []domain.NetworkRelationship
+	for rows.Next() {
+		rel, err := scanPostgresNetworkRelationship(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rel)
+	}
+	if out == nil {
+		out = []domain.NetworkRelationship{}
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) UpsertNetworkRelationship(ctx context.Context, in domain.CreateNetworkRelationship) (domain.NetworkRelationship, error) {
+	if in.Type == "" || in.SourceKind == "" || in.SourceID == "" || in.TargetKind == "" || in.TargetID == "" {
+		return domain.NetworkRelationship{}, fmt.Errorf("relationship type, source, and target are required: %w", storage.ErrValidation)
+	}
+	if in.ID == "" {
+		in.ID = generatedNetworkRelationshipID(in)
+	}
+	if in.Confidence == 0 {
+		in.Confidence = 1
+	}
+	requestedState := in.ResolutionState
+	if in.ResolutionState == "" {
+		in.ResolutionState = "open"
+	}
+	evidence, _ := json.Marshal(in.Evidence)
+	now := time.Now().UTC()
+	_, err := s.pool.Exec(ctx, `INSERT INTO network_relationships
+		(id, organization_id, type, source_kind, source_id, target_kind, target_id, confidence, reason, evidence, resolution_state, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12, $13)
+		ON CONFLICT(id) DO UPDATE SET
+			type = EXCLUDED.type,
+			source_kind = EXCLUDED.source_kind,
+			source_id = EXCLUDED.source_id,
+			target_kind = EXCLUDED.target_kind,
+			target_id = EXCLUDED.target_id,
+			confidence = EXCLUDED.confidence,
+			reason = EXCLUDED.reason,
+			evidence = EXCLUDED.evidence,
+			resolution_state = CASE WHEN $14 = '' THEN network_relationships.resolution_state ELSE EXCLUDED.resolution_state END,
+			updated_at = EXCLUDED.updated_at`,
+		in.ID, s.orgID, string(in.Type), in.SourceKind, in.SourceID, in.TargetKind, in.TargetID, in.Confidence, in.Reason, string(evidence), in.ResolutionState, now, now, requestedState)
+	if err != nil {
+		return domain.NetworkRelationship{}, err
+	}
+	rels, err := s.ListNetworkRelationships(ctx, domain.NetworkRelationshipFilters{})
+	if err != nil {
+		return domain.NetworkRelationship{}, err
+	}
+	for _, rel := range rels {
+		if rel.ID == in.ID {
+			return rel, nil
+		}
+	}
+	return domain.NetworkRelationship{}, storage.ErrNotFound
+}
+
+func (s *Store) UpdateNetworkRelationshipState(ctx context.Context, id string, state string, reason string) (domain.NetworkRelationship, bool, error) {
+	if strings.TrimSpace(state) == "" {
+		return domain.NetworkRelationship{}, false, fmt.Errorf("resolution_state is required: %w", storage.ErrValidation)
+	}
+	tag, err := s.pool.Exec(ctx, `UPDATE network_relationships
+		SET resolution_state = $1, reason = CASE WHEN $2 = '' THEN reason ELSE $2 END, updated_at = $3
+		WHERE id = $4 AND organization_id = $5`, state, reason, time.Now().UTC(), id, s.orgID)
+	if err != nil {
+		return domain.NetworkRelationship{}, false, err
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.NetworkRelationship{}, false, nil
+	}
+	rels, err := s.ListNetworkRelationships(ctx, domain.NetworkRelationshipFilters{})
+	if err != nil {
+		return domain.NetworkRelationship{}, false, err
+	}
+	for _, rel := range rels {
+		if rel.ID == id {
+			return rel, true, nil
+		}
+	}
+	return domain.NetworkRelationship{}, false, nil
+}
+
+func generatedNetworkRelationshipID(in domain.CreateNetworkRelationship) string {
+	raw := strings.Join([]string{string(in.Type), in.SourceKind, in.SourceID, in.TargetKind, in.TargetID}, "\x00")
+	sum := sha1.Sum([]byte(raw))
+	return "rel-" + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func scanPostgresNetworkObject(row pgx.Row) (domain.NetworkObject, error) {
+	var obj domain.NetworkObject
+	var metadata []byte
+	var sourceID *uuid.UUID
+	if err := row.Scan(&obj.ID, &obj.ObjectType, &obj.Provider, &obj.AccountID, &obj.Region, &obj.Name, &obj.CIDR, &obj.IPAddress, &obj.ProviderResourceID, &obj.ParentObjectID, &obj.PoolID, &sourceID, &obj.State, &metadata, &obj.CreatedAt, &obj.UpdatedAt); err != nil {
+		if err == pgx.ErrNoRows {
+			return domain.NetworkObject{}, storage.ErrNotFound
+		}
+		return domain.NetworkObject{}, err
+	}
+	obj.SourceDiscoveredID = sourceID
+	_ = json.Unmarshal(metadata, &obj.Metadata)
+	return obj, nil
+}
+
+func scanPostgresNetworkRelationship(row pgx.Row) (domain.NetworkRelationship, error) {
+	var rel domain.NetworkRelationship
+	var evidence []byte
+	if err := row.Scan(&rel.ID, &rel.Type, &rel.SourceKind, &rel.SourceID, &rel.TargetKind, &rel.TargetID, &rel.Confidence, &rel.Reason, &evidence, &rel.ResolutionState, &rel.CreatedAt, &rel.UpdatedAt); err != nil {
+		if err == pgx.ErrNoRows {
+			return domain.NetworkRelationship{}, storage.ErrNotFound
+		}
+		return domain.NetworkRelationship{}, err
+	}
+	_ = json.Unmarshal(evidence, &rel.Evidence)
+	return rel, nil
+}

--- a/internal/storage/postgres/network.go
+++ b/internal/storage/postgres/network.go
@@ -95,6 +95,9 @@ func (s *Store) CreateNetworkObject(ctx context.Context, in domain.CreateNetwork
 	if state == "" {
 		state = domain.NetworkObjectStateManaged
 	}
+	if err := s.validateNetworkObjectRefs(ctx, in.AccountID, in.ParentObjectID, in.PoolID, in.SourceDiscoveredID); err != nil {
+		return domain.NetworkObject{}, err
+	}
 	metadata, _ := json.Marshal(in.Metadata)
 	if in.Metadata == nil {
 		metadata = []byte("{}")
@@ -157,6 +160,9 @@ func (s *Store) UpdateNetworkObject(ctx context.Context, id int64, update domain
 	}
 	if update.Metadata != nil {
 		obj.Metadata = *update.Metadata
+	}
+	if err := s.validateNetworkObjectRefs(ctx, obj.AccountID, obj.ParentObjectID, obj.PoolID, obj.SourceDiscoveredID); err != nil {
+		return domain.NetworkObject{}, false, err
 	}
 	metadata, _ := json.Marshal(obj.Metadata)
 	if obj.Metadata == nil {
@@ -243,7 +249,7 @@ func (s *Store) UpsertNetworkRelationship(ctx context.Context, in domain.CreateN
 	_, err := s.pool.Exec(ctx, `INSERT INTO network_relationships
 		(id, organization_id, type, source_kind, source_id, target_kind, target_id, confidence, reason, evidence, resolution_state, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12, $13)
-		ON CONFLICT(id) DO UPDATE SET
+		ON CONFLICT(organization_id, id) DO UPDATE SET
 			type = EXCLUDED.type,
 			source_kind = EXCLUDED.source_kind,
 			source_id = EXCLUDED.source_id,
@@ -299,6 +305,41 @@ func generatedNetworkRelationshipID(in domain.CreateNetworkRelationship) string 
 	raw := strings.Join([]string{string(in.Type), in.SourceKind, in.SourceID, in.TargetKind, in.TargetID}, "\x00")
 	sum := sha1.Sum([]byte(raw))
 	return "rel-" + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func (s *Store) validateNetworkObjectRefs(ctx context.Context, accountID int64, parentObjectID *int64, poolID *int64, sourceDiscoveredID *uuid.UUID) error {
+	var exists bool
+	if err := s.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM accounts WHERE seq_id = $1 AND organization_id = $2 AND deleted_at IS NULL)`, accountID, s.orgID).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("account not found: %w", storage.ErrNotFound)
+	}
+	if parentObjectID != nil {
+		if err := s.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM network_objects WHERE id = $1 AND organization_id = $2)`, *parentObjectID, s.orgID).Scan(&exists); err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("parent network object not found: %w", storage.ErrNotFound)
+		}
+	}
+	if poolID != nil {
+		if err := s.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM pools WHERE seq_id = $1 AND organization_id = $2 AND deleted_at IS NULL)`, *poolID, s.orgID).Scan(&exists); err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("pool not found: %w", storage.ErrNotFound)
+		}
+	}
+	if sourceDiscoveredID != nil {
+		if err := s.pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM discovered_resources WHERE id = $1 AND organization_id = $2)`, *sourceDiscoveredID, s.orgID).Scan(&exists); err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("source discovered resource not found: %w", storage.ErrNotFound)
+		}
+	}
+	return nil
 }
 
 func scanPostgresNetworkObject(row pgx.Row) (domain.NetworkObject, error) {

--- a/internal/storage/postgres/postgres_test.go
+++ b/internal/storage/postgres/postgres_test.go
@@ -60,6 +60,8 @@ func resetDB(t *testing.T) {
 	// Truncate in dependency order (children before parents)
 	tables := []string{
 		"pool_utilization_cache",
+		"network_relationships",
+		"network_objects",
 		"drift_items",
 		"sync_jobs",
 		"discovered_resources",
@@ -80,8 +82,92 @@ func resetDB(t *testing.T) {
 		}
 	}
 	// Reset sequences on pools and accounts so seq_id starts at 1
+	_, _ = testDB.pool.Exec(ctx, "ALTER SEQUENCE network_objects_id_seq RESTART WITH 1")
 	_, _ = testDB.pool.Exec(ctx, "ALTER SEQUENCE pools_seq_id_seq RESTART WITH 1")
 	_, _ = testDB.pool.Exec(ctx, "ALTER SEQUENCE accounts_seq_id_seq RESTART WITH 1")
+}
+
+func TestNetworkStorePostgresScopesRelationshipsAndObjectRefsByOrganization(t *testing.T) {
+	resetDB(t)
+	ctx := context.Background()
+	storeA := testDB.store
+	orgB := "00000000-0000-0000-0000-000000000222"
+	if _, err := testDB.pool.Exec(ctx, `INSERT INTO organizations (id, name, slug, plan)
+		VALUES ($1, 'Other Org', 'other-org', 'free')
+		ON CONFLICT (id) DO NOTHING`, orgB); err != nil {
+		t.Fatalf("create second org: %v", err)
+	}
+	storeB := &Store{pool: testDB.pool, orgID: orgB}
+
+	accountA, err := storeA.CreateAccount(ctx, domain.CreateAccount{Key: "aws:a", Name: "A", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account A: %v", err)
+	}
+	accountB, err := storeB.CreateAccount(ctx, domain.CreateAccount{Key: "aws:b", Name: "B", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account B: %v", err)
+	}
+
+	if _, err := storeA.UpsertNetworkRelationship(ctx, domain.CreateNetworkRelationship{
+		ID:         "shared-id",
+		Type:       domain.NetworkRelationshipContains,
+		SourceKind: "network_object",
+		SourceID:   "1",
+		TargetKind: "pool",
+		TargetID:   "1",
+		Reason:     "org-a",
+	}); err != nil {
+		t.Fatalf("create relationship A: %v", err)
+	}
+	if _, err := storeB.UpsertNetworkRelationship(ctx, domain.CreateNetworkRelationship{
+		ID:         "shared-id",
+		Type:       domain.NetworkRelationshipContains,
+		SourceKind: "network_object",
+		SourceID:   "1",
+		TargetKind: "pool",
+		TargetID:   "1",
+		Reason:     "org-b",
+	}); err != nil {
+		t.Fatalf("create relationship B: %v", err)
+	}
+	relsA, err := storeA.ListNetworkRelationships(ctx, domain.NetworkRelationshipFilters{})
+	if err != nil {
+		t.Fatalf("list relationships A: %v", err)
+	}
+	relsB, err := storeB.ListNetworkRelationships(ctx, domain.NetworkRelationshipFilters{})
+	if err != nil {
+		t.Fatalf("list relationships B: %v", err)
+	}
+	if len(relsA) != 1 || relsA[0].Reason != "org-a" {
+		t.Fatalf("relationship A was not isolated: %+v", relsA)
+	}
+	if len(relsB) != 1 || relsB[0].Reason != "org-b" {
+		t.Fatalf("relationship B was not isolated: %+v", relsB)
+	}
+
+	if _, err := storeA.CreateNetworkObject(ctx, domain.CreateNetworkObject{
+		ObjectType: domain.NetworkObjectTypeVPC,
+		AccountID:  accountB.ID,
+		Name:       "cross-org-account",
+	}); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected cross-org account reference to fail, got %v", err)
+	}
+	objA, err := storeA.CreateNetworkObject(ctx, domain.CreateNetworkObject{
+		ObjectType: domain.NetworkObjectTypeVPC,
+		AccountID:  accountA.ID,
+		Name:       "org-a-vpc",
+	})
+	if err != nil {
+		t.Fatalf("create object A: %v", err)
+	}
+	if _, err := storeB.CreateNetworkObject(ctx, domain.CreateNetworkObject{
+		ObjectType:     domain.NetworkObjectTypeSubnet,
+		AccountID:      accountB.ID,
+		Name:           "cross-org-parent",
+		ParentObjectID: &objA.ID,
+	}); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected cross-org parent reference to fail, got %v", err)
+	}
 }
 
 // =============================================================================

--- a/internal/storage/sqlite/network.go
+++ b/internal/storage/sqlite/network.go
@@ -1,0 +1,361 @@
+//go:build sqlite
+
+package sqlite
+
+import (
+	"context"
+	"crypto/sha1"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"cloudpam/internal/domain"
+	"cloudpam/internal/storage"
+)
+
+var _ storage.NetworkStore = (*Store)(nil)
+
+func (s *Store) ListNetworkObjects(ctx context.Context, filters domain.NetworkObjectFilters) ([]domain.NetworkObject, error) {
+	where := []string{"1=1"}
+	args := []any{}
+	if filters.AccountID > 0 {
+		where = append(where, "account_id = ?")
+		args = append(args, filters.AccountID)
+	}
+	if filters.Provider != "" {
+		where = append(where, "provider = ?")
+		args = append(args, filters.Provider)
+	}
+	if filters.Region != "" {
+		where = append(where, "region = ?")
+		args = append(args, filters.Region)
+	}
+	if filters.ObjectType != "" {
+		where = append(where, "object_type = ?")
+		args = append(args, filters.ObjectType)
+	}
+	if filters.State != "" {
+		where = append(where, "state = ?")
+		args = append(args, filters.State)
+	}
+	if filters.Query != "" {
+		q := "%" + strings.ToLower(filters.Query) + "%"
+		where = append(where, "(LOWER(name) LIKE ? OR LOWER(cidr) LIKE ? OR LOWER(ip_address) LIKE ? OR LOWER(provider_resource_id) LIKE ?)")
+		args = append(args, q, q, q, q)
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id, object_type, provider, account_id, region, name, cidr, ip_address, provider_resource_id, parent_object_id, pool_id, source_discovered_id, state, metadata, created_at, updated_at
+		FROM network_objects WHERE `+strings.Join(where, " AND ")+` ORDER BY account_id ASC, region ASC, name ASC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []domain.NetworkObject
+	for rows.Next() {
+		obj, err := scanNetworkObject(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, obj)
+	}
+	if out == nil {
+		out = []domain.NetworkObject{}
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetNetworkObject(ctx context.Context, id int64) (domain.NetworkObject, bool, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT id, object_type, provider, account_id, region, name, cidr, ip_address, provider_resource_id, parent_object_id, pool_id, source_discovered_id, state, metadata, created_at, updated_at
+		FROM network_objects WHERE id = ?`, id)
+	obj, err := scanNetworkObject(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return domain.NetworkObject{}, false, nil
+		}
+		return domain.NetworkObject{}, false, err
+	}
+	return obj, true, nil
+}
+
+func (s *Store) CreateNetworkObject(ctx context.Context, in domain.CreateNetworkObject) (domain.NetworkObject, error) {
+	if in.AccountID < 1 {
+		return domain.NetworkObject{}, fmt.Errorf("account_id is required: %w", storage.ErrValidation)
+	}
+	if strings.TrimSpace(in.Name) == "" {
+		return domain.NetworkObject{}, fmt.Errorf("name is required: %w", storage.ErrValidation)
+	}
+	objectType := in.ObjectType
+	if objectType == "" {
+		objectType = domain.NetworkObjectTypeOther
+	}
+	state := in.State
+	if state == "" {
+		state = domain.NetworkObjectStateManaged
+	}
+	metadata := "{}"
+	if in.Metadata != nil {
+		if b, err := json.Marshal(in.Metadata); err == nil {
+			metadata = string(b)
+		}
+	}
+	var discoveredID *string
+	if in.SourceDiscoveredID != nil {
+		id := in.SourceDiscoveredID.String()
+		discoveredID = &id
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx, `INSERT INTO network_objects
+		(object_type, provider, account_id, region, name, cidr, ip_address, provider_resource_id, parent_object_id, pool_id, source_discovered_id, state, metadata, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		string(objectType), in.Provider, in.AccountID, in.Region, in.Name, in.CIDR, in.IPAddress, in.ProviderResourceID,
+		in.ParentObjectID, in.PoolID, discoveredID, string(state), metadata, now, now)
+	if err != nil {
+		return domain.NetworkObject{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return domain.NetworkObject{}, err
+	}
+	obj, _, err := s.GetNetworkObject(ctx, id)
+	return obj, err
+}
+
+func (s *Store) UpdateNetworkObject(ctx context.Context, id int64, update domain.UpdateNetworkObject) (domain.NetworkObject, bool, error) {
+	obj, found, err := s.GetNetworkObject(ctx, id)
+	if err != nil || !found {
+		return domain.NetworkObject{}, found, err
+	}
+	if update.ObjectType != nil {
+		obj.ObjectType = *update.ObjectType
+	}
+	if update.Provider != nil {
+		obj.Provider = *update.Provider
+	}
+	if update.AccountID != nil {
+		obj.AccountID = *update.AccountID
+	}
+	if update.Region != nil {
+		obj.Region = *update.Region
+	}
+	if update.Name != nil {
+		obj.Name = *update.Name
+	}
+	if update.CIDR != nil {
+		obj.CIDR = *update.CIDR
+	}
+	if update.IPAddress != nil {
+		obj.IPAddress = *update.IPAddress
+	}
+	if update.ProviderResourceID != nil {
+		obj.ProviderResourceID = *update.ProviderResourceID
+	}
+	if update.ParentObjectID != nil {
+		obj.ParentObjectID = update.ParentObjectID
+	}
+	if update.PoolID != nil {
+		obj.PoolID = update.PoolID
+	}
+	if update.SourceDiscoveredID != nil {
+		obj.SourceDiscoveredID = update.SourceDiscoveredID
+	}
+	if update.State != nil {
+		obj.State = *update.State
+	}
+	if update.Metadata != nil {
+		obj.Metadata = *update.Metadata
+	}
+	metadata := "{}"
+	if obj.Metadata != nil {
+		if b, err := json.Marshal(obj.Metadata); err == nil {
+			metadata = string(b)
+		}
+	}
+	var discoveredID *string
+	if obj.SourceDiscoveredID != nil {
+		id := obj.SourceDiscoveredID.String()
+		discoveredID = &id
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err = s.db.ExecContext(ctx, `UPDATE network_objects SET
+		object_type = ?, provider = ?, account_id = ?, region = ?, name = ?, cidr = ?, ip_address = ?, provider_resource_id = ?,
+		parent_object_id = ?, pool_id = ?, source_discovered_id = ?, state = ?, metadata = ?, updated_at = ?
+		WHERE id = ?`,
+		string(obj.ObjectType), obj.Provider, obj.AccountID, obj.Region, obj.Name, obj.CIDR, obj.IPAddress, obj.ProviderResourceID,
+		obj.ParentObjectID, obj.PoolID, discoveredID, string(obj.State), metadata, now, id)
+	if err != nil {
+		return domain.NetworkObject{}, false, err
+	}
+	obj, _, err = s.GetNetworkObject(ctx, id)
+	return obj, true, err
+}
+
+func (s *Store) ListNetworkRelationships(ctx context.Context, filters domain.NetworkRelationshipFilters) ([]domain.NetworkRelationship, error) {
+	where := []string{"1=1"}
+	args := []any{}
+	if filters.Type != "" {
+		where = append(where, "type = ?")
+		args = append(args, filters.Type)
+	}
+	if filters.SourceKind != "" {
+		where = append(where, "source_kind = ?")
+		args = append(args, filters.SourceKind)
+	}
+	if filters.SourceID != "" {
+		where = append(where, "source_id = ?")
+		args = append(args, filters.SourceID)
+	}
+	if filters.TargetKind != "" {
+		where = append(where, "target_kind = ?")
+		args = append(args, filters.TargetKind)
+	}
+	if filters.TargetID != "" {
+		where = append(where, "target_id = ?")
+		args = append(args, filters.TargetID)
+	}
+	if filters.ResolutionState != "" {
+		where = append(where, "resolution_state = ?")
+		args = append(args, filters.ResolutionState)
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id, type, source_kind, source_id, target_kind, target_id, confidence, reason, evidence, resolution_state, created_at, updated_at
+		FROM network_relationships WHERE `+strings.Join(where, " AND ")+` ORDER BY id ASC`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []domain.NetworkRelationship
+	for rows.Next() {
+		rel, err := scanNetworkRelationship(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rel)
+	}
+	if out == nil {
+		out = []domain.NetworkRelationship{}
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) UpsertNetworkRelationship(ctx context.Context, in domain.CreateNetworkRelationship) (domain.NetworkRelationship, error) {
+	if in.Type == "" || in.SourceKind == "" || in.SourceID == "" || in.TargetKind == "" || in.TargetID == "" {
+		return domain.NetworkRelationship{}, fmt.Errorf("relationship type, source, and target are required: %w", storage.ErrValidation)
+	}
+	if in.ID == "" {
+		in.ID = generatedNetworkRelationshipID(in)
+	}
+	if in.Confidence == 0 {
+		in.Confidence = 1
+	}
+	requestedState := in.ResolutionState
+	if in.ResolutionState == "" {
+		in.ResolutionState = "open"
+	}
+	evidence, _ := json.Marshal(in.Evidence)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO network_relationships
+		(id, type, source_kind, source_id, target_kind, target_id, confidence, reason, evidence, resolution_state, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			type = excluded.type,
+			source_kind = excluded.source_kind,
+			source_id = excluded.source_id,
+			target_kind = excluded.target_kind,
+			target_id = excluded.target_id,
+			confidence = excluded.confidence,
+			reason = excluded.reason,
+			evidence = excluded.evidence,
+			resolution_state = CASE WHEN ? = '' THEN network_relationships.resolution_state ELSE excluded.resolution_state END,
+			updated_at = excluded.updated_at`,
+		in.ID, string(in.Type), in.SourceKind, in.SourceID, in.TargetKind, in.TargetID, in.Confidence, in.Reason, string(evidence), in.ResolutionState, now, now, requestedState)
+	if err != nil {
+		return domain.NetworkRelationship{}, err
+	}
+	rels, err := s.ListNetworkRelationships(ctx, domain.NetworkRelationshipFilters{})
+	if err != nil {
+		return domain.NetworkRelationship{}, err
+	}
+	for _, rel := range rels {
+		if rel.ID == in.ID {
+			return rel, nil
+		}
+	}
+	return domain.NetworkRelationship{}, storage.ErrNotFound
+}
+
+func (s *Store) UpdateNetworkRelationshipState(ctx context.Context, id string, state string, reason string) (domain.NetworkRelationship, bool, error) {
+	if strings.TrimSpace(state) == "" {
+		return domain.NetworkRelationship{}, false, fmt.Errorf("resolution_state is required: %w", storage.ErrValidation)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx, `UPDATE network_relationships SET resolution_state = ?, reason = CASE WHEN ? = '' THEN reason ELSE ? END, updated_at = ? WHERE id = ?`, state, reason, reason, now, id)
+	if err != nil {
+		return domain.NetworkRelationship{}, false, err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return domain.NetworkRelationship{}, false, nil
+	}
+	rels, err := s.ListNetworkRelationships(ctx, domain.NetworkRelationshipFilters{})
+	if err != nil {
+		return domain.NetworkRelationship{}, false, err
+	}
+	for _, rel := range rels {
+		if rel.ID == id {
+			return rel, true, nil
+		}
+	}
+	return domain.NetworkRelationship{}, false, nil
+}
+
+func generatedNetworkRelationshipID(in domain.CreateNetworkRelationship) string {
+	raw := strings.Join([]string{string(in.Type), in.SourceKind, in.SourceID, in.TargetKind, in.TargetID}, "\x00")
+	sum := sha1.Sum([]byte(raw))
+	return "rel-" + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanNetworkObject(row scanner) (domain.NetworkObject, error) {
+	var obj domain.NetworkObject
+	var parentID, poolID sql.NullInt64
+	var sourceID, metadata, createdAt, updatedAt string
+	if err := row.Scan(&obj.ID, &obj.ObjectType, &obj.Provider, &obj.AccountID, &obj.Region, &obj.Name, &obj.CIDR, &obj.IPAddress, &obj.ProviderResourceID, &parentID, &poolID, &sourceID, &obj.State, &metadata, &createdAt, &updatedAt); err != nil {
+		return domain.NetworkObject{}, err
+	}
+	if parentID.Valid {
+		obj.ParentObjectID = &parentID.Int64
+	}
+	if poolID.Valid {
+		obj.PoolID = &poolID.Int64
+	}
+	if sourceID != "" {
+		id, err := uuid.Parse(sourceID)
+		if err == nil {
+			obj.SourceDiscoveredID = &id
+		}
+	}
+	_ = json.Unmarshal([]byte(metadata), &obj.Metadata)
+	obj.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+	obj.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+	return obj, nil
+}
+
+func scanNetworkRelationship(row scanner) (domain.NetworkRelationship, error) {
+	var rel domain.NetworkRelationship
+	var evidence, createdAt, updatedAt string
+	if err := row.Scan(&rel.ID, &rel.Type, &rel.SourceKind, &rel.SourceID, &rel.TargetKind, &rel.TargetID, &rel.Confidence, &rel.Reason, &evidence, &rel.ResolutionState, &createdAt, &updatedAt); err != nil {
+		return domain.NetworkRelationship{}, err
+	}
+	_ = json.Unmarshal([]byte(evidence), &rel.Evidence)
+	rel.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+	rel.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+	return rel, nil
+}

--- a/migrations/0021_network_objects_relationships.sql
+++ b/migrations/0021_network_objects_relationships.sql
@@ -1,0 +1,46 @@
+-- Durable managed network objects and explicit network relationships.
+
+CREATE TABLE IF NOT EXISTS network_objects (
+    id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+    object_type            TEXT NOT NULL,
+    provider               TEXT NOT NULL DEFAULT '',
+    account_id             INTEGER NOT NULL REFERENCES accounts(id),
+    region                 TEXT NOT NULL DEFAULT '',
+    name                   TEXT NOT NULL,
+    cidr                   TEXT NOT NULL DEFAULT '',
+    ip_address             TEXT NOT NULL DEFAULT '',
+    provider_resource_id   TEXT NOT NULL DEFAULT '',
+    parent_object_id       INTEGER REFERENCES network_objects(id) ON DELETE SET NULL,
+    pool_id                INTEGER REFERENCES pools(id) ON DELETE SET NULL,
+    source_discovered_id   TEXT REFERENCES discovered_resources(id) ON DELETE SET NULL,
+    state                  TEXT NOT NULL DEFAULT 'managed',
+    metadata               TEXT NOT NULL DEFAULT '{}',
+    created_at             TEXT NOT NULL,
+    updated_at             TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_network_objects_account ON network_objects(account_id);
+CREATE INDEX IF NOT EXISTS idx_network_objects_provider ON network_objects(provider);
+CREATE INDEX IF NOT EXISTS idx_network_objects_type ON network_objects(object_type);
+CREATE INDEX IF NOT EXISTS idx_network_objects_state ON network_objects(state);
+CREATE INDEX IF NOT EXISTS idx_network_objects_pool ON network_objects(pool_id);
+
+CREATE TABLE IF NOT EXISTS network_relationships (
+    id               TEXT PRIMARY KEY,
+    type             TEXT NOT NULL,
+    source_kind      TEXT NOT NULL,
+    source_id        TEXT NOT NULL,
+    target_kind      TEXT NOT NULL,
+    target_id        TEXT NOT NULL,
+    confidence       REAL NOT NULL DEFAULT 1,
+    reason           TEXT NOT NULL DEFAULT '',
+    evidence         TEXT NOT NULL DEFAULT '[]',
+    resolution_state TEXT NOT NULL DEFAULT 'open',
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_network_relationships_type ON network_relationships(type);
+CREATE INDEX IF NOT EXISTS idx_network_relationships_source ON network_relationships(source_kind, source_id);
+CREATE INDEX IF NOT EXISTS idx_network_relationships_target ON network_relationships(target_kind, target_id);
+CREATE INDEX IF NOT EXISTS idx_network_relationships_state ON network_relationships(resolution_state);

--- a/migrations/postgres/0022_network_objects_relationships.up.sql
+++ b/migrations/postgres/0022_network_objects_relationships.up.sql
@@ -27,7 +27,7 @@ CREATE INDEX IF NOT EXISTS idx_network_objects_state ON network_objects(state);
 CREATE INDEX IF NOT EXISTS idx_network_objects_pool ON network_objects(pool_id);
 
 CREATE TABLE IF NOT EXISTS network_relationships (
-    id               TEXT PRIMARY KEY,
+    id               TEXT NOT NULL,
     organization_id  UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
     type             TEXT NOT NULL,
     source_kind      TEXT NOT NULL,
@@ -39,7 +39,8 @@ CREATE TABLE IF NOT EXISTS network_relationships (
     evidence         JSONB NOT NULL DEFAULT '[]',
     resolution_state TEXT NOT NULL DEFAULT 'open',
     created_at       TIMESTAMPTZ NOT NULL,
-    updated_at       TIMESTAMPTZ NOT NULL
+    updated_at       TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (organization_id, id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_network_relationships_org_type ON network_relationships(organization_id, type);

--- a/migrations/postgres/0022_network_objects_relationships.up.sql
+++ b/migrations/postgres/0022_network_objects_relationships.up.sql
@@ -1,0 +1,48 @@
+-- Durable managed network objects and explicit network relationships.
+
+CREATE TABLE IF NOT EXISTS network_objects (
+    id                     BIGSERIAL PRIMARY KEY,
+    organization_id        UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    object_type            TEXT NOT NULL,
+    provider               TEXT NOT NULL DEFAULT '',
+    account_id             BIGINT NOT NULL REFERENCES accounts(seq_id) ON DELETE CASCADE,
+    region                 TEXT NOT NULL DEFAULT '',
+    name                   TEXT NOT NULL,
+    cidr                   TEXT NOT NULL DEFAULT '',
+    ip_address             TEXT NOT NULL DEFAULT '',
+    provider_resource_id   TEXT NOT NULL DEFAULT '',
+    parent_object_id       BIGINT REFERENCES network_objects(id) ON DELETE SET NULL,
+    pool_id                BIGINT REFERENCES pools(seq_id) ON DELETE SET NULL,
+    source_discovered_id   UUID,
+    state                  TEXT NOT NULL DEFAULT 'managed',
+    metadata               JSONB NOT NULL DEFAULT '{}',
+    created_at             TIMESTAMPTZ NOT NULL,
+    updated_at             TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_network_objects_org_account ON network_objects(organization_id, account_id);
+CREATE INDEX IF NOT EXISTS idx_network_objects_provider ON network_objects(provider);
+CREATE INDEX IF NOT EXISTS idx_network_objects_type ON network_objects(object_type);
+CREATE INDEX IF NOT EXISTS idx_network_objects_state ON network_objects(state);
+CREATE INDEX IF NOT EXISTS idx_network_objects_pool ON network_objects(pool_id);
+
+CREATE TABLE IF NOT EXISTS network_relationships (
+    id               TEXT PRIMARY KEY,
+    organization_id  UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    type             TEXT NOT NULL,
+    source_kind      TEXT NOT NULL,
+    source_id        TEXT NOT NULL,
+    target_kind      TEXT NOT NULL,
+    target_id        TEXT NOT NULL,
+    confidence       DOUBLE PRECISION NOT NULL DEFAULT 1,
+    reason           TEXT NOT NULL DEFAULT '',
+    evidence         JSONB NOT NULL DEFAULT '[]',
+    resolution_state TEXT NOT NULL DEFAULT 'open',
+    created_at       TIMESTAMPTZ NOT NULL,
+    updated_at       TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_network_relationships_org_type ON network_relationships(organization_id, type);
+CREATE INDEX IF NOT EXISTS idx_network_relationships_source ON network_relationships(organization_id, source_kind, source_id);
+CREATE INDEX IF NOT EXISTS idx_network_relationships_target ON network_relationships(organization_id, target_kind, target_id);
+CREATE INDEX IF NOT EXISTS idx_network_relationships_state ON network_relationships(organization_id, resolution_state);


### PR DESCRIPTION
## Summary

Closes #190, #191, #192, and #193.

This PR ships the next durable discovery/network model slice:

- Adds durable managed `network_objects` for VPCs, subnets, EIPs/public IPs, networks, placeholders, and other provider-neutral network objects.
- Adds durable `network_relationships` so matches, containment, conflicts, missing parents, imports, and duplicate evidence can survive recomputation and process restarts.
- Includes managed network objects and relationship records in merged network views.
- Extends real network conflict actions with `create_placeholder_parent`.
- Records durable relationships for computed conflicts and successful `link`/`import`/placeholder actions.
- Adds request-scoped schema policy evaluation for account-level, region-level, global, and manual duplicate handling.
- Adds `POST /api/v1/network/relationships/resolve` so caller-supplied relationship IDs containing URL path separators can be resolved from the request body.
- Generates URL-safe opaque relationship IDs when CloudPAM creates relationship IDs automatically.

Follow-up issue #204 tracks persisting schema policy as an operator setting rather than only request-scoped query parameters.

## API

New and updated endpoints:

- `GET /api/v1/network/objects`
- `POST /api/v1/network/objects`
- `GET /api/v1/network/objects/{objectId}`
- `PATCH /api/v1/network/objects/{objectId}`
- `GET /api/v1/network/relationships`
- `POST /api/v1/network/relationships`
- `POST /api/v1/network/relationships/resolve`
- `POST /api/v1/network/relationships/{relationshipId}/resolve`
- `POST /api/v1/network/conflicts/{conflictId}/actions/create_placeholder_parent`

Merged network views now accept `schema_policy` and `duplicates` query params.

## Storage

- Adds SQLite migration `0021_network_objects_relationships.sql`.
- Adds PostgreSQL migration `0022_network_objects_relationships.up.sql`.
- Adds memory, SQLite, and PostgreSQL `NetworkStore` implementations.
- Wires `NetworkStore` selection through memory, SQLite, PostgreSQL, and combined builds.

## Documentation

- Adds `0.17.0` changelog notes for durable network objects, relationships, placeholder-parent action support, schema policy query handling, and body-based relationship resolution.
- Updates `docs/DISCOVERY.md` with managed network object usage, relationship resolution, and schema policy behavior.

## Testing

Ran:

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./internal/api ./internal/storage`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./...`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test -tags sqlite ./internal/storage/sqlite`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test -tags postgres ./cmd/cloudpam`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test -tags 'sqlite postgres' ./cmd/cloudpam`

Not run:

- Live PostgreSQL storage package tests, because `internal/storage/postgres` requires `DATABASE_URL` in `TestMain`.

## Notes

- No UI screenshots included because this PR is backend/API/docs only.
- Path-based relationship resolution is retained for URL-safe IDs; the new body-based resolve endpoint is the recommended path for caller-supplied IDs that may contain `/`.
