### PR TITLE
Discovery: audit network conflict actions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
-## [0.17.0] - 2026-06-03
+## [0.17.1] - 2026-06-03
 
 ### Added
 - Added durable managed network objects and explicit network relationships so VPCs, subnets, EIPs/public IPs, soft links, conflict evidence, placeholder parents, and imported relationships can be stored separately from allocated blocks.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ patch or minor version entry for every user-facing change.
 - Added `POST /api/v1/network/relationships/resolve` so relationship IDs that contain URL path separators can be resolved from the request body while server-generated relationship IDs remain URL-safe.
 - Merged network conflict evaluation now supports schema policy query options for account-level, region-level, global, and manual duplicate handling with policy evidence in conflict responses.
 - Network conflict decisions and concrete actions now write audit events, and link actions can update an existing discovered-resource pool association when an alternate exact-pool conflict identifies the target pool.
+- The Merged Network conflict UI now exposes alternate exact-pool filtering, placeholder-parent actions, and the full network conflict action response contract.
 
 ## [0.16.2] - 2026-06-02
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ patch or minor version entry for every user-facing change.
 - Added network object and relationship APIs under `/api/v1/network/objects` and `/api/v1/network/relationships`, plus placeholder-parent conflict action support.
 - Added `POST /api/v1/network/relationships/resolve` so relationship IDs that contain URL path separators can be resolved from the request body while server-generated relationship IDs remain URL-safe.
 - Merged network conflict evaluation now supports schema policy query options for account-level, region-level, global, and manual duplicate handling with policy evidence in conflict responses.
+- Network conflict decisions and concrete actions now write audit events, and link actions can update an existing discovered-resource pool association when an alternate exact-pool conflict identifies the target pool.
 
 ## [0.16.2] - 2026-06-02
 

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"cloudpam/internal/audit"
 	"cloudpam/internal/auth"
 	"cloudpam/internal/domain"
 	"cloudpam/internal/storage"
@@ -362,6 +363,11 @@ func (ns *NetworkServer) handleResolveNetworkConflict(w http.ResponseWriter, r *
 			conflict.Status = string(networkDecisionStatus(req.Decision))
 			conflict.ResolutionState = conflict.Status
 			conflict.ResolutionRequested = req.Decision
+			ns.logNetworkConflictAudit(r.Context(), "resolve", conflict, map[string]any{
+				"decision": req.Decision,
+				"status":   conflict.Status,
+				"reason":   req.Reason,
+			})
 			writeJSON(w, http.StatusOK, conflict)
 			return
 		}
@@ -426,6 +432,10 @@ func (ns *NetworkServer) handleNetworkConflictLinkAction(w http.ResponseWriter, 
 		"discovered_id":           req.DiscoveredID.String(),
 		"pool_id":                 fmt.Sprintf("%d", req.PoolID),
 	}
+	previousPoolID := res.PoolID
+	if previousPoolID != nil {
+		actionDetails["previous_pool_id"] = fmt.Sprintf("%d", *previousPoolID)
+	}
 	resolveReq := domain.ResolveNetworkConflictRequest{
 		Decision: "link",
 		Reason:   networkActionReason("link", req.Reason, actionDetails),
@@ -434,7 +444,6 @@ func (ns *NetworkServer) handleNetworkConflictLinkAction(w http.ResponseWriter, 
 		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "prepare conflict action failed", err.Error())
 		return
 	}
-	previousPoolID := res.PoolID
 	if err := ns.discStore.LinkResourceToPool(r.Context(), req.DiscoveredID, req.PoolID); err != nil {
 		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "link resource to pool failed", err.Error())
 		return
@@ -462,12 +471,19 @@ func (ns *NetworkServer) handleNetworkConflictLinkAction(w http.ResponseWriter, 
 	}})
 
 	updated := ns.conflictAfterAction(r.Context(), *conflict, "link")
+	ns.logNetworkConflictAudit(r.Context(), "link", *conflict, map[string]any{
+		"discovered_id":    req.DiscoveredID.String(),
+		"pool_id":          req.PoolID,
+		"previous_pool_id": valueOrNil(previousPoolID),
+		"relationships":    len(relationships),
+	})
 	writeJSON(w, http.StatusOK, domain.NetworkConflictActionResponse{
 		Conflict:       updated,
 		Action:         "link",
 		ResourceLinked: true,
 		DiscoveredID:   &req.DiscoveredID,
 		PoolID:         &req.PoolID,
+		PreviousPoolID: previousPoolID,
 		Relationships:  relationships,
 	})
 }
@@ -619,6 +635,15 @@ func (ns *NetworkServer) handleNetworkConflictImportAction(w http.ResponseWriter
 	relationships := ns.persistNetworkConflictActionRelationships(r.Context(), "import", *conflict, relationshipInputs)
 
 	updated := ns.conflictAfterAction(r.Context(), *conflict, "import")
+	ns.logNetworkConflictAudit(r.Context(), "import", *conflict, map[string]any{
+		"pool_id":             valueOrNil(req.PoolID),
+		"pools_created":       importResp.PoolsCreated,
+		"resources_linked":    importResp.ResourcesLinked,
+		"created_pool_ids":    importResp.CreatedPoolIDs,
+		"linked_resource_ids": importResp.LinkedResourceIDs,
+		"relationships":       len(relationships),
+		"selected_resources":  req.ResourceIDs,
+	})
 	writeJSON(w, http.StatusOK, domain.NetworkConflictActionResponse{
 		Conflict:      updated,
 		Action:        "import",
@@ -743,6 +768,11 @@ func (ns *NetworkServer) handleNetworkConflictPlaceholderParentAction(w http.Res
 		},
 	})
 	updated := ns.conflictAfterAction(r.Context(), *conflict, "create_placeholder_parent")
+	ns.logNetworkConflictAudit(r.Context(), "create_placeholder_parent", *conflict, map[string]any{
+		"discovered_id":     req.DiscoveredID.String(),
+		"network_object_id": obj.ID,
+		"relationships":     len(relationships),
+	})
 	writeJSON(w, http.StatusOK, domain.NetworkConflictActionResponse{
 		Conflict:      updated,
 		Action:        "create_placeholder_parent",
@@ -1250,25 +1280,35 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 				continue
 			}
 			if networkCIDREqual(res.CIDR, pool.CIDR) {
-				if res.PoolID == nil {
-					add(domain.NetworkConflict{
-						ID:                fmt.Sprintf("unlinked-exact-pool:%s:%d", res.ID.String(), pool.ID),
-						Type:              "unlinked_exact_pool",
-						Severity:          "warning",
-						Status:            "open",
-						Title:             "Discovered CIDR matches managed pool",
-						Description:       fmt.Sprintf("%s (%s) exactly matches pool %s", res.ResourceID, res.CIDR, pool.Name),
-						RecommendedAction: "Link the discovered resource to the matching managed pool, import separately, or mark reviewed.",
-						NodeIDs:           []string{nodeID, poolNodeID(pool.ID)},
-						DiscoveredIDs:     []uuid.UUID{res.ID},
-						PoolIDs:           []int64{pool.ID},
-						AccountIDs:        accountIDsForPool(res.AccountID, pool),
-						Regions:           []string{res.Region},
-						ObjectTypes:       []string{string(res.ResourceType), string(pool.Type)},
-						CIDR:              res.CIDR,
-						Evidence:          []string{fmt.Sprintf("pool_id=%d", pool.ID), "pool_cidr=" + pool.CIDR},
-					})
+				conflictType := "unlinked_exact_pool"
+				conflictID := fmt.Sprintf("unlinked-exact-pool:%s:%d", res.ID.String(), pool.ID)
+				title := "Discovered CIDR matches managed pool"
+				recommendedAction := "Link the discovered resource to the matching managed pool, import separately, or mark reviewed."
+				evidence := []string{fmt.Sprintf("pool_id=%d", pool.ID), "pool_cidr=" + pool.CIDR}
+				if res.PoolID != nil {
+					conflictType = "alternate_exact_pool"
+					conflictID = fmt.Sprintf("alternate-exact-pool:%s:%d", res.ID.String(), pool.ID)
+					title = "Discovered CIDR matches another managed pool"
+					recommendedAction = "Update the discovered resource link to the matching managed pool, keep the current link, or mark reviewed."
+					evidence = append(evidence, fmt.Sprintf("current_pool_id=%d", *res.PoolID))
 				}
+				add(domain.NetworkConflict{
+					ID:                conflictID,
+					Type:              conflictType,
+					Severity:          "warning",
+					Status:            "open",
+					Title:             title,
+					Description:       fmt.Sprintf("%s (%s) exactly matches pool %s", res.ResourceID, res.CIDR, pool.Name),
+					RecommendedAction: recommendedAction,
+					NodeIDs:           []string{nodeID, poolNodeID(pool.ID)},
+					DiscoveredIDs:     []uuid.UUID{res.ID},
+					PoolIDs:           []int64{pool.ID},
+					AccountIDs:        accountIDsForPool(res.AccountID, pool),
+					Regions:           []string{res.Region},
+					ObjectTypes:       []string{string(res.ResourceType), string(pool.Type)},
+					CIDR:              res.CIDR,
+					Evidence:          evidence,
+				})
 				continue
 			}
 			if !networkCIDROverlaps(res.CIDR, pool.CIDR) {
@@ -1427,6 +1467,15 @@ func (ns *NetworkServer) persistNetworkConflictActionResolution(ctx context.Cont
 	return ns.driftStore.UpdateDriftStatus(ctx, conflict.ID, status, reason)
 }
 
+func (ns *NetworkServer) logNetworkConflictAudit(ctx context.Context, action string, conflict domain.NetworkConflict, after map[string]any) {
+	if after == nil {
+		after = map[string]any{}
+	}
+	after["conflict_id"] = conflict.ID
+	after["conflict_type"] = conflict.Type
+	ns.srv.logAuditWithChanges(ctx, "network_conflict."+action, audit.ResourceNetworkConflict, conflict.ID, conflict.Title, &audit.Changes{After: after}, http.StatusOK)
+}
+
 func (ns *NetworkServer) ensureNetworkConflictResolutionRecord(ctx context.Context, conflict domain.NetworkConflict, reason string, details map[string]string) error {
 	if ns.driftStore == nil {
 		return fmt.Errorf("drift store is not available")
@@ -1541,7 +1590,7 @@ func relationshipsFromConflict(conflict domain.NetworkConflict) []domain.CreateN
 		relationshipType = domain.NetworkRelationshipMissingParent
 	case "duplicate_cidr":
 		relationshipType = domain.NetworkRelationshipDuplicateOf
-	case "unlinked_exact_pool":
+	case "unlinked_exact_pool", "alternate_exact_pool":
 		relationshipType = domain.NetworkRelationshipMatches
 	case "managed_overlap", "linked_pool_mismatch", "outside_pool", "invalid_nesting", "invalid_cidr":
 		relationshipType = domain.NetworkRelationshipConflicts
@@ -1637,8 +1686,8 @@ func validateNetworkConflictLinkAction(conflict domain.NetworkConflict, res doma
 	if !containsInt64(conflict.PoolIDs, req.PoolID) {
 		return fmt.Errorf("pool is not part of this conflict")
 	}
-	if res.PoolID != nil {
-		return fmt.Errorf("discovered resource is already linked")
+	if res.PoolID != nil && *res.PoolID == req.PoolID {
+		return fmt.Errorf("discovered resource is already linked to this pool")
 	}
 	if !req.Override {
 		if pool.AccountID != nil && *pool.AccountID != res.AccountID {

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"cloudpam/internal/audit"
 	"cloudpam/internal/domain"
 	"cloudpam/internal/storage"
 )
@@ -399,6 +400,7 @@ func TestNetworkConflictsExposeMissingParentAndResolveRequest(t *testing.T) {
 	if resp.Items[0].Status != "resolved" || resp.Items[0].ResolutionRequested != "skip" {
 		t.Fatalf("resolution was not durable in computed conflict view: %+v", resp.Items[0])
 	}
+	assertNetworkConflictAuditAction(t, discSrv.srv, resolved.ID, "network_conflict.resolve")
 }
 
 func TestNetworkConflictCreatePlaceholderParentAction(t *testing.T) {
@@ -456,6 +458,7 @@ func TestNetworkConflictCreatePlaceholderParentAction(t *testing.T) {
 	if objects.Total != 1 || objects.Items[0].ProviderResourceID != parent {
 		t.Fatalf("placeholder object not durable/listable: %+v", objects)
 	}
+	assertNetworkConflictAuditAction(t, discSrv.srv, conflicts.Items[0].ID, "network_conflict.create_placeholder_parent")
 }
 
 func TestNetworkSchemaPolicyChangesDuplicateDetection(t *testing.T) {
@@ -581,6 +584,67 @@ func TestNetworkConflictLinkActionLinksExactPoolAndResolves(t *testing.T) {
 	if linked.PoolID == nil || *linked.PoolID != pool.ID {
 		t.Fatalf("resource was not linked to pool: %+v", linked)
 	}
+	assertNetworkConflictAuditAction(t, discSrv.srv, conflicts.Items[0].ID, "network_conflict.link")
+}
+
+func TestNetworkConflictLinkActionUpdatesExistingAssociation(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	oldPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "old-vpc", CIDR: "10.105.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create old pool: %v", err)
+	}
+	newPool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "new-vpc", CIDR: "10.105.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create new pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-prod",
+		Name:         "prod-vpc",
+		CIDR:         "10.105.0.0/16",
+		PoolID:       &oldPool.ID,
+		Status:       domain.DiscoveryStatusActive,
+		DiscoveredAt: now,
+		LastSeenAt:   now,
+	})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=alternate_exact_pool", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected one alternate exact-pool conflict, got %+v", conflicts)
+	}
+
+	body := fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d,"reason":"use newer managed pool"}`, vpcID, newPool.ID)
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), body, http.StatusOK)
+	var action domain.NetworkConflictActionResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &action); err != nil {
+		t.Fatalf("unmarshal link action: %v", err)
+	}
+	if action.Action != "link" || !action.ResourceLinked || action.PreviousPoolID == nil || *action.PreviousPoolID != oldPool.ID {
+		t.Fatalf("unexpected relink action response: %+v", action)
+	}
+	linked, err := ds.GetDiscoveredResource(t.Context(), vpcID)
+	if err != nil {
+		t.Fatalf("load linked resource: %v", err)
+	}
+	if linked.PoolID == nil || *linked.PoolID != newPool.ID {
+		t.Fatalf("resource was not relinked to new pool: %+v", linked)
+	}
+	assertNetworkConflictAuditAction(t, discSrv.srv, conflicts.Items[0].ID, "network_conflict.link")
 }
 
 func TestNetworkConflictLinkActionRejectsUnrelatedAndUnsafePayloads(t *testing.T) {
@@ -681,6 +745,7 @@ func TestNetworkConflictImportActionImportsMissingParentWithOverride(t *testing.
 	if linked.PoolID == nil {
 		t.Fatalf("resource was not linked after import: %+v", linked)
 	}
+	assertNetworkConflictAuditAction(t, discSrv.srv, conflicts.Items[0].ID, "network_conflict.import")
 }
 
 func TestNetworkConflictImportActionRejectsCrossAccountParentPoolWithOverride(t *testing.T) {
@@ -997,6 +1062,24 @@ func (s *failResolvedDriftStore) UpdateDriftDetails(ctx context.Context, id stri
 
 func (s *failResolvedDriftStore) DeleteOpenForAccount(ctx context.Context, accountID int64) error {
 	return s.base.DeleteOpenForAccount(ctx, accountID)
+}
+
+func assertNetworkConflictAuditAction(t *testing.T, srv *Server, conflictID, action string) {
+	t.Helper()
+	events, err := srv.auditLogger.GetByResource(t.Context(), audit.ResourceNetworkConflict, conflictID)
+	if err != nil {
+		t.Fatalf("get conflict audit events: %v", err)
+	}
+	for _, event := range events {
+		if event.Action != action {
+			continue
+		}
+		if event.Changes == nil || event.Changes.After["conflict_id"] != conflictID {
+			t.Fatalf("audit event missing conflict after details: %+v", event)
+		}
+		return
+	}
+	t.Fatalf("audit action %q not found for conflict %s: %+v", action, conflictID, events)
 }
 
 func hierarchyHasParentChild(nodes []domain.NetworkNode, parentPrefix string, childID string) bool {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -128,6 +128,11 @@ func (s *Server) writeStoreErr(ctx context.Context, w http.ResponseWriter, err e
 
 // logAudit logs an audit event for CRUD operations.
 func (s *Server) logAudit(ctx context.Context, action, resourceType, resourceID, resourceName string, statusCode int) {
+	s.logAuditWithChanges(ctx, action, resourceType, resourceID, resourceName, nil, statusCode)
+}
+
+// logAuditWithChanges logs an audit event with optional before/after details.
+func (s *Server) logAuditWithChanges(ctx context.Context, action, resourceType, resourceID, resourceName string, changes *audit.Changes, statusCode int) {
 	if s.auditLogger == nil {
 		return
 	}
@@ -150,6 +155,7 @@ func (s *Server) logAudit(ctx context.Context, action, resourceType, resourceID,
 		ResourceType: resourceType,
 		ResourceID:   resourceID,
 		ResourceName: resourceName,
+		Changes:      changes,
 		StatusCode:   statusCode,
 	}
 	if reqID := ctx.Value(requestIDContextKey); reqID != nil {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -62,11 +62,12 @@ const (
 
 // Valid resource types for audit events.
 const (
-	ResourcePool    = "pool"
-	ResourceAccount = "account"
-	ResourceAPIKey  = "api_key"
-	ResourceUser    = "user"
-	ResourceSession = "session"
+	ResourcePool            = "pool"
+	ResourceAccount         = "account"
+	ResourceAPIKey          = "api_key"
+	ResourceUser            = "user"
+	ResourceSession         = "session"
+	ResourceNetworkConflict = "network_conflict"
 )
 
 // Valid actor types.

--- a/internal/domain/network.go
+++ b/internal/domain/network.go
@@ -279,6 +279,7 @@ type NetworkConflictActionResponse struct {
 	ResourceLinked bool                          `json:"resource_linked,omitempty"`
 	DiscoveredID   *uuid.UUID                    `json:"discovered_id,omitempty"`
 	PoolID         *int64                        `json:"pool_id,omitempty"`
+	PreviousPoolID *int64                        `json:"previous_pool_id,omitempty"`
 	NetworkObject  *NetworkObject                `json:"network_object,omitempty"`
 	Relationships  []NetworkRelationship         `json:"relationships,omitempty"`
 	Import         *DiscoveryImportApplyResponse `json:"import,omitempty"`

--- a/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
+++ b/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
@@ -34,6 +34,17 @@ const pools: Pool[] = [
   },
 ]
 
+const missingParentConflict: NetworkConflict = {
+  ...conflict,
+  id: 'missing-parent:00000000-0000-0000-0000-000000000001',
+  type: 'missing_parent',
+  title: 'Discovered resource references missing parent',
+  description: 'subnet-1 references vpc-missing',
+  recommended_action: 'Create a placeholder parent, import, or mark reviewed.',
+  pool_ids: [],
+  evidence: ['parent_resource_id=vpc-missing'],
+}
+
 const preview: DiscoveryImportPreviewResponse = {
   items: [],
   importable: 1,
@@ -52,6 +63,7 @@ function renderList(overrides: Partial<ComponentProps<typeof NetworkConflictList
     onResolve: vi.fn(),
     onLink: vi.fn(),
     onImport: vi.fn(),
+    onPlaceholderParent: vi.fn(),
     onPreviewImport: vi.fn().mockResolvedValue(preview),
     pools,
     ...overrides,
@@ -112,6 +124,25 @@ describe('NetworkConflictList', () => {
       undefined,
       '',
       false,
+    )
+  })
+
+  it('submits a placeholder-parent action for missing parent conflicts', () => {
+    const props = renderList({
+      conflicts: [missingParentConflict],
+      selected: missingParentConflict,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Placeholder parent/i }))
+    fireEvent.change(screen.getByPlaceholderText('Placeholder name'), { target: { value: 'placeholder-vpc' } })
+    fireEvent.change(screen.getByPlaceholderText('Reason'), { target: { value: 'parent not scanned yet' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create placeholder' }))
+
+    expect(props.onPlaceholderParent).toHaveBeenCalledWith(
+      missingParentConflict,
+      '00000000-0000-0000-0000-000000000001',
+      'placeholder-vpc',
+      'parent not scanned yet',
     )
   })
 })

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -602,12 +602,51 @@ export interface NetworkConflictImportActionRequest {
   override?: boolean
 }
 
+export interface NetworkConflictPlaceholderParentActionRequest {
+  discovered_id: string
+  name?: string
+  reason?: string
+}
+
+export interface NetworkObject {
+  id: number
+  object_type: string
+  provider: string
+  account_id: number
+  region?: string
+  name: string
+  cidr?: string
+  provider_resource_id?: string
+  state: string
+  metadata?: Record<string, string>
+  created_at: string
+  updated_at: string
+}
+
+export interface NetworkRelationship {
+  id: string
+  type: string
+  source_kind: string
+  source_id: string
+  target_kind: string
+  target_id: string
+  confidence: number
+  reason?: string
+  evidence?: string[]
+  resolution_state: string
+  created_at: string
+  updated_at: string
+}
+
 export interface NetworkConflictActionResponse {
   conflict: NetworkConflict
-  action: 'link' | 'import'
+  action: 'link' | 'import' | 'create_placeholder_parent'
   resource_linked?: boolean
   discovered_id?: string
   pool_id?: number
+  previous_pool_id?: number
+  network_object?: NetworkObject
+  relationships?: NetworkRelationship[]
   import?: DiscoveryImportApplyResponse
 }
 

--- a/ui/src/hooks/useNetwork.ts
+++ b/ui/src/hooks/useNetwork.ts
@@ -6,6 +6,7 @@ import type {
   NetworkConflictImportActionRequest,
   NetworkConflictLinkActionRequest,
   NetworkConflictListResponse,
+  NetworkConflictPlaceholderParentActionRequest,
   NetworkViewResponse,
 } from '../api/types'
 
@@ -117,6 +118,16 @@ export function useNetworkView() {
     [],
   )
 
+  const createPlaceholderParentConflict = useCallback(
+    async (id: string, req: NetworkConflictPlaceholderParentActionRequest) => {
+      return post<NetworkConflictActionResponse>(
+        `/api/v1/network/conflicts/${encodeURIComponent(id)}/actions/create_placeholder_parent`,
+        req,
+      )
+    },
+    [],
+  )
+
   return {
     flat,
     hierarchy,
@@ -129,5 +140,6 @@ export function useNetworkView() {
     resolveConflict,
     linkConflict,
     importConflict,
+    createPlaceholderParentConflict,
   }
 }

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -750,6 +750,7 @@ function NetworkTab({
     resolveConflict,
     linkConflict,
     importConflict,
+    createPlaceholderParentConflict,
   } = useNetworkView()
   const { previewDiscoveryImport: previewNetworkImport } = useSyncJobs()
   const { showToast } = useToast()
@@ -818,6 +819,21 @@ function NetworkTab({
     }
   }
 
+  async function handlePlaceholderParentAction(conflict: NetworkConflict, discoveredId: string, name: string, reason: string) {
+    try {
+      const resp = await createPlaceholderParentConflict(conflict.id, {
+        discovered_id: discoveredId,
+        name: name || undefined,
+        reason: reason || undefined,
+      })
+      showToast(`Placeholder parent ${resp.network_object?.name || 'created'}`, 'success')
+      setSelectedConflict(resp.conflict)
+      load()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Placeholder parent action failed', 'error')
+    }
+  }
+
   async function handlePreviewImportAction(conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined) {
     const accountId = conflict.account_ids?.[0] ?? selectedAccountId
     if (!accountId) {
@@ -868,6 +884,7 @@ function NetworkTab({
             <option value="">All issues</option>
             <option value="missing_parent">Missing parent</option>
             <option value="unlinked_exact_pool">Exact pool match</option>
+            <option value="alternate_exact_pool">Alternate exact pool</option>
             <option value="invalid_nesting">Invalid nesting</option>
             <option value="outside_pool">Outside pool</option>
             <option value="duplicate_cidr">Duplicate CIDR</option>
@@ -906,6 +923,7 @@ function NetworkTab({
           onResolve={handleResolve}
           onLink={handleLinkAction}
           onImport={handleImportAction}
+          onPlaceholderParent={handlePlaceholderParentAction}
           onPreviewImport={handlePreviewImportAction}
           pools={pools}
         />
@@ -1046,6 +1064,7 @@ export function NetworkConflictList({
   onResolve,
   onLink,
   onImport,
+  onPlaceholderParent,
   onPreviewImport,
   pools,
 }: {
@@ -1056,14 +1075,17 @@ export function NetworkConflictList({
   onResolve: (conflict: NetworkConflict, decision: string) => void
   onLink: (conflict: NetworkConflict, discoveredId: string, poolId: number, reason: string, override: boolean) => void
   onImport: (conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined, reason: string, override: boolean) => void
+  onPlaceholderParent: (conflict: NetworkConflict, discoveredId: string, name: string, reason: string) => void
   onPreviewImport: (conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined) => Promise<DiscoveryImportPreviewResponse>
   pools: Pool[]
 }) {
-  const [actionMode, setActionMode] = useState<'link' | 'import' | null>(null)
+  const [actionMode, setActionMode] = useState<'link' | 'import' | 'placeholder_parent' | null>(null)
   const [linkDiscoveredID, setLinkDiscoveredID] = useState('')
   const [linkPoolID, setLinkPoolID] = useState('')
   const [importResourceIDs, setImportResourceIDs] = useState<string[]>([])
   const [importPoolID, setImportPoolID] = useState('')
+  const [placeholderDiscoveredID, setPlaceholderDiscoveredID] = useState('')
+  const [placeholderName, setPlaceholderName] = useState('')
   const [reason, setReason] = useState('')
   const [override, setOverride] = useState(false)
   const [preview, setPreview] = useState<DiscoveryImportPreviewResponse | null>(null)
@@ -1080,11 +1102,14 @@ export function NetworkConflictList({
     setLinkPoolID(selected?.pool_ids?.[0] ? String(selected.pool_ids[0]) : '')
     setImportResourceIDs(selected?.discovered_ids ?? [])
     setImportPoolID('')
+    setPlaceholderDiscoveredID(selected?.discovered_ids?.[0] ?? '')
+    setPlaceholderName('')
   }, [selected?.id])
 
   if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
   const poolOptions = pools.filter((pool) => !selected?.pool_ids?.length || selected.pool_ids.includes(pool.id))
   const allPoolOptions = poolOptions.length > 0 ? poolOptions : pools
+  const canCreatePlaceholderParent = selected?.type === 'missing_parent' && (selected.discovered_ids?.length ?? 0) > 0
 
   async function previewImport() {
     if (!selected) return
@@ -1176,6 +1201,16 @@ export function NetworkConflictList({
                   <UploadCloud className="h-3.5 w-3.5" />
                   Import as pool
                 </button>
+                {canCreatePlaceholderParent && (
+                  <button
+                    type="button"
+                    onClick={() => setActionMode(actionMode === 'placeholder_parent' ? null : 'placeholder_parent')}
+                    className="inline-flex items-center gap-1 rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Placeholder parent
+                  </button>
+                )}
               </div>
               {actionError && <div className="mt-2 text-xs text-red-600 dark:text-red-400">{actionError}</div>}
               {actionMode === 'link' && (
@@ -1276,6 +1311,37 @@ export function NetworkConflictList({
                       {preview.importable} importable, {preview.blocked} blocked, {preview.conflict_count} conflicts
                     </div>
                   )}
+                </div>
+              )}
+              {actionMode === 'placeholder_parent' && canCreatePlaceholderParent && (
+                <div className="mt-3 space-y-2">
+                  <select
+                    value={placeholderDiscoveredID}
+                    onChange={(e) => setPlaceholderDiscoveredID(e.target.value)}
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                  >
+                    {(selected.discovered_ids ?? []).map((id) => <option key={id} value={id}>{id}</option>)}
+                  </select>
+                  <input
+                    value={placeholderName}
+                    onChange={(e) => setPlaceholderName(e.target.value)}
+                    placeholder="Placeholder name"
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                  />
+                  <input
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    placeholder="Reason"
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                  />
+                  <button
+                    type="button"
+                    disabled={!placeholderDiscoveredID}
+                    onClick={() => selected && onPlaceholderParent(selected, placeholderDiscoveredID, placeholderName, reason)}
+                    className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Create placeholder
+                  </button>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary

Ships the remaining issue 192 network conflict action work as version `0.17.1`.

This PR makes network conflict decisions and concrete actions auditable, and it adds a safe relink path for discovered resources that already point at one managed pool but exactly match another managed pool.

Closes #192.

## What Changed

- Added `network_conflict.resolve` audit events for successful `skip`, `ignore`, and `defer` decisions.
- Added action-specific audit events for successful `link`, `import`, and `create_placeholder_parent` actions.
- Added audit `after` details that include the conflict ID, conflict type, and changed resource IDs/counts.
- Added an `alternate_exact_pool` conflict type for already-linked discovered resources whose CIDR exactly matches a different managed pool.
- Updated `link` validation so relinks are allowed only when the target pool is part of the selected conflict and account/CIDR checks pass, while no-op links to the current pool are rejected.
- Added `previous_pool_id` to link action responses when an existing association is updated.
- Added the `alternate_exact_pool` option to the Merged Network issue filter.
- Added a Merged Network placeholder-parent action form for missing-parent conflicts.
- Updated UI API types for `create_placeholder_parent`, `previous_pool_id`, `network_object`, and `relationships`.
- Updated changelog notes under `0.17.1`.

## Validation

- Invalid link requests are still rejected when the discovered resource or pool is not part of the selected conflict.
- `override` does not allow arbitrary relinks outside the selected conflict.
- Relinks preserve rollback behavior if final conflict resolution persistence fails.
- Audit logging remains non-fatal, matching existing CloudPAM audit behavior.

## Tests

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./internal/api ./internal/storage`
- `cd ui && npm run build`
- `cd ui && npm test -- DiscoveryNetworkConflictList`

Earlier verification on the same implementation also passed:

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./...`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test -tags sqlite ./internal/storage/sqlite`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test -tags postgres ./cmd/cloudpam`
