### PR TITLE
UI: complete Discovery network object and relationship surface

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,9 @@ patch or minor version entry for every user-facing change.
 - Discovery Merged Network now includes managed network object and relationship browsers, request-scoped schema policy controls, relink-oriented alternate exact-pool actions, placeholder-parent action summaries, and inline network action result details.
 - Network relationship resolution in the UI now uses an explicit per-row Apply action with pending state and inline error handling.
 
+### Fixed
+- Merged Network relationship filters now stay scoped to the selected account and use the backend's `resolved` relationship state vocabulary.
+
 ## [0.17.1] - 2026-06-03
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.17.2] - 2026-06-03
+
+### Added
+- Discovery Merged Network now includes managed network object and relationship browsers, request-scoped schema policy controls, relink-oriented alternate exact-pool actions, placeholder-parent action summaries, and inline network action result details.
+- Network relationship resolution in the UI now uses an explicit per-row Apply action with pending state and inline error handling.
+
 ## [0.17.1] - 2026-06-03
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ patch or minor version entry for every user-facing change.
 
 ### Added
 - Discovery Merged Network now includes managed network object and relationship browsers, request-scoped schema policy controls, relink-oriented alternate exact-pool actions, placeholder-parent action summaries, and inline network action result details.
+- Discovery conflict details now show structured affected resources, ownership, pool and parent evidence, CIDR/IP evidence, attached relationships, current resolution state, and navigation back to affected merged rows or relationship filters.
+- Managed network object browsing now supports provider, region, pool ID, and source discovered resource filters in addition to account, type, state, and search.
 - Network relationship resolution in the UI now uses an explicit per-row Apply action with pending state and inline error handling.
 
 ### Fixed

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -853,11 +853,14 @@ func networkObjectFiltersFromRequest(r *http.Request) domain.NetworkObjectFilter
 func networkRelationshipFiltersFromRequest(r *http.Request) domain.NetworkRelationshipFilters {
 	q := r.URL.Query()
 	return domain.NetworkRelationshipFilters{
+		IDs:             q["id"],
 		Type:            q.Get("type"),
 		SourceKind:      q.Get("source_kind"),
 		SourceID:        q.Get("source_id"),
 		TargetKind:      q.Get("target_kind"),
 		TargetID:        q.Get("target_id"),
+		EntityKind:      q.Get("entity_kind"),
+		EntityID:        q.Get("entity_id"),
 		ResolutionState: q.Get("resolution_state"),
 	}
 }

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -837,6 +837,16 @@ func networkObjectFiltersFromRequest(r *http.Request) domain.NetworkObjectFilter
 			filters.AccountID = id
 		}
 	}
+	if idText := q.Get("pool_id"); idText != "" {
+		if id, err := strconv.ParseInt(idText, 10, 64); err == nil {
+			filters.PoolID = id
+		}
+	}
+	if idText := q.Get("source_discovered_id"); idText != "" {
+		if id, err := uuid.Parse(idText); err == nil {
+			filters.SourceDiscoveredID = id.String()
+		}
+	}
 	return filters
 }
 

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -244,6 +244,9 @@ func (ns *NetworkServer) handleNetworkRelationships(w http.ResponseWriter, r *ht
 			ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "list network relationships failed", err.Error())
 			return
 		}
+		if accountID := relationshipAccountIDFromRequest(r); accountID > 0 {
+			relationships = ns.filterNetworkRelationshipsByAccount(r.Context(), relationships, accountID)
+		}
 		writeJSON(w, http.StatusOK, domain.NetworkRelationshipListResponse{Items: relationships, Total: len(relationships)})
 	case http.MethodPost:
 		var req domain.CreateNetworkRelationship
@@ -846,6 +849,53 @@ func networkRelationshipFiltersFromRequest(r *http.Request) domain.NetworkRelati
 		TargetKind:      q.Get("target_kind"),
 		TargetID:        q.Get("target_id"),
 		ResolutionState: q.Get("resolution_state"),
+	}
+}
+
+func relationshipAccountIDFromRequest(r *http.Request) int64 {
+	accountID, _ := strconv.ParseInt(r.URL.Query().Get("account_id"), 10, 64)
+	return accountID
+}
+
+func (ns *NetworkServer) filterNetworkRelationshipsByAccount(ctx context.Context, relationships []domain.NetworkRelationship, accountID int64) []domain.NetworkRelationship {
+	filtered := make([]domain.NetworkRelationship, 0, len(relationships))
+	for _, relationship := range relationships {
+		if ns.relationshipEndpointBelongsToAccount(ctx, relationship.SourceKind, relationship.SourceID, accountID) ||
+			ns.relationshipEndpointBelongsToAccount(ctx, relationship.TargetKind, relationship.TargetID, accountID) {
+			filtered = append(filtered, relationship)
+		}
+	}
+	return filtered
+}
+
+func (ns *NetworkServer) relationshipEndpointBelongsToAccount(ctx context.Context, kind string, id string, accountID int64) bool {
+	switch kind {
+	case "discovered":
+		resourceID, err := uuid.Parse(id)
+		if err != nil {
+			return false
+		}
+		resource, err := ns.discStore.GetDiscoveredResource(ctx, resourceID)
+		return err == nil && resource.AccountID == accountID
+	case "pool":
+		poolID, err := strconv.ParseInt(id, 10, 64)
+		if err != nil {
+			return false
+		}
+		pool, found, err := ns.store.GetPool(ctx, poolID)
+		return err == nil && found && pool.AccountID != nil && *pool.AccountID == accountID
+	case "network_object":
+		objectID, err := strconv.ParseInt(id, 10, 64)
+		if err != nil || ns.networkStore == nil {
+			return false
+		}
+		object, found, err := ns.networkStore.GetNetworkObject(ctx, objectID)
+		return err == nil && found && object.AccountID == accountID
+	case "conflict":
+		conflict, err := ns.findNetworkConflict(ctx, id)
+		return err == nil && conflict != nil && containsInt64(conflict.AccountIDs, accountID)
+	default:
+		return false
 	}
 }
 

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -70,7 +70,12 @@ func TestNetworkObjectsCreateUpdateAndAppearInMergedView(t *testing.T) {
 		t.Fatalf("create account: %v", err)
 	}
 
-	body := fmt.Sprintf(`{"object_type":"vpc","provider":"aws","account_id":%d,"region":"us-east-1","name":"managed-vpc","cidr":"10.60.0.0/16","provider_resource_id":"vpc-managed"}`, account.ID)
+	sourceID := uuid.New()
+	pool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "managed-root", CIDR: "10.60.0.0/16", Type: domain.PoolTypeVPC, Status: domain.PoolStatusActive})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	body := fmt.Sprintf(`{"object_type":"vpc","provider":"aws","account_id":%d,"region":"us-east-1","name":"managed-vpc","cidr":"10.60.0.0/16","provider_resource_id":"vpc-managed","pool_id":%d,"source_discovered_id":"%s"}`, account.ID, pool.ID, sourceID)
 	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/objects", body, http.StatusCreated)
 	var obj domain.NetworkObject
 	if err := json.Unmarshal(rr.Body.Bytes(), &obj); err != nil {
@@ -101,6 +106,15 @@ func TestNetworkObjectsCreateUpdateAndAppearInMergedView(t *testing.T) {
 	}
 	if !sawManaged {
 		t.Fatalf("managed network object missing from merged view: %+v", view.Items)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, fmt.Sprintf("/api/v1/network/objects?pool_id=%d&source_discovered_id=%s", pool.ID, sourceID), "", http.StatusOK)
+	var objects domain.NetworkObjectListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &objects); err != nil {
+		t.Fatalf("unmarshal objects: %v", err)
+	}
+	if objects.Total != 1 || objects.Items[0].ID != obj.ID {
+		t.Fatalf("object filters did not return created object: %+v", objects)
 	}
 }
 

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -171,6 +171,14 @@ func TestNetworkRelationshipsCreateFilterResolveAndAttachToMergedView(t *testing
 		t.Fatalf("account relationship filter returned %+v", rels)
 	}
 
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/relationships?entity_kind=pool&entity_id=42", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &rels); err != nil {
+		t.Fatalf("unmarshal entity relationships: %v", err)
+	}
+	if rels.Total != 1 || rels.Items[0].ID != "rel-test" {
+		t.Fatalf("entity relationship filter returned %+v", rels)
+	}
+
 	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/relationships/rel-test/resolve", `{"resolution_state":"resolved","reason":"accepted"}`, http.StatusOK)
 	if err := json.Unmarshal(rr.Body.Bytes(), &rel); err != nil {
 		t.Fatalf("unmarshal resolved relationship: %v", err)
@@ -193,6 +201,14 @@ func TestNetworkRelationshipsCreateFilterResolveAndAttachToMergedView(t *testing
 	}
 	if rel.ResolutionState != "ignored" || rel.Reason != "body lookup" {
 		t.Fatalf("body relationship resolution did not persist: %+v", rel)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/relationships?id=rel-test&id=tenant%2Fa", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &rels); err != nil {
+		t.Fatalf("unmarshal id-filtered relationships: %v", err)
+	}
+	if rels.Total != 2 {
+		t.Fatalf("multi-id relationship filter returned %+v", rels)
 	}
 
 	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/flat?q=managed-net", "", http.StatusOK)

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -136,6 +136,27 @@ func TestNetworkRelationshipsCreateFilterResolveAndAttachToMergedView(t *testing
 		t.Fatalf("relationship filter returned %+v", rels)
 	}
 
+	otherAccount, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:210987654321", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create other account: %v", err)
+	}
+	otherObjBody := fmt.Sprintf(`{"object_type":"network","provider":"aws","account_id":%d,"name":"dev-net"}`, otherAccount.ID)
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/objects", otherObjBody, http.StatusCreated)
+	var otherObj domain.NetworkObject
+	if err := json.Unmarshal(rr.Body.Bytes(), &otherObj); err != nil {
+		t.Fatalf("unmarshal other object: %v", err)
+	}
+	otherRelBody := fmt.Sprintf(`{"id":"rel-other-account","type":"contains","source_kind":"network_object","source_id":"%d","target_kind":"pool","target_id":"99","confidence":0.5}`, otherObj.ID)
+	doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/relationships", otherRelBody, http.StatusCreated)
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, fmt.Sprintf("/api/v1/network/relationships?account_id=%d&type=contains&source_kind=network_object", account.ID), "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &rels); err != nil {
+		t.Fatalf("unmarshal account-scoped relationships: %v", err)
+	}
+	if rels.Total != 1 || rels.Items[0].ID != "rel-test" {
+		t.Fatalf("account relationship filter returned %+v", rels)
+	}
+
 	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/network/relationships/rel-test/resolve", `{"resolution_state":"resolved","reason":"accepted"}`, http.StatusOK)
 	if err := json.Unmarshal(rr.Body.Bytes(), &rel); err != nil {
 		t.Fatalf("unmarshal resolved relationship: %v", err)

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -1184,6 +1184,8 @@ func networkObjectQueryParams() []openAPIParameter {
 		queryParam("region", "Cloud region", "string"),
 		queryParam("object_type", "Network object type", "string"),
 		queryParam("state", "Network object state", "string"),
+		queryParam("pool_id", "Associated pool ID", "integer"),
+		queryParam("source_discovered_id", "Source discovered resource ID", "string"),
 		queryParam("q", "Search query", "string"),
 	}
 }

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -1194,10 +1194,13 @@ func networkRelationshipQueryParams() []openAPIParameter {
 	return []openAPIParameter{
 		queryParam("account_id", "Account ID", "integer"),
 		queryParam("type", "Relationship type", "string"),
+		queryParam("id", "Relationship ID. Repeat to match multiple IDs.", "string"),
 		queryParam("source_kind", "Source entity kind", "string"),
 		queryParam("source_id", "Source entity ID", "string"),
 		queryParam("target_kind", "Target entity kind", "string"),
 		queryParam("target_id", "Target entity ID", "string"),
+		queryParam("entity_kind", "Endpoint entity kind matched as source or target", "string"),
+		queryParam("entity_id", "Endpoint entity ID matched as source or target", "string"),
 		queryParam("resolution_state", "Resolution state", "string"),
 	}
 }

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -1190,6 +1190,7 @@ func networkObjectQueryParams() []openAPIParameter {
 
 func networkRelationshipQueryParams() []openAPIParameter {
 	return []openAPIParameter{
+		queryParam("account_id", "Account ID", "integer"),
 		queryParam("type", "Relationship type", "string"),
 		queryParam("source_kind", "Source entity kind", "string"),
 		queryParam("source_id", "Source entity ID", "string"),

--- a/internal/domain/network.go
+++ b/internal/domain/network.go
@@ -139,11 +139,14 @@ type CreateNetworkRelationship struct {
 }
 
 type NetworkRelationshipFilters struct {
+	IDs             []string
 	Type            string
 	SourceKind      string
 	SourceID        string
 	TargetKind      string
 	TargetID        string
+	EntityKind      string
+	EntityID        string
 	ResolutionState string
 }
 

--- a/internal/domain/network.go
+++ b/internal/domain/network.go
@@ -82,12 +82,14 @@ type UpdateNetworkObject struct {
 }
 
 type NetworkObjectFilters struct {
-	AccountID  int64
-	Provider   string
-	Region     string
-	ObjectType string
-	State      string
-	Query      string
+	AccountID          int64
+	Provider           string
+	Region             string
+	ObjectType         string
+	State              string
+	PoolID             int64
+	SourceDiscoveredID string
+	Query              string
 }
 
 type NetworkObjectListResponse struct {

--- a/internal/storage/network_memory.go
+++ b/internal/storage/network_memory.go
@@ -213,8 +213,8 @@ func (m *MemoryNetworkStore) ListNetworkRelationships(_ context.Context, filters
 			continue
 		}
 		if filters.EntityKind != "" && filters.EntityID != "" &&
-			!((rel.SourceKind == filters.EntityKind && rel.SourceID == filters.EntityID) ||
-				(rel.TargetKind == filters.EntityKind && rel.TargetID == filters.EntityID)) {
+			(rel.SourceKind != filters.EntityKind || rel.SourceID != filters.EntityID) &&
+			(rel.TargetKind != filters.EntityKind || rel.TargetID != filters.EntityID) {
 			continue
 		}
 		if filters.ResolutionState != "" && rel.ResolutionState != filters.ResolutionState {

--- a/internal/storage/network_memory.go
+++ b/internal/storage/network_memory.go
@@ -187,7 +187,16 @@ func (m *MemoryNetworkStore) ListNetworkRelationships(_ context.Context, filters
 	defer m.store.mu.RUnlock()
 
 	out := make([]domain.NetworkRelationship, 0, len(m.relationships))
+	ids := map[string]struct{}{}
+	for _, id := range filters.IDs {
+		ids[id] = struct{}{}
+	}
 	for _, rel := range m.relationships {
+		if len(ids) > 0 {
+			if _, ok := ids[rel.ID]; !ok {
+				continue
+			}
+		}
 		if filters.Type != "" && string(rel.Type) != filters.Type {
 			continue
 		}
@@ -201,6 +210,11 @@ func (m *MemoryNetworkStore) ListNetworkRelationships(_ context.Context, filters
 			continue
 		}
 		if filters.TargetID != "" && rel.TargetID != filters.TargetID {
+			continue
+		}
+		if filters.EntityKind != "" && filters.EntityID != "" &&
+			!((rel.SourceKind == filters.EntityKind && rel.SourceID == filters.EntityID) ||
+				(rel.TargetKind == filters.EntityKind && rel.TargetID == filters.EntityID)) {
 			continue
 		}
 		if filters.ResolutionState != "" && rel.ResolutionState != filters.ResolutionState {

--- a/internal/storage/network_memory.go
+++ b/internal/storage/network_memory.go
@@ -53,6 +53,12 @@ func (m *MemoryNetworkStore) ListNetworkObjects(_ context.Context, filters domai
 		if filters.State != "" && string(obj.State) != filters.State {
 			continue
 		}
+		if filters.PoolID > 0 && (obj.PoolID == nil || *obj.PoolID != filters.PoolID) {
+			continue
+		}
+		if filters.SourceDiscoveredID != "" && (obj.SourceDiscoveredID == nil || obj.SourceDiscoveredID.String() != filters.SourceDiscoveredID) {
+			continue
+		}
 		if filters.Query != "" {
 			q := strings.ToLower(filters.Query)
 			haystack := strings.ToLower(strings.Join([]string{obj.Name, obj.CIDR, obj.IPAddress, obj.ProviderResourceID}, " "))

--- a/internal/storage/postgres/network.go
+++ b/internal/storage/postgres/network.go
@@ -197,6 +197,13 @@ func (s *Store) ListNetworkRelationships(ctx context.Context, filters domain.Net
 		args = append(args, v)
 		return fmt.Sprintf("$%d", len(args))
 	}
+	if len(filters.IDs) > 0 {
+		placeholders := make([]string, 0, len(filters.IDs))
+		for _, id := range filters.IDs {
+			placeholders = append(placeholders, addArg(id))
+		}
+		where = append(where, "id IN ("+strings.Join(placeholders, ", ")+")")
+	}
 	if filters.Type != "" {
 		where = append(where, "type = "+addArg(filters.Type))
 	}
@@ -211,6 +218,11 @@ func (s *Store) ListNetworkRelationships(ctx context.Context, filters domain.Net
 	}
 	if filters.TargetID != "" {
 		where = append(where, "target_id = "+addArg(filters.TargetID))
+	}
+	if filters.EntityKind != "" && filters.EntityID != "" {
+		kindArg := addArg(filters.EntityKind)
+		idArg := addArg(filters.EntityID)
+		where = append(where, "((source_kind = "+kindArg+" AND source_id = "+idArg+") OR (target_kind = "+kindArg+" AND target_id = "+idArg+"))")
 	}
 	if filters.ResolutionState != "" {
 		where = append(where, "resolution_state = "+addArg(filters.ResolutionState))

--- a/internal/storage/postgres/network.go
+++ b/internal/storage/postgres/network.go
@@ -42,6 +42,12 @@ func (s *Store) ListNetworkObjects(ctx context.Context, filters domain.NetworkOb
 	if filters.State != "" {
 		where = append(where, "state = "+addArg(filters.State))
 	}
+	if filters.PoolID > 0 {
+		where = append(where, "pool_id = "+addArg(filters.PoolID))
+	}
+	if filters.SourceDiscoveredID != "" {
+		where = append(where, "source_discovered_id = "+addArg(filters.SourceDiscoveredID)+"::uuid")
+	}
 	if filters.Query != "" {
 		q := "%" + strings.ToLower(filters.Query) + "%"
 		where = append(where, fmt.Sprintf("(LOWER(name) LIKE %s OR LOWER(cidr) LIKE %s OR LOWER(ip_address) LIKE %s OR LOWER(provider_resource_id) LIKE %s)", addArg(q), addArg(q), addArg(q), addArg(q)))

--- a/internal/storage/sqlite/network.go
+++ b/internal/storage/sqlite/network.go
@@ -205,6 +205,14 @@ func (s *Store) UpdateNetworkObject(ctx context.Context, id int64, update domain
 func (s *Store) ListNetworkRelationships(ctx context.Context, filters domain.NetworkRelationshipFilters) ([]domain.NetworkRelationship, error) {
 	where := []string{"1=1"}
 	args := []any{}
+	if len(filters.IDs) > 0 {
+		placeholders := make([]string, 0, len(filters.IDs))
+		for _, id := range filters.IDs {
+			placeholders = append(placeholders, "?")
+			args = append(args, id)
+		}
+		where = append(where, "id IN ("+strings.Join(placeholders, ", ")+")")
+	}
 	if filters.Type != "" {
 		where = append(where, "type = ?")
 		args = append(args, filters.Type)
@@ -224,6 +232,10 @@ func (s *Store) ListNetworkRelationships(ctx context.Context, filters domain.Net
 	if filters.TargetID != "" {
 		where = append(where, "target_id = ?")
 		args = append(args, filters.TargetID)
+	}
+	if filters.EntityKind != "" && filters.EntityID != "" {
+		where = append(where, "((source_kind = ? AND source_id = ?) OR (target_kind = ? AND target_id = ?))")
+		args = append(args, filters.EntityKind, filters.EntityID, filters.EntityKind, filters.EntityID)
 	}
 	if filters.ResolutionState != "" {
 		where = append(where, "resolution_state = ?")

--- a/internal/storage/sqlite/network.go
+++ b/internal/storage/sqlite/network.go
@@ -43,6 +43,14 @@ func (s *Store) ListNetworkObjects(ctx context.Context, filters domain.NetworkOb
 		where = append(where, "state = ?")
 		args = append(args, filters.State)
 	}
+	if filters.PoolID > 0 {
+		where = append(where, "pool_id = ?")
+		args = append(args, filters.PoolID)
+	}
+	if filters.SourceDiscoveredID != "" {
+		where = append(where, "source_discovered_id = ?")
+		args = append(args, filters.SourceDiscoveredID)
+	}
 	if filters.Query != "" {
 		q := "%" + strings.ToLower(filters.Query) + "%"
 		where = append(where, "(LOWER(name) LIKE ? OR LOWER(cidr) LIKE ? OR LOWER(ip_address) LIKE ? OR LOWER(provider_resource_id) LIKE ?)")

--- a/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
+++ b/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { NetworkConflictList } from '../pages/DiscoveryPage'
-import type { DiscoveryImportPreviewResponse, NetworkConflict, Pool } from '../api/types'
+import type { DiscoveryImportPreviewResponse, NetworkConflict, NetworkConflictActionResponse, Pool } from '../api/types'
 
 const conflict: NetworkConflict = {
   id: 'unlinked-exact-pool:00000000-0000-0000-0000-000000000001:42',
@@ -45,6 +45,16 @@ const missingParentConflict: NetworkConflict = {
   evidence: ['parent_resource_id=vpc-missing'],
 }
 
+const relinkConflict: NetworkConflict = {
+  ...conflict,
+  id: 'alternate-exact-pool:00000000-0000-0000-0000-000000000001:42',
+  type: 'alternate_exact_pool',
+  title: 'Discovered CIDR matches an alternate pool',
+  description: 'vpc-prod is linked to one pool and exactly matches prod-vpc',
+  recommended_action: 'Relink the discovered resource to the alternate matching managed pool.',
+  evidence: ['current_pool_id=41', 'alternate_pool_id=42'],
+}
+
 const preview: DiscoveryImportPreviewResponse = {
   items: [],
   importable: 1,
@@ -54,6 +64,15 @@ const preview: DiscoveryImportPreviewResponse = {
   conflict_count: 0,
 }
 
+const actionResponse: NetworkConflictActionResponse = {
+  conflict,
+  action: 'link',
+  resource_linked: true,
+  discovered_id: '00000000-0000-0000-0000-000000000001',
+  pool_id: 42,
+  relationships: [],
+}
+
 function renderList(overrides: Partial<ComponentProps<typeof NetworkConflictList>> = {}) {
   const props: ComponentProps<typeof NetworkConflictList> = {
     conflicts: [conflict],
@@ -61,9 +80,9 @@ function renderList(overrides: Partial<ComponentProps<typeof NetworkConflictList
     selected: conflict,
     onSelect: vi.fn(),
     onResolve: vi.fn(),
-    onLink: vi.fn(),
-    onImport: vi.fn(),
-    onPlaceholderParent: vi.fn(),
+    onLink: vi.fn().mockResolvedValue(actionResponse),
+    onImport: vi.fn().mockResolvedValue({ ...actionResponse, action: 'import' }),
+    onPlaceholderParent: vi.fn().mockResolvedValue({ ...actionResponse, action: 'create_placeholder_parent' }),
     onPreviewImport: vi.fn().mockResolvedValue(preview),
     pools,
     ...overrides,
@@ -84,7 +103,7 @@ describe('NetworkConflictList', () => {
     expect(screen.getByRole('button', { name: /Import as pool/i })).toBeTruthy()
   })
 
-  it('submits a link action with selected resource, pool, reason, and override', () => {
+  it('submits a link action with selected resource, pool, reason, and override', async () => {
     const props = renderList()
 
     fireEvent.click(screen.getByRole('button', { name: /Link to pool/i }))
@@ -92,13 +111,15 @@ describe('NetworkConflictList', () => {
     fireEvent.click(screen.getByLabelText('Override validation'))
     fireEvent.click(screen.getByRole('button', { name: 'Confirm link' }))
 
-    expect(props.onLink).toHaveBeenCalledWith(
-      conflict,
-      '00000000-0000-0000-0000-000000000001',
-      42,
-      'exact match reviewed',
-      true,
-    )
+    await waitFor(() => {
+      expect(props.onLink).toHaveBeenCalledWith(
+        conflict,
+        '00000000-0000-0000-0000-000000000001',
+        42,
+        'exact match reviewed',
+        true,
+      )
+    })
   })
 
   it('requires import preview before apply and submits selected resources', async () => {
@@ -118,16 +139,18 @@ describe('NetworkConflictList', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Apply import' }))
-    expect(props.onImport).toHaveBeenCalledWith(
-      conflict,
-      ['00000000-0000-0000-0000-000000000001'],
-      undefined,
-      '',
-      false,
-    )
+    await waitFor(() => {
+      expect(props.onImport).toHaveBeenCalledWith(
+        conflict,
+        ['00000000-0000-0000-0000-000000000001'],
+        undefined,
+        '',
+        false,
+      )
+    })
   })
 
-  it('submits a placeholder-parent action for missing parent conflicts', () => {
+  it('submits a placeholder-parent action for missing parent conflicts', async () => {
     const props = renderList({
       conflicts: [missingParentConflict],
       selected: missingParentConflict,
@@ -138,11 +161,45 @@ describe('NetworkConflictList', () => {
     fireEvent.change(screen.getByPlaceholderText('Reason'), { target: { value: 'parent not scanned yet' } })
     fireEvent.click(screen.getByRole('button', { name: 'Create placeholder' }))
 
-    expect(props.onPlaceholderParent).toHaveBeenCalledWith(
-      missingParentConflict,
-      '00000000-0000-0000-0000-000000000001',
-      'placeholder-vpc',
-      'parent not scanned yet',
-    )
+    await waitFor(() => {
+      expect(props.onPlaceholderParent).toHaveBeenCalledWith(
+        missingParentConflict,
+        '00000000-0000-0000-0000-000000000001',
+        'placeholder-vpc',
+        'parent not scanned yet',
+      )
+    })
+  })
+
+  it('uses relink wording and displays previous pool result details for alternate exact pool conflicts', async () => {
+    const props = renderList({
+      conflicts: [relinkConflict],
+      selected: relinkConflict,
+      onLink: vi.fn().mockResolvedValue({
+        ...actionResponse,
+        conflict: relinkConflict,
+        previous_pool_id: 41,
+        pool_id: 42,
+        relationships: [{ id: 'rel/one', type: 'matches', source_kind: 'discovered', source_id: '00000000-0000-0000-0000-000000000001', target_kind: 'pool', target_id: '42', confidence: 1, resolution_state: 'accepted', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' }],
+      }),
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Relink to pool/i }))
+    expect(screen.getByText(/updates the discovered resource pool association/i)).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm relink' }))
+
+    await waitFor(() => {
+      expect(props.onLink).toHaveBeenCalledWith(
+        relinkConflict,
+        '00000000-0000-0000-0000-000000000001',
+        42,
+        '',
+        false,
+      )
+      expect(screen.getByText('Resource relinked')).toBeTruthy()
+      expect(screen.getByText('Previous pool: 41')).toBeTruthy()
+      expect(screen.getByText('Target pool: 42')).toBeTruthy()
+      expect(screen.getByText('1 relationship recorded')).toBeTruthy()
+    })
   })
 })

--- a/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
+++ b/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { NetworkConflictList } from '../pages/DiscoveryPage'
-import type { DiscoveryImportPreviewResponse, NetworkConflict, NetworkConflictActionResponse, Pool } from '../api/types'
+import type { Account, DiscoveryImportPreviewResponse, NetworkConflict, NetworkConflictActionResponse, Pool } from '../api/types'
 
 const conflict: NetworkConflict = {
   id: 'unlinked-exact-pool:00000000-0000-0000-0000-000000000001:42',
@@ -18,7 +18,27 @@ const conflict: NetworkConflict = {
   cidr: '10.0.0.0/16',
   evidence: ['pool_id=42', 'pool_cidr=10.0.0.0/16'],
   available_decisions: ['skip', 'ignore', 'defer'],
+  relationships: [{
+    id: 'matches/discovered/00000000-0000-0000-0000-000000000001/pool/42',
+    type: 'matches',
+    source_kind: 'discovered',
+    source_id: '00000000-0000-0000-0000-000000000001',
+    target_kind: 'pool',
+    target_id: '42',
+    confidence: 1,
+    resolution_state: 'open',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }],
 }
+
+const accounts: Account[] = [{
+  id: 7,
+  key: 'aws:123456789012',
+  name: 'Production AWS',
+  provider: 'aws',
+  created_at: '2026-01-01T00:00:00Z',
+}]
 
 const pools: Pool[] = [
   {
@@ -84,7 +104,11 @@ function renderList(overrides: Partial<ComponentProps<typeof NetworkConflictList
     onImport: vi.fn().mockResolvedValue({ ...actionResponse, action: 'import' }),
     onPlaceholderParent: vi.fn().mockResolvedValue({ ...actionResponse, action: 'create_placeholder_parent' }),
     onPreviewImport: vi.fn().mockResolvedValue(preview),
+    onViewFlat: vi.fn(),
+    onViewHierarchy: vi.fn(),
+    onShowRelationships: vi.fn(),
     pools,
+    accounts,
     ...overrides,
   }
   render(<NetworkConflictList {...props} />)
@@ -101,6 +125,27 @@ describe('NetworkConflictList', () => {
     expect(screen.getByText('Actions')).toBeTruthy()
     expect(screen.getByRole('button', { name: /Link to pool/i })).toBeTruthy()
     expect(screen.getByRole('button', { name: /Import as pool/i })).toBeTruthy()
+  })
+
+  it('renders structured conflict detail sections and context navigation actions', () => {
+    const props = renderList()
+
+    expect(screen.getByText('Affected resources')).toBeTruthy()
+    expect(screen.getAllByText(/00000000-0000-0000-0000-000000000001/).length).toBeGreaterThan(0)
+    expect(screen.getByText('Ownership')).toBeTruthy()
+    expect(screen.getByText(/Production AWS \(7\)/)).toBeTruthy()
+    expect(screen.getByText('Pools and parent chain')).toBeTruthy()
+    expect(screen.getByText(/prod-vpc \(42, 10.0.0.0\/16\)/)).toBeTruthy()
+    expect(screen.getByText('CIDR/IP evidence')).toBeTruthy()
+    expect(screen.getAllByText('Relationships').length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByRole('button', { name: 'View in flat' }))
+    fireEvent.click(screen.getByRole('button', { name: 'View in hierarchy' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Show relationships' }))
+
+    expect(props.onViewFlat).toHaveBeenCalledWith(conflict)
+    expect(props.onViewHierarchy).toHaveBeenCalledWith(conflict)
+    expect(props.onShowRelationships).toHaveBeenCalledWith(conflict)
   })
 
   it('submits a link action with selected resource, pool, reason, and override', async () => {
@@ -201,5 +246,10 @@ describe('NetworkConflictList', () => {
       expect(screen.getByText('Target pool: 42')).toBeTruthy()
       expect(screen.getByText('1 relationship recorded')).toBeTruthy()
     })
+
+    fireEvent.click(screen.getByRole('button', { name: 'View affected row' }))
+    fireEvent.click(screen.getByRole('button', { name: 'View relationships' }))
+    expect(props.onViewFlat).toHaveBeenCalledWith(relinkConflict)
+    expect(props.onShowRelationships).toHaveBeenCalledWith(relinkConflict)
   })
 })

--- a/ui/src/__tests__/DiscoveryNetworkRelationshipTable.test.tsx
+++ b/ui/src/__tests__/DiscoveryNetworkRelationshipTable.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { NetworkRelationshipTable } from '../pages/DiscoveryPage'
+import type { NetworkRelationship } from '../api/types'
+
+const relationship: NetworkRelationship = {
+  id: 'contains/discovered/id/with/slashes',
+  type: 'contains',
+  source_kind: 'network_object',
+  source_id: '1',
+  target_kind: 'discovered',
+  target_id: 'id/with/slashes',
+  confidence: 1,
+  reason: 'placeholder parent',
+  evidence: ['parent_resource_id=vpc-missing'],
+  resolution_state: 'open',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+describe('NetworkRelationshipTable', () => {
+  it('requires Apply before submitting relationship resolution changes', async () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined)
+    render(<NetworkRelationshipTable relationships={[relationship]} loading={false} onResolve={onResolve} />)
+
+    fireEvent.change(screen.getByLabelText(`Resolution for ${relationship.id}`), { target: { value: 'accepted' } })
+    fireEvent.change(screen.getByPlaceholderText('Reason'), { target: { value: 'reviewed relationship' } })
+    expect(onResolve).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByLabelText(`Apply relationship ${relationship.id}`))
+
+    await waitFor(() => {
+      expect(onResolve).toHaveBeenCalledWith(relationship, 'accepted', 'reviewed relationship')
+    })
+  })
+
+  it('shows inline errors when relationship resolution fails', async () => {
+    const onResolve = vi.fn().mockRejectedValue(new Error('server rejected relationship update'))
+    render(<NetworkRelationshipTable relationships={[relationship]} loading={false} onResolve={onResolve} />)
+
+    fireEvent.change(screen.getByLabelText(`Resolution for ${relationship.id}`), { target: { value: 'rejected' } })
+    fireEvent.click(screen.getByLabelText(`Apply relationship ${relationship.id}`))
+
+    await waitFor(() => {
+      expect(screen.getByText('server rejected relationship update')).toBeTruthy()
+    })
+  })
+})

--- a/ui/src/__tests__/DiscoveryNetworkRelationshipTable.test.tsx
+++ b/ui/src/__tests__/DiscoveryNetworkRelationshipTable.test.tsx
@@ -23,14 +23,14 @@ describe('NetworkRelationshipTable', () => {
     const onResolve = vi.fn().mockResolvedValue(undefined)
     render(<NetworkRelationshipTable relationships={[relationship]} loading={false} onResolve={onResolve} />)
 
-    fireEvent.change(screen.getByLabelText(`Resolution for ${relationship.id}`), { target: { value: 'accepted' } })
+    fireEvent.change(screen.getByLabelText(`Resolution for ${relationship.id}`), { target: { value: 'resolved' } })
     fireEvent.change(screen.getByPlaceholderText('Reason'), { target: { value: 'reviewed relationship' } })
     expect(onResolve).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByLabelText(`Apply relationship ${relationship.id}`))
 
     await waitFor(() => {
-      expect(onResolve).toHaveBeenCalledWith(relationship, 'accepted', 'reviewed relationship')
+      expect(onResolve).toHaveBeenCalledWith(relationship, 'resolved', 'reviewed relationship')
     })
   })
 
@@ -38,7 +38,7 @@ describe('NetworkRelationshipTable', () => {
     const onResolve = vi.fn().mockRejectedValue(new Error('server rejected relationship update'))
     render(<NetworkRelationshipTable relationships={[relationship]} loading={false} onResolve={onResolve} />)
 
-    fireEvent.change(screen.getByLabelText(`Resolution for ${relationship.id}`), { target: { value: 'rejected' } })
+    fireEvent.change(screen.getByLabelText(`Resolution for ${relationship.id}`), { target: { value: 'ignored' } })
     fireEvent.click(screen.getByLabelText(`Apply relationship ${relationship.id}`))
 
     await waitFor(() => {

--- a/ui/src/__tests__/useNetwork.test.tsx
+++ b/ui/src/__tests__/useNetwork.test.tsx
@@ -55,6 +55,27 @@ describe('useNetworkView', () => {
     await waitFor(() => expect(result.current.objects?.total).toBe(0))
   })
 
+  it('loads network relationships scoped to the selected account', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ items: [], total: 0 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useNetworkView())
+
+    await act(async () => {
+      await result.current.fetchRelationships({
+        account_id: 7,
+        type: 'matches',
+        source_kind: 'discovered',
+        resolution_state: 'resolved',
+      })
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/network/relationships?account_id=7&type=matches&source_kind=discovered&resolution_state=resolved',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    )
+    await waitFor(() => expect(result.current.relationships?.total).toBe(0))
+  })
+
   it('resolves relationships through the body-form endpoint', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
       id: 'contains/discovered/id/with/slashes',
@@ -64,7 +85,7 @@ describe('useNetworkView', () => {
       target_kind: 'discovered',
       target_id: 'id/with/slashes',
       confidence: 1,
-      resolution_state: 'accepted',
+      resolution_state: 'resolved',
       created_at: '2026-01-01T00:00:00Z',
       updated_at: '2026-01-01T00:00:00Z',
     }))
@@ -74,7 +95,7 @@ describe('useNetworkView', () => {
     await act(async () => {
       await result.current.resolveNetworkRelationship({
         id: 'contains/discovered/id/with/slashes',
-        resolution_state: 'accepted',
+        resolution_state: 'resolved',
         reason: 'reviewed',
       })
     })
@@ -85,7 +106,7 @@ describe('useNetworkView', () => {
         method: 'POST',
         body: JSON.stringify({
           id: 'contains/discovered/id/with/slashes',
-          resolution_state: 'accepted',
+          resolution_state: 'resolved',
           reason: 'reviewed',
         }),
       }),

--- a/ui/src/__tests__/useNetwork.test.tsx
+++ b/ui/src/__tests__/useNetwork.test.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useNetworkView } from '../hooks/useNetwork'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useNetworkView', () => {
+  it('passes schema policy and alternate exact pool filters to conflict queries', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ items: [], total: 0 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useNetworkView())
+
+    await act(async () => {
+      await result.current.fetchConflicts({
+        account_id: 7,
+        conflict_type: 'alternate_exact_pool',
+        schema_policy: 'region_level',
+        q: 'prod',
+      })
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/network/conflicts?account_id=7&conflict_type=alternate_exact_pool&schema_policy=region_level&q=prod',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    )
+  })
+
+  it('loads managed network objects with API-backed filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ items: [], total: 0 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useNetworkView())
+
+    await act(async () => {
+      await result.current.fetchObjects({
+        account_id: 7,
+        object_type: 'vpc',
+        status: 'placeholder',
+        q: 'missing',
+      })
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/network/objects?account_id=7&object_type=vpc&state=placeholder&q=missing',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    )
+    await waitFor(() => expect(result.current.objects?.total).toBe(0))
+  })
+
+  it('resolves relationships through the body-form endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      id: 'contains/discovered/id/with/slashes',
+      type: 'contains',
+      source_kind: 'network_object',
+      source_id: '1',
+      target_kind: 'discovered',
+      target_id: 'id/with/slashes',
+      confidence: 1,
+      resolution_state: 'accepted',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useNetworkView())
+
+    await act(async () => {
+      await result.current.resolveNetworkRelationship({
+        id: 'contains/discovered/id/with/slashes',
+        resolution_state: 'accepted',
+        reason: 'reviewed',
+      })
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/network/relationships/resolve',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          id: 'contains/discovered/id/with/slashes',
+          resolution_state: 'accepted',
+          reason: 'reviewed',
+        }),
+      }),
+    )
+  })
+})

--- a/ui/src/__tests__/useNetwork.test.tsx
+++ b/ui/src/__tests__/useNetwork.test.tsx
@@ -80,6 +80,27 @@ describe('useNetworkView', () => {
     await waitFor(() => expect(result.current.relationships?.total).toBe(0))
   })
 
+  it('loads network relationships by attached IDs and endpoint entity filters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ items: [], total: 0 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useNetworkView())
+
+    await act(async () => {
+      await result.current.fetchRelationships({
+        account_id: 7,
+        ids: ['rel-one', 'rel/two'],
+        entity_kind: 'pool',
+        entity_id: '42',
+      })
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/network/relationships?account_id=7&id=rel-one&id=rel%2Ftwo&entity_kind=pool&entity_id=42',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    )
+    await waitFor(() => expect(result.current.relationships?.total).toBe(0))
+  })
+
   it('resolves relationships through the body-form endpoint', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
       id: 'contains/discovered/id/with/slashes',

--- a/ui/src/__tests__/useNetwork.test.tsx
+++ b/ui/src/__tests__/useNetwork.test.tsx
@@ -42,14 +42,18 @@ describe('useNetworkView', () => {
     await act(async () => {
       await result.current.fetchObjects({
         account_id: 7,
+        provider: 'aws',
+        region: 'us-west-2',
         object_type: 'vpc',
         status: 'placeholder',
+        pool_id: 42,
+        source_discovered_id: '00000000-0000-0000-0000-000000000001',
         q: 'missing',
       })
     })
 
     expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/network/objects?account_id=7&object_type=vpc&state=placeholder&q=missing',
+      '/api/v1/network/objects?account_id=7&provider=aws&region=us-west-2&object_type=vpc&state=placeholder&pool_id=42&source_discovered_id=00000000-0000-0000-0000-000000000001&q=missing',
       expect.objectContaining({ credentials: 'same-origin' }),
     )
     await waitFor(() => expect(result.current.objects?.total).toBe(0))

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -551,6 +551,7 @@ export interface NetworkNode {
   state: string
   issues?: NetworkIssue[]
   evidence?: string[]
+  relationships?: NetworkRelationship[]
   children?: NetworkNode[]
 }
 
@@ -571,6 +572,7 @@ export interface NetworkConflict {
   object_types?: string[]
   cidr?: string
   evidence?: string[]
+  relationships?: NetworkRelationship[]
   available_decisions?: string[]
   resolution_state?: string
   resolution_requested?: string
@@ -616,11 +618,52 @@ export interface NetworkObject {
   region?: string
   name: string
   cidr?: string
+  ip_address?: string
   provider_resource_id?: string
+  parent_object_id?: number | null
+  pool_id?: number | null
+  source_discovered_id?: string | null
   state: string
   metadata?: Record<string, string>
   created_at: string
   updated_at: string
+}
+
+export interface NetworkObjectListResponse {
+  items: NetworkObject[]
+  total: number
+}
+
+export interface CreateNetworkObjectRequest {
+  object_type: string
+  provider?: string
+  account_id: number
+  region?: string
+  name: string
+  cidr?: string
+  ip_address?: string
+  provider_resource_id?: string
+  parent_object_id?: number | null
+  pool_id?: number | null
+  source_discovered_id?: string | null
+  state?: string
+  metadata?: Record<string, string>
+}
+
+export interface UpdateNetworkObjectRequest {
+  object_type?: string
+  provider?: string
+  account_id?: number
+  region?: string
+  name?: string
+  cidr?: string
+  ip_address?: string
+  provider_resource_id?: string
+  parent_object_id?: number | null
+  pool_id?: number | null
+  source_discovered_id?: string | null
+  state?: string
+  metadata?: Record<string, string>
 }
 
 export interface NetworkRelationship {
@@ -636,6 +679,30 @@ export interface NetworkRelationship {
   resolution_state: string
   created_at: string
   updated_at: string
+}
+
+export interface NetworkRelationshipListResponse {
+  items: NetworkRelationship[]
+  total: number
+}
+
+export interface CreateNetworkRelationshipRequest {
+  id?: string
+  type: string
+  source_kind: string
+  source_id: string
+  target_kind: string
+  target_id: string
+  confidence?: number
+  reason?: string
+  evidence?: string[]
+  resolution_state?: string
+}
+
+export interface ResolveNetworkRelationshipRequest {
+  id: string
+  resolution_state: string
+  reason?: string
 }
 
 export interface NetworkConflictActionResponse {

--- a/ui/src/hooks/useNetwork.ts
+++ b/ui/src/hooks/useNetwork.ts
@@ -20,6 +20,8 @@ export interface NetworkFilters {
   region?: string
   object_type?: string
   status?: string
+  pool_id?: number
+  source_discovered_id?: string
   conflict_type?: string
   schema_policy?: string
   q?: string
@@ -69,6 +71,8 @@ function objectQuery(filters?: NetworkFilters) {
   if (filters?.region) params.set('region', filters.region)
   if (filters?.object_type) params.set('object_type', filters.object_type)
   if (filters?.status) params.set('state', filters.status)
+  if (filters?.pool_id) params.set('pool_id', String(filters.pool_id))
+  if (filters?.source_discovered_id) params.set('source_discovered_id', filters.source_discovered_id)
   if (filters?.q) params.set('q', filters.q)
   const query = params.toString()
   return query ? `?${query}` : ''

--- a/ui/src/hooks/useNetwork.ts
+++ b/ui/src/hooks/useNetwork.ts
@@ -7,7 +7,11 @@ import type {
   NetworkConflictLinkActionRequest,
   NetworkConflictListResponse,
   NetworkConflictPlaceholderParentActionRequest,
+  NetworkObjectListResponse,
+  NetworkRelationship,
+  NetworkRelationshipListResponse,
   NetworkViewResponse,
+  ResolveNetworkRelationshipRequest,
 } from '../api/types'
 
 export interface NetworkFilters {
@@ -17,7 +21,17 @@ export interface NetworkFilters {
   object_type?: string
   status?: string
   conflict_type?: string
+  schema_policy?: string
   q?: string
+}
+
+export interface NetworkRelationshipFilters {
+  type?: string
+  source_kind?: string
+  source_id?: string
+  target_kind?: string
+  target_id?: string
+  resolution_state?: string
 }
 
 function networkQuery(filters?: NetworkFilters) {
@@ -28,6 +42,31 @@ function networkQuery(filters?: NetworkFilters) {
   if (filters?.object_type) params.set('object_type', filters.object_type)
   if (filters?.status) params.set('status', filters.status)
   if (filters?.conflict_type) params.set('conflict_type', filters.conflict_type)
+  if (filters?.schema_policy) params.set('schema_policy', filters.schema_policy)
+  if (filters?.q) params.set('q', filters.q)
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}
+
+function relationshipQuery(filters?: NetworkRelationshipFilters) {
+  const params = new URLSearchParams()
+  if (filters?.type) params.set('type', filters.type)
+  if (filters?.source_kind) params.set('source_kind', filters.source_kind)
+  if (filters?.source_id) params.set('source_id', filters.source_id)
+  if (filters?.target_kind) params.set('target_kind', filters.target_kind)
+  if (filters?.target_id) params.set('target_id', filters.target_id)
+  if (filters?.resolution_state) params.set('resolution_state', filters.resolution_state)
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}
+
+function objectQuery(filters?: NetworkFilters) {
+  const params = new URLSearchParams()
+  if (filters?.account_id) params.set('account_id', String(filters.account_id))
+  if (filters?.provider) params.set('provider', filters.provider)
+  if (filters?.region) params.set('region', filters.region)
+  if (filters?.object_type) params.set('object_type', filters.object_type)
+  if (filters?.status) params.set('state', filters.status)
   if (filters?.q) params.set('q', filters.q)
   const query = params.toString()
   return query ? `?${query}` : ''
@@ -37,6 +76,8 @@ export function useNetworkView() {
   const [flat, setFlat] = useState<NetworkViewResponse | null>(null)
   const [hierarchy, setHierarchy] = useState<NetworkViewResponse | null>(null)
   const [conflicts, setConflicts] = useState<NetworkConflictListResponse | null>(null)
+  const [objects, setObjects] = useState<NetworkObjectListResponse | null>(null)
+  const [relationships, setRelationships] = useState<NetworkRelationshipListResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -88,6 +129,38 @@ export function useNetworkView() {
     }
   }, [])
 
+  const fetchObjects = useCallback(async (filters?: NetworkFilters) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await get<NetworkObjectListResponse>(`/api/v1/network/objects${objectQuery(filters)}`)
+      setObjects(resp)
+      return resp
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load network objects'
+      setError(msg)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const fetchRelationships = useCallback(async (filters?: NetworkRelationshipFilters) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await get<NetworkRelationshipListResponse>(`/api/v1/network/relationships${relationshipQuery(filters)}`)
+      setRelationships(resp)
+      return resp
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load network relationships'
+      setError(msg)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
   const resolveConflict = useCallback(
     async (id: string, decision: string, reason?: string) => {
       return post<NetworkConflict>(`/api/v1/network/conflicts/${encodeURIComponent(id)}/resolve`, {
@@ -128,18 +201,30 @@ export function useNetworkView() {
     [],
   )
 
+  const resolveNetworkRelationship = useCallback(
+    async (req: ResolveNetworkRelationshipRequest) => {
+      return post<NetworkRelationship>('/api/v1/network/relationships/resolve', req)
+    },
+    [],
+  )
+
   return {
     flat,
     hierarchy,
     conflicts,
+    objects,
+    relationships,
     loading,
     error,
     fetchFlat,
     fetchHierarchy,
     fetchConflicts,
+    fetchObjects,
+    fetchRelationships,
     resolveConflict,
     linkConflict,
     importConflict,
     createPlaceholderParentConflict,
+    resolveNetworkRelationship,
   }
 }

--- a/ui/src/hooks/useNetwork.ts
+++ b/ui/src/hooks/useNetwork.ts
@@ -26,6 +26,7 @@ export interface NetworkFilters {
 }
 
 export interface NetworkRelationshipFilters {
+  account_id?: number
   type?: string
   source_kind?: string
   source_id?: string
@@ -50,6 +51,7 @@ function networkQuery(filters?: NetworkFilters) {
 
 function relationshipQuery(filters?: NetworkRelationshipFilters) {
   const params = new URLSearchParams()
+  if (filters?.account_id) params.set('account_id', String(filters.account_id))
   if (filters?.type) params.set('type', filters.type)
   if (filters?.source_kind) params.set('source_kind', filters.source_kind)
   if (filters?.source_id) params.set('source_id', filters.source_id)

--- a/ui/src/hooks/useNetwork.ts
+++ b/ui/src/hooks/useNetwork.ts
@@ -29,11 +29,14 @@ export interface NetworkFilters {
 
 export interface NetworkRelationshipFilters {
   account_id?: number
+  ids?: string[]
   type?: string
   source_kind?: string
   source_id?: string
   target_kind?: string
   target_id?: string
+  entity_kind?: string
+  entity_id?: string
   resolution_state?: string
 }
 
@@ -54,11 +57,14 @@ function networkQuery(filters?: NetworkFilters) {
 function relationshipQuery(filters?: NetworkRelationshipFilters) {
   const params = new URLSearchParams()
   if (filters?.account_id) params.set('account_id', String(filters.account_id))
+  filters?.ids?.forEach((id) => params.append('id', id))
   if (filters?.type) params.set('type', filters.type)
   if (filters?.source_kind) params.set('source_kind', filters.source_kind)
   if (filters?.source_id) params.set('source_id', filters.source_id)
   if (filters?.target_kind) params.set('target_kind', filters.target_kind)
   if (filters?.target_id) params.set('target_id', filters.target_id)
+  if (filters?.entity_kind) params.set('entity_kind', filters.entity_kind)
+  if (filters?.entity_id) params.set('entity_id', filters.entity_id)
   if (filters?.resolution_state) params.set('resolution_state', filters.resolution_state)
   const query = params.toString()
   return query ? `?${query}` : ''

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -17,6 +17,7 @@ import {
   Plus,
   Network,
   Table2,
+  GitBranch,
 } from 'lucide-react'
 import {
   useDiscoveryResources,
@@ -43,6 +44,9 @@ import type {
   NetworkNode,
   NetworkConflict,
   NetworkIssue,
+  NetworkObject,
+  NetworkRelationship,
+  NetworkConflictActionResponse,
 } from '../api/types'
 
 type Tab = 'resources' | 'network' | 'sync' | 'agents'
@@ -722,7 +726,7 @@ const DEFAULT_RESOURCE_COLUMNS: ResourceColumnKey[] = [
   'last_seen',
 ]
 
-type NetworkMode = 'hierarchy' | 'flat' | 'conflicts'
+type NetworkMode = 'hierarchy' | 'flat' | 'conflicts' | 'objects' | 'relationships'
 
 function NetworkTab({
   selectedAccountId,
@@ -736,21 +740,34 @@ function NetworkTab({
   const [mode, setMode] = useState<NetworkMode>('hierarchy')
   const [query, setQuery] = useState('')
   const [objectType, setObjectType] = useState('')
+  const [objectState, setObjectState] = useState('')
   const [conflictType, setConflictType] = useState('')
+  const [schemaPolicy, setSchemaPolicy] = useState('account_level')
+  const [relationshipType, setRelationshipType] = useState('')
+  const [relationshipState, setRelationshipState] = useState('')
+  const [relationshipSourceKind, setRelationshipSourceKind] = useState('')
+  const [relationshipSourceID, setRelationshipSourceID] = useState('')
+  const [relationshipTargetKind, setRelationshipTargetKind] = useState('')
+  const [relationshipTargetID, setRelationshipTargetID] = useState('')
   const [selectedConflict, setSelectedConflict] = useState<NetworkConflict | null>(null)
   const {
     flat,
     hierarchy,
     conflicts,
+    objects,
+    relationships,
     loading,
     error,
     fetchFlat,
     fetchHierarchy,
     fetchConflicts,
+    fetchObjects,
+    fetchRelationships,
     resolveConflict,
     linkConflict,
     importConflict,
     createPlaceholderParentConflict,
+    resolveNetworkRelationship,
   } = useNetworkView()
   const { previewDiscoveryImport: previewNetworkImport } = useSyncJobs()
   const { showToast } = useToast()
@@ -758,19 +775,34 @@ function NetworkTab({
   const filters = useMemo(() => ({
     account_id: selectedAccountId ?? undefined,
     object_type: objectType || undefined,
+    status: objectState || undefined,
     conflict_type: conflictType || undefined,
+    schema_policy: schemaPolicy,
     q: query || undefined,
-  }), [selectedAccountId, objectType, conflictType, query])
+  }), [selectedAccountId, objectType, objectState, conflictType, schemaPolicy, query])
+
+  const relationshipFilters = useMemo(() => ({
+    type: relationshipType || undefined,
+    source_kind: relationshipSourceKind || undefined,
+    source_id: relationshipSourceID || undefined,
+    target_kind: relationshipTargetKind || undefined,
+    target_id: relationshipTargetID || undefined,
+    resolution_state: relationshipState || undefined,
+  }), [relationshipType, relationshipSourceKind, relationshipSourceID, relationshipTargetKind, relationshipTargetID, relationshipState])
 
   const load = useCallback(() => {
     if (mode === 'hierarchy') {
       void fetchHierarchy(filters)
     } else if (mode === 'flat') {
       void fetchFlat(filters)
-    } else {
+    } else if (mode === 'conflicts') {
       void fetchConflicts(filters)
+    } else if (mode === 'objects') {
+      void fetchObjects(filters)
+    } else {
+      void fetchRelationships(relationshipFilters)
     }
-  }, [fetchConflicts, fetchFlat, fetchHierarchy, filters, mode])
+  }, [fetchConflicts, fetchFlat, fetchHierarchy, fetchObjects, fetchRelationships, filters, mode, relationshipFilters])
 
   useEffect(() => {
     load()
@@ -795,11 +827,13 @@ function NetworkTab({
         reason: reason || undefined,
         override,
       })
-      showToast('Resource linked to pool', 'success')
+      showToast(conflict.type === 'alternate_exact_pool' ? 'Resource relinked to pool' : 'Resource linked to pool', 'success')
       setSelectedConflict(resp.conflict)
       load()
+      return resp
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Link action failed', 'error')
+      throw err
     }
   }
 
@@ -814,8 +848,10 @@ function NetworkTab({
       showToast(`Imported ${resp.import?.pools_created ?? 0} pools and linked ${resp.import?.resources_linked ?? 0} resources`, 'success')
       setSelectedConflict(resp.conflict)
       load()
+      return resp
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Import action failed', 'error')
+      throw err
     }
   }
 
@@ -829,8 +865,25 @@ function NetworkTab({
       showToast(`Placeholder parent ${resp.network_object?.name || 'created'}`, 'success')
       setSelectedConflict(resp.conflict)
       load()
+      return resp
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Placeholder parent action failed', 'error')
+      throw err
+    }
+  }
+
+  async function handleResolveRelationship(relationship: NetworkRelationship, resolutionState: string, reason: string) {
+    try {
+      await resolveNetworkRelationship({
+        id: relationship.id,
+        resolution_state: resolutionState,
+        reason: reason || undefined,
+      })
+      showToast(`Relationship marked ${resolutionState}`, 'success')
+      load()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Relationship resolution failed', 'error')
+      throw err
     }
   }
 
@@ -845,6 +898,13 @@ function NetworkTab({
   const activeItems = mode === 'hierarchy' ? hierarchy?.items : flat?.items
   const activeTotal = mode === 'hierarchy' ? hierarchy?.total : flat?.total
   const activeConflictCount = mode === 'hierarchy' ? hierarchy?.conflict_count : flat?.conflict_count
+  const rowCount = mode === 'conflicts'
+    ? conflicts?.total ?? 0
+    : mode === 'objects'
+      ? objects?.total ?? 0
+      : mode === 'relationships'
+        ? relationships?.total ?? 0
+        : activeTotal ?? 0
 
   return (
     <div className="space-y-4">
@@ -853,6 +913,8 @@ function NetworkTab({
           <NetworkModeButton active={mode === 'hierarchy'} onClick={() => setMode('hierarchy')} label="Hierarchy" />
           <NetworkModeButton active={mode === 'flat'} onClick={() => setMode('flat')} label="Flat" />
           <NetworkModeButton active={mode === 'conflicts'} onClick={() => setMode('conflicts')} label="Conflicts" />
+          <NetworkModeButton active={mode === 'objects'} onClick={() => setMode('objects')} label="Objects" />
+          <NetworkModeButton active={mode === 'relationships'} onClick={() => setMode('relationships')} label="Relationships" />
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <div className="relative min-w-[220px] flex-1">
@@ -865,6 +927,16 @@ function NetworkTab({
             />
           </div>
           <select
+            value={schemaPolicy}
+            onChange={(e) => setSchemaPolicy(e.target.value)}
+            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+          >
+            <option value="account_level">Account policy</option>
+            <option value="region_level">Region policy</option>
+            <option value="global">Global policy</option>
+            <option value="manual">Manual policy</option>
+          </select>
+          <select
             value={objectType}
             onChange={(e) => setObjectType(e.target.value)}
             className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
@@ -873,9 +945,25 @@ function NetworkTab({
             <option value="supernet">Pool</option>
             <option value="vpc">VPC</option>
             <option value="subnet">Subnet</option>
+            <option value="eip">EIP object</option>
+            <option value="public_ip">Public IP object</option>
+            <option value="network">Network object</option>
             <option value="elastic_ip">EIP</option>
             <option value="network_interface">NIC</option>
           </select>
+          {mode === 'objects' && (
+            <select
+              value={objectState}
+              onChange={(e) => setObjectState(e.target.value)}
+              className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+            >
+              <option value="">All states</option>
+              <option value="managed">Managed</option>
+              <option value="placeholder">Placeholder</option>
+              <option value="imported">Imported</option>
+              <option value="ignored">Ignored</option>
+            </select>
+          )}
           <select
             value={conflictType}
             onChange={(e) => setConflictType(e.target.value)}
@@ -884,13 +972,66 @@ function NetworkTab({
             <option value="">All issues</option>
             <option value="missing_parent">Missing parent</option>
             <option value="unlinked_exact_pool">Exact pool match</option>
-            <option value="alternate_exact_pool">Alternate exact pool</option>
+            <option value="alternate_exact_pool">Relink candidate</option>
             <option value="invalid_nesting">Invalid nesting</option>
             <option value="outside_pool">Outside pool</option>
             <option value="duplicate_cidr">Duplicate CIDR</option>
             <option value="managed_overlap">Managed overlap</option>
             <option value="linked_pool_mismatch">Linked mismatch</option>
           </select>
+          {mode === 'relationships' && (
+            <>
+              <select
+                value={relationshipType}
+                onChange={(e) => setRelationshipType(e.target.value)}
+                className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              >
+                <option value="">All relationships</option>
+                <option value="contains">Contains</option>
+                <option value="matches">Matches</option>
+                <option value="conflicts">Conflicts</option>
+                <option value="missing_parent">Missing parent</option>
+                <option value="candidate_import">Candidate import</option>
+                <option value="imported_as">Imported as</option>
+                <option value="duplicate_of">Duplicate of</option>
+              </select>
+              <select
+                value={relationshipState}
+                onChange={(e) => setRelationshipState(e.target.value)}
+                className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              >
+                <option value="">All resolutions</option>
+                <option value="open">Open</option>
+                <option value="accepted">Accepted</option>
+                <option value="rejected">Rejected</option>
+                <option value="ignored">Ignored</option>
+              </select>
+              <input
+                value={relationshipSourceKind}
+                onChange={(e) => setRelationshipSourceKind(e.target.value)}
+                placeholder="Source kind"
+                className="w-32 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <input
+                value={relationshipSourceID}
+                onChange={(e) => setRelationshipSourceID(e.target.value)}
+                placeholder="Source ID"
+                className="w-36 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <input
+                value={relationshipTargetKind}
+                onChange={(e) => setRelationshipTargetKind(e.target.value)}
+                placeholder="Target kind"
+                className="w-32 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <input
+                value={relationshipTargetID}
+                onChange={(e) => setRelationshipTargetID(e.target.value)}
+                placeholder="Target ID"
+                className="w-36 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+            </>
+          )}
           <button
             type="button"
             onClick={load}
@@ -903,8 +1044,9 @@ function NetworkTab({
       </div>
 
       <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-        <span>{mode === 'conflicts' ? conflicts?.total ?? 0 : activeTotal ?? 0} rows</span>
-        {mode !== 'conflicts' && <span>{activeConflictCount ?? 0} issues</span>}
+        <span>{rowCount} rows</span>
+        {(mode === 'hierarchy' || mode === 'flat') && <span>{activeConflictCount ?? 0} issues</span>}
+        <span>{schemaPolicy.replace(/_/g, ' ')} policy, request-scoped</span>
         {selectedAccountId && <span>{accounts.find((a) => a.id === selectedAccountId)?.name || `Account ${selectedAccountId}`}</span>}
       </div>
 
@@ -926,6 +1068,14 @@ function NetworkTab({
           onPlaceholderParent={handlePlaceholderParentAction}
           onPreviewImport={handlePreviewImportAction}
           pools={pools}
+        />
+      ) : mode === 'objects' ? (
+        <NetworkObjectTable objects={objects?.items ?? []} loading={loading} accounts={accounts} pools={pools} />
+      ) : mode === 'relationships' ? (
+        <NetworkRelationshipTable
+          relationships={relationships?.items ?? []}
+          loading={loading}
+          onResolve={handleResolveRelationship}
         />
       ) : mode === 'flat' ? (
         <NetworkFlatTable nodes={activeItems ?? []} loading={loading} />
@@ -996,6 +1146,7 @@ function NetworkTreeNode({ node, depth }: { node: NetworkNode; depth: number }) 
             <StatusBadge label={node.state} />
           </div>
           <NetworkIssueBadges issues={node.issues ?? []} />
+          <RelationshipBadges relationships={node.relationships ?? []} />
         </div>
       </div>
       {expanded && hasChildren && (
@@ -1023,12 +1174,13 @@ function NetworkFlatTable({ nodes, loading }: { nodes: NetworkNode[]; loading: b
             <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Region</th>
             <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">State</th>
             <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Issues</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Relationships</th>
           </tr>
         </thead>
         <tbody>
           {nodes.length === 0 && (
             <tr>
-              <td colSpan={7} className="px-3 py-8 text-center text-gray-500 dark:text-gray-400">No merged network records found.</td>
+              <td colSpan={8} className="px-3 py-8 text-center text-gray-500 dark:text-gray-400">No merged network records found.</td>
             </tr>
           )}
           {nodes.map((node) => (
@@ -1048,10 +1200,245 @@ function NetworkFlatTable({ nodes, loading }: { nodes: NetworkNode[]; loading: b
               <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{node.region || '-'}</td>
               <td className="px-3 py-2"><StatusBadge label={node.state} /></td>
               <td className="px-3 py-2"><NetworkIssueBadges issues={node.issues ?? []} /></td>
+              <td className="px-3 py-2"><RelationshipBadges relationships={node.relationships ?? []} /></td>
             </tr>
           ))}
         </tbody>
       </table>
+    </div>
+  )
+}
+
+function NetworkObjectTable({
+  objects,
+  loading,
+  accounts,
+  pools,
+}: {
+  objects: NetworkObject[]
+  loading: boolean
+  accounts: Account[]
+  pools: Pool[]
+}) {
+  if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
+  return (
+    <div className="overflow-x-auto rounded border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 bg-gray-50 text-left dark:border-gray-700 dark:bg-gray-900">
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Object</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">CIDR/IP</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Provider</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Account</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Region</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">State</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Parent</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Pool</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Source</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {objects.length === 0 && (
+            <tr>
+              <td colSpan={10} className="px-3 py-8 text-center text-gray-500 dark:text-gray-400">No managed network objects found.</td>
+            </tr>
+          )}
+          {objects.map((object) => {
+            const account = accounts.find((item) => item.id === object.account_id)
+            const pool = object.pool_id ? pools.find((item) => item.id === object.pool_id) : undefined
+            return (
+              <tr key={object.id} className="border-b border-gray-100 last:border-b-0 dark:border-gray-700/50">
+                <td className="px-3 py-2">
+                  <div className="font-medium text-gray-900 dark:text-gray-100">{object.name}</div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">{object.object_type} · {object.provider_resource_id || `object:${object.id}`}</div>
+                </td>
+                <td className="px-3 py-2 font-mono text-gray-700 dark:text-gray-300">{object.cidr || object.ip_address || '-'}</td>
+                <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{object.provider || '-'}</td>
+                <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{account?.name || object.account_id}</td>
+                <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{object.region || '-'}</td>
+                <td className="px-3 py-2"><StatusBadge label={object.state} /></td>
+                <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{object.parent_object_id ?? '-'}</td>
+                <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{pool ? `${pool.name} (${pool.id})` : object.pool_id ?? '-'}</td>
+                <td className="px-3 py-2 font-mono text-xs text-gray-500 dark:text-gray-400">{object.source_discovered_id || '-'}</td>
+                <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{formatTimeAgo(object.updated_at)}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export function NetworkRelationshipTable({
+  relationships,
+  loading,
+  onResolve,
+}: {
+  relationships: NetworkRelationship[]
+  loading: boolean
+  onResolve: (relationship: NetworkRelationship, resolutionState: string, reason: string) => Promise<void>
+}) {
+  const [resolutionStateByID, setResolutionStateByID] = useState<Record<string, string>>({})
+  const [resolutionReasonByID, setResolutionReasonByID] = useState<Record<string, string>>({})
+  const [resolvingByID, setResolvingByID] = useState<Record<string, boolean>>({})
+  const [resolutionErrorByID, setResolutionErrorByID] = useState<Record<string, string>>({})
+
+  async function applyResolution(relationship: NetworkRelationship) {
+    const nextState = resolutionStateByID[relationship.id] || relationship.resolution_state || 'open'
+    const reason = resolutionReasonByID[relationship.id] || ''
+    setResolvingByID((current) => ({ ...current, [relationship.id]: true }))
+    setResolutionErrorByID((current) => {
+      const next = { ...current }
+      delete next[relationship.id]
+      return next
+    })
+    try {
+      await onResolve(relationship, nextState, reason)
+    } catch (err) {
+      setResolutionErrorByID((current) => ({
+        ...current,
+        [relationship.id]: err instanceof Error ? err.message : 'Relationship resolution failed',
+      }))
+    } finally {
+      setResolvingByID((current) => ({ ...current, [relationship.id]: false }))
+    }
+  }
+
+  if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
+  return (
+    <div className="overflow-x-auto rounded border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 bg-gray-50 text-left dark:border-gray-700 dark:bg-gray-900">
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Relationship</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Source</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Target</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Confidence</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Reason / Evidence</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Resolution</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {relationships.length === 0 && (
+            <tr>
+              <td colSpan={7} className="px-3 py-8 text-center text-gray-500 dark:text-gray-400">No network relationships found.</td>
+            </tr>
+          )}
+          {relationships.map((relationship) => {
+            const resolving = resolvingByID[relationship.id] || false
+            return (
+              <tr key={relationship.id} className="border-b border-gray-100 align-top last:border-b-0 dark:border-gray-700/50">
+                <td className="px-3 py-2">
+                  <div className="flex items-center gap-2">
+                    <GitBranch className="h-4 w-4 text-blue-600" />
+                    <div>
+                      <div className="font-medium text-gray-900 dark:text-gray-100">{relationship.type.replace(/_/g, ' ')}</div>
+                      <div className="font-mono text-xs text-gray-500 dark:text-gray-400">{relationship.id}</div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-3 py-2">
+                  <EntityRef kind={relationship.source_kind} id={relationship.source_id} />
+                </td>
+                <td className="px-3 py-2">
+                  <EntityRef kind={relationship.target_kind} id={relationship.target_id} />
+                </td>
+                <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{Math.round(relationship.confidence * 100)}%</td>
+                <td className="max-w-md px-3 py-2 text-gray-600 dark:text-gray-400">
+                  <div>{relationship.reason || '-'}</div>
+                  {(relationship.evidence ?? []).length > 0 && (
+                    <div className="mt-1 space-y-0.5 font-mono text-xs text-gray-500 dark:text-gray-500">
+                      {relationship.evidence!.slice(0, 3).map((item) => <div key={item}>{item}</div>)}
+                    </div>
+                  )}
+                </td>
+                <td className="px-3 py-2">
+                  <div className="flex min-w-[280px] flex-wrap gap-2">
+                    <select
+                      aria-label={`Resolution for ${relationship.id}`}
+                      value={resolutionStateByID[relationship.id] || relationship.resolution_state || 'open'}
+                      onChange={(e) => setResolutionStateByID((current) => ({ ...current, [relationship.id]: e.target.value }))}
+                      disabled={resolving}
+                      className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                    >
+                      <option value="open">Open</option>
+                      <option value="accepted">Accepted</option>
+                      <option value="rejected">Rejected</option>
+                      <option value="ignored">Ignored</option>
+                    </select>
+                    <input
+                      value={resolutionReasonByID[relationship.id] || ''}
+                      onChange={(e) => setResolutionReasonByID((current) => ({ ...current, [relationship.id]: e.target.value }))}
+                      placeholder="Reason"
+                      disabled={resolving}
+                      className="min-w-[120px] flex-1 rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                    />
+                    <button
+                      type="button"
+                      aria-label={`Apply relationship ${relationship.id}`}
+                      disabled={resolving}
+                      onClick={() => void applyResolution(relationship)}
+                      className="inline-flex items-center gap-1 rounded bg-blue-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {resolving && <Loader2 className="h-3 w-3 animate-spin" />}
+                      Apply
+                    </button>
+                  </div>
+                  {resolutionErrorByID[relationship.id] && (
+                    <div className="mt-1 text-xs text-red-600 dark:text-red-400">{resolutionErrorByID[relationship.id]}</div>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{formatTimeAgo(relationship.updated_at)}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function EntityRef({ kind, id }: { kind: string; id: string }) {
+  return (
+    <div>
+      <div className="text-xs uppercase text-gray-500 dark:text-gray-400">{kind}</div>
+      <div className="font-mono text-xs text-gray-700 dark:text-gray-300">{id}</div>
+    </div>
+  )
+}
+
+function NetworkActionResultSummary({ result }: { result: NetworkConflictActionResponse }) {
+  const relationshipCount = result.relationships?.length ?? 0
+  return (
+    <div className="mt-3 rounded bg-green-50 p-2 text-xs text-green-800 dark:bg-green-900/20 dark:text-green-300">
+      <div className="font-semibold">
+        {result.action === 'create_placeholder_parent'
+          ? 'Placeholder parent ready'
+          : result.action === 'import'
+            ? 'Import applied'
+            : result.previous_pool_id
+              ? 'Resource relinked'
+              : 'Resource linked'}
+      </div>
+      <div className="mt-1 space-y-0.5">
+        {result.discovered_id && <div>Discovered resource: <span className="font-mono">{result.discovered_id}</span></div>}
+        {result.previous_pool_id != null && <div>Previous pool: {result.previous_pool_id}</div>}
+        {result.pool_id != null && <div>Target pool: {result.pool_id}</div>}
+        {result.import && (
+          <div>
+            {result.import.pools_created} pools created, {result.import.resources_linked} resources linked, {result.import.skipped} skipped
+          </div>
+        )}
+        {result.network_object && (
+          <div>
+            Object: {result.network_object.name} ({result.network_object.object_type}, {result.network_object.state})
+          </div>
+        )}
+        <div>{relationshipCount} relationship{relationshipCount === 1 ? '' : 's'} recorded</div>
+      </div>
     </div>
   )
 }
@@ -1073,9 +1460,9 @@ export function NetworkConflictList({
   selected: NetworkConflict | null
   onSelect: (conflict: NetworkConflict | null) => void
   onResolve: (conflict: NetworkConflict, decision: string) => void
-  onLink: (conflict: NetworkConflict, discoveredId: string, poolId: number, reason: string, override: boolean) => void
-  onImport: (conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined, reason: string, override: boolean) => void
-  onPlaceholderParent: (conflict: NetworkConflict, discoveredId: string, name: string, reason: string) => void
+  onLink: (conflict: NetworkConflict, discoveredId: string, poolId: number, reason: string, override: boolean) => Promise<NetworkConflictActionResponse>
+  onImport: (conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined, reason: string, override: boolean) => Promise<NetworkConflictActionResponse>
+  onPlaceholderParent: (conflict: NetworkConflict, discoveredId: string, name: string, reason: string) => Promise<NetworkConflictActionResponse>
   onPreviewImport: (conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined) => Promise<DiscoveryImportPreviewResponse>
   pools: Pool[]
 }) {
@@ -1091,6 +1478,7 @@ export function NetworkConflictList({
   const [preview, setPreview] = useState<DiscoveryImportPreviewResponse | null>(null)
   const [previewLoading, setPreviewLoading] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
+  const [actionResult, setActionResult] = useState<NetworkConflictActionResponse | null>(null)
 
   useEffect(() => {
     setActionMode(null)
@@ -1098,6 +1486,7 @@ export function NetworkConflictList({
     setOverride(false)
     setPreview(null)
     setActionError(null)
+    setActionResult(null)
     setLinkDiscoveredID(selected?.discovered_ids?.[0] ?? '')
     setLinkPoolID(selected?.pool_ids?.[0] ? String(selected.pool_ids[0]) : '')
     setImportResourceIDs(selected?.discovered_ids ?? [])
@@ -1110,6 +1499,7 @@ export function NetworkConflictList({
   const poolOptions = pools.filter((pool) => !selected?.pool_ids?.length || selected.pool_ids.includes(pool.id))
   const allPoolOptions = poolOptions.length > 0 ? poolOptions : pools
   const canCreatePlaceholderParent = selected?.type === 'missing_parent' && (selected.discovered_ids?.length ?? 0) > 0
+  const isRelinkCandidate = selected?.type === 'alternate_exact_pool'
 
   async function previewImport() {
     if (!selected) return
@@ -1127,6 +1517,16 @@ export function NetworkConflictList({
       setActionError(err instanceof Error ? err.message : 'Import preview failed')
     } finally {
       setPreviewLoading(false)
+    }
+  }
+
+  async function runAction(next: () => Promise<NetworkConflictActionResponse>) {
+    setActionError(null)
+    try {
+      setActionResult(await next())
+    } catch (err) {
+      setActionResult(null)
+      setActionError(err instanceof Error ? err.message : 'Action failed')
     }
   }
 
@@ -1167,6 +1567,7 @@ export function NetworkConflictList({
                 <div key={line}>{line}</div>
               ))}
             </div>
+            <RelationshipBadges relationships={selected.relationships ?? []} />
             <div className="border-t border-gray-100 pt-3 dark:border-gray-700">
               <div className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">Review</div>
               <div className="mt-2 flex flex-wrap gap-2">
@@ -1191,7 +1592,7 @@ export function NetworkConflictList({
                   className="inline-flex items-center gap-1 rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
                 >
                   <Link2 className="h-3.5 w-3.5" />
-                  Link to pool
+                  {isRelinkCandidate ? 'Relink to pool' : 'Link to pool'}
                 </button>
                 <button
                   type="button"
@@ -1213,8 +1614,14 @@ export function NetworkConflictList({
                 )}
               </div>
               {actionError && <div className="mt-2 text-xs text-red-600 dark:text-red-400">{actionError}</div>}
+              {actionResult && <NetworkActionResultSummary result={actionResult} />}
               {actionMode === 'link' && (
                 <div className="mt-3 space-y-2">
+                  {isRelinkCandidate && (
+                    <div className="rounded bg-amber-50 p-2 text-xs text-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+                      This updates the discovered resource pool association to the selected alternate match.
+                    </div>
+                  )}
                   <select
                     value={linkDiscoveredID}
                     onChange={(e) => setLinkDiscoveredID(e.target.value)}
@@ -1243,10 +1650,10 @@ export function NetworkConflictList({
                   <button
                     type="button"
                     disabled={!linkDiscoveredID || !linkPoolID}
-                    onClick={() => selected && onLink(selected, linkDiscoveredID, Number(linkPoolID), reason, override)}
+                    onClick={() => selected && void runAction(() => onLink(selected, linkDiscoveredID, Number(linkPoolID), reason, override))}
                     className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                    Confirm link
+                    {isRelinkCandidate ? 'Confirm relink' : 'Confirm link'}
                   </button>
                 </div>
               )}
@@ -1300,7 +1707,7 @@ export function NetworkConflictList({
                     <button
                       type="button"
                       disabled={importResourceIDs.length === 0 || !preview}
-                      onClick={() => selected && onImport(selected, importResourceIDs, importPoolID ? Number(importPoolID) : undefined, reason, override)}
+                      onClick={() => selected && void runAction(() => onImport(selected, importResourceIDs, importPoolID ? Number(importPoolID) : undefined, reason, override))}
                       className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Apply import
@@ -1337,7 +1744,7 @@ export function NetworkConflictList({
                   <button
                     type="button"
                     disabled={!placeholderDiscoveredID}
-                    onClick={() => selected && onPlaceholderParent(selected, placeholderDiscoveredID, placeholderName, reason)}
+                    onClick={() => selected && void runAction(() => onPlaceholderParent(selected, placeholderDiscoveredID, placeholderName, reason))}
                     className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     Create placeholder
@@ -1368,6 +1775,25 @@ function NetworkIssueBadges({ issues }: { issues: NetworkIssue[] }) {
           {issue.type.replace(/_/g, ' ')}
         </span>
       ))}
+    </div>
+  )
+}
+
+function RelationshipBadges({ relationships }: { relationships: NetworkRelationship[] }) {
+  if (relationships.length === 0) return null
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {relationships.slice(0, 4).map((relationship) => (
+        <span key={relationship.id} className="inline-flex items-center gap-1 rounded bg-blue-50 px-1.5 py-0.5 text-[11px] text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+          <GitBranch className="h-3 w-3" />
+          {relationship.type.replace(/_/g, ' ')}
+        </span>
+      ))}
+      {relationships.length > 4 && (
+        <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[11px] text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+          +{relationships.length - 4}
+        </span>
+      )}
     </div>
   )
 }

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -750,10 +750,13 @@ function NetworkTab({
   const [schemaPolicy, setSchemaPolicy] = useState('account_level')
   const [relationshipType, setRelationshipType] = useState('')
   const [relationshipState, setRelationshipState] = useState('')
+  const [relationshipIDs, setRelationshipIDs] = useState<string[]>([])
   const [relationshipSourceKind, setRelationshipSourceKind] = useState('')
   const [relationshipSourceID, setRelationshipSourceID] = useState('')
   const [relationshipTargetKind, setRelationshipTargetKind] = useState('')
   const [relationshipTargetID, setRelationshipTargetID] = useState('')
+  const [relationshipEntityKind, setRelationshipEntityKind] = useState('')
+  const [relationshipEntityID, setRelationshipEntityID] = useState('')
   const [selectedConflict, setSelectedConflict] = useState<NetworkConflict | null>(null)
   const [pendingJumpNodeID, setPendingJumpNodeID] = useState<string | null>(null)
   const {
@@ -793,13 +796,16 @@ function NetworkTab({
 
   const relationshipFilters = useMemo(() => ({
     account_id: selectedAccountId ?? undefined,
+    ids: relationshipIDs.length > 0 ? relationshipIDs : undefined,
     type: relationshipType || undefined,
     source_kind: relationshipSourceKind || undefined,
     source_id: relationshipSourceID || undefined,
     target_kind: relationshipTargetKind || undefined,
     target_id: relationshipTargetID || undefined,
+    entity_kind: relationshipEntityKind || undefined,
+    entity_id: relationshipEntityID || undefined,
     resolution_state: relationshipState || undefined,
-  }), [selectedAccountId, relationshipType, relationshipSourceKind, relationshipSourceID, relationshipTargetKind, relationshipTargetID, relationshipState])
+  }), [selectedAccountId, relationshipIDs, relationshipType, relationshipSourceKind, relationshipSourceID, relationshipTargetKind, relationshipTargetID, relationshipEntityKind, relationshipEntityID, relationshipState])
 
   const load = useCallback(() => {
     if (mode === 'hierarchy') {
@@ -933,54 +939,68 @@ function NetworkTab({
   }
 
   function showRelationshipFilter(filter: {
+    ids?: string[]
     type?: string
     source_kind?: string
     source_id?: string
     target_kind?: string
     target_id?: string
+    entity_kind?: string
+    entity_id?: string
   }) {
     setMode('relationships')
+    setRelationshipIDs(filter.ids ?? [])
+    setRelationshipEntityKind(filter.entity_kind || '')
+    setRelationshipEntityID(filter.entity_id || '')
     setRelationshipType(filter.type || '')
+    setRelationshipState('')
     setRelationshipSourceKind(filter.source_kind || '')
     setRelationshipSourceID(filter.source_id || '')
     setRelationshipTargetKind(filter.target_kind || '')
     setRelationshipTargetID(filter.target_id || '')
+    if (filter.entity_kind && filter.entity_id) {
+      setRelationshipSourceKind('')
+      setRelationshipSourceID('')
+      setRelationshipTargetKind('')
+      setRelationshipTargetID('')
+    }
+    if (filter.ids?.length) {
+      setRelationshipType('')
+      setRelationshipSourceKind('')
+      setRelationshipSourceID('')
+      setRelationshipTargetKind('')
+      setRelationshipTargetID('')
+    }
   }
 
   function showRelationshipsForConflict(conflict: NetworkConflict) {
-    const relationship = conflict.relationships?.[0]
-    if (relationship) {
-      showRelationshipFilter({
-        type: relationship.type,
-        source_kind: relationship.source_kind,
-        source_id: relationship.source_id,
-        target_kind: relationship.target_kind,
-        target_id: relationship.target_id,
-      })
+    const relationshipIDs = (conflict.relationships ?? []).map((relationship) => relationship.id).filter(Boolean)
+    if (relationshipIDs.length > 0) {
+      showRelationshipFilter({ ids: relationshipIDs })
       return
     }
     const discoveredID = conflict.discovered_ids?.[0]
     const poolID = conflict.pool_ids?.[0]
     showRelationshipFilter(discoveredID
-      ? { source_kind: 'discovered', source_id: discoveredID }
+      ? { entity_kind: 'discovered', entity_id: discoveredID }
       : poolID
-        ? { target_kind: 'pool', target_id: String(poolID) }
+        ? { entity_kind: 'pool', entity_id: String(poolID) }
         : { type: conflict.type })
   }
 
   function showRelationshipsForNode(node: NetworkNode) {
     const poolIDMatch = node.id.match(/^pool:(\d+)$/)
-    const objectIDMatch = node.id.match(/^network-object:(\d+)$/)
+    const objectIDMatch = node.id.match(/^network_object:(\d+)$/)
     showRelationshipFilter({
-      source_kind: node.kind === 'pool' ? 'pool' : node.kind,
-      source_id: poolIDMatch?.[1] || objectIDMatch?.[1] || node.discovered_id || node.id,
+      entity_kind: node.kind === 'pool' ? 'pool' : node.kind,
+      entity_id: poolIDMatch?.[1] || objectIDMatch?.[1] || node.discovered_id || node.id,
     })
   }
 
   function showRelationshipsForObject(object: NetworkObject) {
     showRelationshipFilter({
-      source_kind: 'network_object',
-      source_id: String(object.id),
+      entity_kind: 'network_object',
+      entity_id: String(object.id),
     })
   }
 
@@ -1000,7 +1020,16 @@ function NetworkTab({
           <NetworkModeButton active={mode === 'flat'} onClick={() => setMode('flat')} label="Flat" />
           <NetworkModeButton active={mode === 'conflicts'} onClick={() => setMode('conflicts')} label="Conflicts" />
           <NetworkModeButton active={mode === 'objects'} onClick={() => setMode('objects')} label="Objects" />
-          <NetworkModeButton active={mode === 'relationships'} onClick={() => setMode('relationships')} label="Relationships" />
+          <NetworkModeButton
+            active={mode === 'relationships'}
+            onClick={() => {
+              setRelationshipIDs([])
+              setRelationshipEntityKind('')
+              setRelationshipEntityID('')
+              setMode('relationships')
+            }}
+            label="Relationships"
+          />
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <div className="relative min-w-[220px] flex-1">
@@ -1100,7 +1129,12 @@ function NetworkTab({
             <>
               <select
                 value={relationshipType}
-                onChange={(e) => setRelationshipType(e.target.value)}
+                onChange={(e) => {
+                  setRelationshipIDs([])
+                  setRelationshipEntityKind('')
+                  setRelationshipEntityID('')
+                  setRelationshipType(e.target.value)
+                }}
                 className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
               >
                 <option value="">All relationships</option>
@@ -1124,25 +1158,45 @@ function NetworkTab({
               </select>
               <input
                 value={relationshipSourceKind}
-                onChange={(e) => setRelationshipSourceKind(e.target.value)}
+                onChange={(e) => {
+                  setRelationshipIDs([])
+                  setRelationshipEntityKind('')
+                  setRelationshipEntityID('')
+                  setRelationshipSourceKind(e.target.value)
+                }}
                 placeholder="Source kind"
                 className="w-32 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
               />
               <input
                 value={relationshipSourceID}
-                onChange={(e) => setRelationshipSourceID(e.target.value)}
+                onChange={(e) => {
+                  setRelationshipIDs([])
+                  setRelationshipEntityKind('')
+                  setRelationshipEntityID('')
+                  setRelationshipSourceID(e.target.value)
+                }}
                 placeholder="Source ID"
                 className="w-36 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
               />
               <input
                 value={relationshipTargetKind}
-                onChange={(e) => setRelationshipTargetKind(e.target.value)}
+                onChange={(e) => {
+                  setRelationshipIDs([])
+                  setRelationshipEntityKind('')
+                  setRelationshipEntityID('')
+                  setRelationshipTargetKind(e.target.value)
+                }}
                 placeholder="Target kind"
                 className="w-32 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
               />
               <input
                 value={relationshipTargetID}
-                onChange={(e) => setRelationshipTargetID(e.target.value)}
+                onChange={(e) => {
+                  setRelationshipIDs([])
+                  setRelationshipEntityKind('')
+                  setRelationshipEntityID('')
+                  setRelationshipTargetID(e.target.value)
+                }}
                 placeholder="Target ID"
                 className="w-36 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
               />

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -782,13 +782,14 @@ function NetworkTab({
   }), [selectedAccountId, objectType, objectState, conflictType, schemaPolicy, query])
 
   const relationshipFilters = useMemo(() => ({
+    account_id: selectedAccountId ?? undefined,
     type: relationshipType || undefined,
     source_kind: relationshipSourceKind || undefined,
     source_id: relationshipSourceID || undefined,
     target_kind: relationshipTargetKind || undefined,
     target_id: relationshipTargetID || undefined,
     resolution_state: relationshipState || undefined,
-  }), [relationshipType, relationshipSourceKind, relationshipSourceID, relationshipTargetKind, relationshipTargetID, relationshipState])
+  }), [selectedAccountId, relationshipType, relationshipSourceKind, relationshipSourceID, relationshipTargetKind, relationshipTargetID, relationshipState])
 
   const load = useCallback(() => {
     if (mode === 'hierarchy') {
@@ -1002,8 +1003,7 @@ function NetworkTab({
               >
                 <option value="">All resolutions</option>
                 <option value="open">Open</option>
-                <option value="accepted">Accepted</option>
-                <option value="rejected">Rejected</option>
+                <option value="resolved">Resolved</option>
                 <option value="ignored">Ignored</option>
               </select>
               <input
@@ -1365,8 +1365,7 @@ export function NetworkRelationshipTable({
                       className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
                     >
                       <option value="open">Open</option>
-                      <option value="accepted">Accepted</option>
-                      <option value="rejected">Rejected</option>
+                      <option value="resolved">Resolved</option>
                       <option value="ignored">Ignored</option>
                     </select>
                     <input

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
+import { useEffect, useState, useCallback, useMemo, useRef, type ReactNode } from 'react'
 import {
   RefreshCw,
   Link2,
@@ -18,6 +18,7 @@ import {
   Network,
   Table2,
   GitBranch,
+  ArrowRight,
 } from 'lucide-react'
 import {
   useDiscoveryResources,
@@ -739,8 +740,12 @@ function NetworkTab({
 }) {
   const [mode, setMode] = useState<NetworkMode>('hierarchy')
   const [query, setQuery] = useState('')
+  const [networkProvider, setNetworkProvider] = useState('')
+  const [networkRegion, setNetworkRegion] = useState('')
   const [objectType, setObjectType] = useState('')
   const [objectState, setObjectState] = useState('')
+  const [objectPoolID, setObjectPoolID] = useState('')
+  const [objectSourceDiscoveredID, setObjectSourceDiscoveredID] = useState('')
   const [conflictType, setConflictType] = useState('')
   const [schemaPolicy, setSchemaPolicy] = useState('account_level')
   const [relationshipType, setRelationshipType] = useState('')
@@ -750,6 +755,7 @@ function NetworkTab({
   const [relationshipTargetKind, setRelationshipTargetKind] = useState('')
   const [relationshipTargetID, setRelationshipTargetID] = useState('')
   const [selectedConflict, setSelectedConflict] = useState<NetworkConflict | null>(null)
+  const [pendingJumpNodeID, setPendingJumpNodeID] = useState<string | null>(null)
   const {
     flat,
     hierarchy,
@@ -774,12 +780,16 @@ function NetworkTab({
 
   const filters = useMemo(() => ({
     account_id: selectedAccountId ?? undefined,
+    provider: networkProvider || undefined,
+    region: networkRegion || undefined,
     object_type: objectType || undefined,
     status: objectState || undefined,
+    pool_id: objectPoolID ? Number(objectPoolID) : undefined,
+    source_discovered_id: objectSourceDiscoveredID || undefined,
     conflict_type: conflictType || undefined,
     schema_policy: schemaPolicy,
     q: query || undefined,
-  }), [selectedAccountId, objectType, objectState, conflictType, schemaPolicy, query])
+  }), [selectedAccountId, networkProvider, networkRegion, objectType, objectState, objectPoolID, objectSourceDiscoveredID, conflictType, schemaPolicy, query])
 
   const relationshipFilters = useMemo(() => ({
     account_id: selectedAccountId ?? undefined,
@@ -808,6 +818,22 @@ function NetworkTab({
   useEffect(() => {
     load()
   }, [load])
+
+  const activeItems = mode === 'hierarchy' ? hierarchy?.items : flat?.items
+  const activeTotal = mode === 'hierarchy' ? hierarchy?.total : flat?.total
+  const activeConflictCount = mode === 'hierarchy' ? hierarchy?.conflict_count : flat?.conflict_count
+
+  useEffect(() => {
+    if (!pendingJumpNodeID || (mode !== 'flat' && mode !== 'hierarchy')) return
+    const frame = window.requestAnimationFrame(() => {
+      const target = document.getElementById(networkNodeElementID(pendingJumpNodeID))
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        setPendingJumpNodeID(null)
+      }
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [mode, activeItems, pendingJumpNodeID])
 
   async function handleResolve(conflict: NetworkConflict, decision: string) {
     try {
@@ -896,9 +922,68 @@ function NetworkTab({
     return previewNetworkImport(accountId, resourceIds, poolId)
   }
 
-  const activeItems = mode === 'hierarchy' ? hierarchy?.items : flat?.items
-  const activeTotal = mode === 'hierarchy' ? hierarchy?.total : flat?.total
-  const activeConflictCount = mode === 'hierarchy' ? hierarchy?.conflict_count : flat?.conflict_count
+  function showConflictInMode(conflict: NetworkConflict, nextMode: Extract<NetworkMode, 'flat' | 'hierarchy'>) {
+    const nodeID = conflict.node_ids?.[0]
+    setMode(nextMode)
+    if (nodeID) {
+      setPendingJumpNodeID(nodeID)
+      return
+    }
+    if (conflict.cidr) setQuery(conflict.cidr)
+  }
+
+  function showRelationshipFilter(filter: {
+    type?: string
+    source_kind?: string
+    source_id?: string
+    target_kind?: string
+    target_id?: string
+  }) {
+    setMode('relationships')
+    setRelationshipType(filter.type || '')
+    setRelationshipSourceKind(filter.source_kind || '')
+    setRelationshipSourceID(filter.source_id || '')
+    setRelationshipTargetKind(filter.target_kind || '')
+    setRelationshipTargetID(filter.target_id || '')
+  }
+
+  function showRelationshipsForConflict(conflict: NetworkConflict) {
+    const relationship = conflict.relationships?.[0]
+    if (relationship) {
+      showRelationshipFilter({
+        type: relationship.type,
+        source_kind: relationship.source_kind,
+        source_id: relationship.source_id,
+        target_kind: relationship.target_kind,
+        target_id: relationship.target_id,
+      })
+      return
+    }
+    const discoveredID = conflict.discovered_ids?.[0]
+    const poolID = conflict.pool_ids?.[0]
+    showRelationshipFilter(discoveredID
+      ? { source_kind: 'discovered', source_id: discoveredID }
+      : poolID
+        ? { target_kind: 'pool', target_id: String(poolID) }
+        : { type: conflict.type })
+  }
+
+  function showRelationshipsForNode(node: NetworkNode) {
+    const poolIDMatch = node.id.match(/^pool:(\d+)$/)
+    const objectIDMatch = node.id.match(/^network-object:(\d+)$/)
+    showRelationshipFilter({
+      source_kind: node.kind === 'pool' ? 'pool' : node.kind,
+      source_id: poolIDMatch?.[1] || objectIDMatch?.[1] || node.discovered_id || node.id,
+    })
+  }
+
+  function showRelationshipsForObject(object: NetworkObject) {
+    showRelationshipFilter({
+      source_kind: 'network_object',
+      source_id: String(object.id),
+    })
+  }
+
   const rowCount = mode === 'conflicts'
     ? conflicts?.total ?? 0
     : mode === 'objects'
@@ -937,6 +1022,22 @@ function NetworkTab({
             <option value="global">Global policy</option>
             <option value="manual">Manual policy</option>
           </select>
+          {(mode === 'objects' || mode === 'hierarchy' || mode === 'flat' || mode === 'conflicts') && (
+            <>
+              <input
+                value={networkProvider}
+                onChange={(e) => setNetworkProvider(e.target.value)}
+                placeholder="Provider"
+                className="w-28 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <input
+                value={networkRegion}
+                onChange={(e) => setNetworkRegion(e.target.value)}
+                placeholder="Region"
+                className="w-32 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+            </>
+          )}
           <select
             value={objectType}
             onChange={(e) => setObjectType(e.target.value)}
@@ -953,17 +1054,32 @@ function NetworkTab({
             <option value="network_interface">NIC</option>
           </select>
           {mode === 'objects' && (
-            <select
-              value={objectState}
-              onChange={(e) => setObjectState(e.target.value)}
-              className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-            >
-              <option value="">All states</option>
-              <option value="managed">Managed</option>
-              <option value="placeholder">Placeholder</option>
-              <option value="imported">Imported</option>
-              <option value="ignored">Ignored</option>
-            </select>
+            <>
+              <select
+                value={objectState}
+                onChange={(e) => setObjectState(e.target.value)}
+                className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              >
+                <option value="">All states</option>
+                <option value="managed">Managed</option>
+                <option value="placeholder">Placeholder</option>
+                <option value="imported">Imported</option>
+                <option value="ignored">Ignored</option>
+              </select>
+              <input
+                value={objectPoolID}
+                onChange={(e) => setObjectPoolID(e.target.value)}
+                placeholder="Pool ID"
+                inputMode="numeric"
+                className="w-28 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+              <input
+                value={objectSourceDiscoveredID}
+                onChange={(e) => setObjectSourceDiscoveredID(e.target.value)}
+                placeholder="Source discovered ID"
+                className="w-44 rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+            </>
           )}
           <select
             value={conflictType}
@@ -1067,10 +1183,20 @@ function NetworkTab({
           onImport={handleImportAction}
           onPlaceholderParent={handlePlaceholderParentAction}
           onPreviewImport={handlePreviewImportAction}
+          onViewFlat={(conflict) => showConflictInMode(conflict, 'flat')}
+          onViewHierarchy={(conflict) => showConflictInMode(conflict, 'hierarchy')}
+          onShowRelationships={showRelationshipsForConflict}
           pools={pools}
+          accounts={accounts}
         />
       ) : mode === 'objects' ? (
-        <NetworkObjectTable objects={objects?.items ?? []} loading={loading} accounts={accounts} pools={pools} />
+        <NetworkObjectTable
+          objects={objects?.items ?? []}
+          loading={loading}
+          accounts={accounts}
+          pools={pools}
+          onShowRelationships={showRelationshipsForObject}
+        />
       ) : mode === 'relationships' ? (
         <NetworkRelationshipTable
           relationships={relationships?.items ?? []}
@@ -1078,9 +1204,9 @@ function NetworkTab({
           onResolve={handleResolveRelationship}
         />
       ) : mode === 'flat' ? (
-        <NetworkFlatTable nodes={activeItems ?? []} loading={loading} />
+        <NetworkFlatTable nodes={activeItems ?? []} loading={loading} highlightedNodeID={pendingJumpNodeID} onShowRelationships={showRelationshipsForNode} />
       ) : (
-        <NetworkHierarchy nodes={activeItems ?? []} loading={loading} />
+        <NetworkHierarchy nodes={activeItems ?? []} loading={loading} highlightedNodeID={pendingJumpNodeID} onShowRelationships={showRelationshipsForNode} />
       )}
     </div>
   )
@@ -1106,25 +1232,51 @@ function NetworkModeButton({
   )
 }
 
-function NetworkHierarchy({ nodes, loading }: { nodes: NetworkNode[]; loading: boolean }) {
+function networkNodeElementID(id: string) {
+  return `network-node-${id.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+}
+
+function NetworkHierarchy({
+  nodes,
+  loading,
+  highlightedNodeID,
+  onShowRelationships,
+}: {
+  nodes: NetworkNode[]
+  loading: boolean
+  highlightedNodeID: string | null
+  onShowRelationships: (node: NetworkNode) => void
+}) {
   if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
   if (nodes.length === 0) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">No merged network records found.</div>
   return (
     <div className="rounded border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-gray-800">
       {nodes.map((node) => (
-        <NetworkTreeNode key={node.id} node={node} depth={0} />
+        <NetworkTreeNode key={node.id} node={node} depth={0} highlightedNodeID={highlightedNodeID} onShowRelationships={onShowRelationships} />
       ))}
     </div>
   )
 }
 
-function NetworkTreeNode({ node, depth }: { node: NetworkNode; depth: number }) {
+function NetworkTreeNode({
+  node,
+  depth,
+  highlightedNodeID,
+  onShowRelationships,
+}: {
+  node: NetworkNode
+  depth: number
+  highlightedNodeID: string | null
+  onShowRelationships: (node: NetworkNode) => void
+}) {
   const [expanded, setExpanded] = useState(depth < 2)
   const hasChildren = (node.children?.length ?? 0) > 0
+  const highlighted = highlightedNodeID === node.id
   return (
     <div>
       <div
-        className="flex min-h-10 items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700/50"
+        id={networkNodeElementID(node.id)}
+        className={`flex min-h-10 items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700/50 ${highlighted ? 'ring-2 ring-blue-500 bg-blue-50 dark:bg-blue-900/20' : ''}`}
         style={{ paddingLeft: `${depth * 18 + 8}px` }}
       >
         {hasChildren ? (
@@ -1148,11 +1300,21 @@ function NetworkTreeNode({ node, depth }: { node: NetworkNode; depth: number }) 
           <NetworkIssueBadges issues={node.issues ?? []} />
           <RelationshipBadges relationships={node.relationships ?? []} />
         </div>
+        {(node.relationships?.length ?? 0) > 0 && (
+          <button
+            type="button"
+            onClick={() => onShowRelationships(node)}
+            className="inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            <GitBranch className="h-3.5 w-3.5" />
+            Relationships
+          </button>
+        )}
       </div>
       {expanded && hasChildren && (
         <div>
           {node.children!.map((child) => (
-            <NetworkTreeNode key={child.id} node={child} depth={depth + 1} />
+            <NetworkTreeNode key={child.id} node={child} depth={depth + 1} highlightedNodeID={highlightedNodeID} onShowRelationships={onShowRelationships} />
           ))}
         </div>
       )}
@@ -1160,7 +1322,17 @@ function NetworkTreeNode({ node, depth }: { node: NetworkNode; depth: number }) 
   )
 }
 
-function NetworkFlatTable({ nodes, loading }: { nodes: NetworkNode[]; loading: boolean }) {
+function NetworkFlatTable({
+  nodes,
+  loading,
+  highlightedNodeID,
+  onShowRelationships,
+}: {
+  nodes: NetworkNode[]
+  loading: boolean
+  highlightedNodeID: string | null
+  onShowRelationships: (node: NetworkNode) => void
+}) {
   if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
   return (
     <div className="overflow-x-auto rounded border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
@@ -1175,16 +1347,21 @@ function NetworkFlatTable({ nodes, loading }: { nodes: NetworkNode[]; loading: b
             <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">State</th>
             <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Issues</th>
             <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Relationships</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Actions</th>
           </tr>
         </thead>
         <tbody>
           {nodes.length === 0 && (
             <tr>
-              <td colSpan={8} className="px-3 py-8 text-center text-gray-500 dark:text-gray-400">No merged network records found.</td>
+              <td colSpan={9} className="px-3 py-8 text-center text-gray-500 dark:text-gray-400">No merged network records found.</td>
             </tr>
           )}
           {nodes.map((node) => (
-            <tr key={node.id} className="border-b border-gray-100 last:border-b-0 dark:border-gray-700/50">
+            <tr
+              key={node.id}
+              id={networkNodeElementID(node.id)}
+              className={`border-b border-gray-100 last:border-b-0 dark:border-gray-700/50 ${highlightedNodeID === node.id ? 'bg-blue-50 ring-2 ring-inset ring-blue-500 dark:bg-blue-900/20' : ''}`}
+            >
               <td className="px-3 py-2">
                 <div className="flex items-center gap-2">
                   <NetworkObjectIcon node={node} />
@@ -1201,6 +1378,18 @@ function NetworkFlatTable({ nodes, loading }: { nodes: NetworkNode[]; loading: b
               <td className="px-3 py-2"><StatusBadge label={node.state} /></td>
               <td className="px-3 py-2"><NetworkIssueBadges issues={node.issues ?? []} /></td>
               <td className="px-3 py-2"><RelationshipBadges relationships={node.relationships ?? []} /></td>
+              <td className="px-3 py-2">
+                {(node.relationships?.length ?? 0) > 0 ? (
+                  <button
+                    type="button"
+                    onClick={() => onShowRelationships(node)}
+                    className="inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    <GitBranch className="h-3.5 w-3.5" />
+                    Relationships
+                  </button>
+                ) : '-'}
+              </td>
             </tr>
           ))}
         </tbody>
@@ -1214,11 +1403,13 @@ function NetworkObjectTable({
   loading,
   accounts,
   pools,
+  onShowRelationships,
 }: {
   objects: NetworkObject[]
   loading: boolean
   accounts: Account[]
   pools: Pool[]
+  onShowRelationships: (object: NetworkObject) => void
 }) {
   if (loading) return <div className="py-8 text-center text-gray-500 dark:text-gray-400">Loading...</div>
   return (
@@ -1236,12 +1427,13 @@ function NetworkObjectTable({
             <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Pool</th>
             <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Source</th>
             <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Updated</th>
+            <th className="px-3 py-2 font-medium text-gray-600 dark:text-gray-400">Actions</th>
           </tr>
         </thead>
         <tbody>
           {objects.length === 0 && (
             <tr>
-              <td colSpan={10} className="px-3 py-8 text-center text-gray-500 dark:text-gray-400">No managed network objects found.</td>
+              <td colSpan={11} className="px-3 py-8 text-center text-gray-500 dark:text-gray-400">No managed network objects found.</td>
             </tr>
           )}
           {objects.map((object) => {
@@ -1262,6 +1454,16 @@ function NetworkObjectTable({
                 <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{pool ? `${pool.name} (${pool.id})` : object.pool_id ?? '-'}</td>
                 <td className="px-3 py-2 font-mono text-xs text-gray-500 dark:text-gray-400">{object.source_discovered_id || '-'}</td>
                 <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{formatTimeAgo(object.updated_at)}</td>
+                <td className="px-3 py-2">
+                  <button
+                    type="button"
+                    onClick={() => onShowRelationships(object)}
+                    className="inline-flex items-center gap-1 rounded border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    <GitBranch className="h-3.5 w-3.5" />
+                    Relationships
+                  </button>
+                </td>
               </tr>
             )
           })}
@@ -1409,7 +1611,42 @@ function EntityRef({ kind, id }: { kind: string; id: string }) {
   )
 }
 
-function NetworkActionResultSummary({ result }: { result: NetworkConflictActionResponse }) {
+function ConflictDetailSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="border-t border-gray-100 pt-3 dark:border-gray-700">
+      <div className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">{title}</div>
+      <div className="mt-2 space-y-1">{children}</div>
+    </div>
+  )
+}
+
+function DetailList({ label, values }: { label: string; values: Array<string | number> }) {
+  const filtered = values.filter((value) => value !== '' && value != null).map((value) => String(value))
+  return (
+    <div className="text-xs text-gray-500 dark:text-gray-400">
+      <span className="font-medium text-gray-700 dark:text-gray-300">{label}: </span>
+      {filtered.length > 0 ? (
+        <span className="font-mono">{filtered.join(', ')}</span>
+      ) : (
+        <span>-</span>
+      )}
+    </div>
+  )
+}
+
+function evidenceValues(evidence: string[] | undefined, keys: string[]) {
+  return (evidence ?? []).filter((line) => keys.some((key) => line.startsWith(`${key}=`) || line.includes(`${key}=`)))
+}
+
+function NetworkActionResultSummary({
+  result,
+  onViewFlat,
+  onShowRelationships,
+}: {
+  result: NetworkConflictActionResponse
+  onViewFlat: (conflict: NetworkConflict) => void
+  onShowRelationships: (conflict: NetworkConflict) => void
+}) {
   const relationshipCount = result.relationships?.length ?? 0
   return (
     <div className="mt-3 rounded bg-green-50 p-2 text-xs text-green-800 dark:bg-green-900/20 dark:text-green-300">
@@ -1438,6 +1675,24 @@ function NetworkActionResultSummary({ result }: { result: NetworkConflictActionR
         )}
         <div>{relationshipCount} relationship{relationshipCount === 1 ? '' : 's'} recorded</div>
       </div>
+      <div className="mt-2 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => onViewFlat(result.conflict)}
+          className="inline-flex items-center gap-1 rounded border border-green-300 px-2 py-1 text-xs text-green-800 hover:bg-green-100 dark:border-green-700 dark:text-green-300 dark:hover:bg-green-900/40"
+        >
+          <ArrowRight className="h-3.5 w-3.5" />
+          View affected row
+        </button>
+        <button
+          type="button"
+          onClick={() => onShowRelationships(result.conflict)}
+          className="inline-flex items-center gap-1 rounded border border-green-300 px-2 py-1 text-xs text-green-800 hover:bg-green-100 dark:border-green-700 dark:text-green-300 dark:hover:bg-green-900/40"
+        >
+          <GitBranch className="h-3.5 w-3.5" />
+          View relationships
+        </button>
+      </div>
     </div>
   )
 }
@@ -1452,7 +1707,11 @@ export function NetworkConflictList({
   onImport,
   onPlaceholderParent,
   onPreviewImport,
+  onViewFlat,
+  onViewHierarchy,
+  onShowRelationships,
   pools,
+  accounts,
 }: {
   conflicts: NetworkConflict[]
   loading: boolean
@@ -1463,7 +1722,11 @@ export function NetworkConflictList({
   onImport: (conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined, reason: string, override: boolean) => Promise<NetworkConflictActionResponse>
   onPlaceholderParent: (conflict: NetworkConflict, discoveredId: string, name: string, reason: string) => Promise<NetworkConflictActionResponse>
   onPreviewImport: (conflict: NetworkConflict, resourceIds: string[], poolId: number | undefined) => Promise<DiscoveryImportPreviewResponse>
+  onViewFlat: (conflict: NetworkConflict) => void
+  onViewHierarchy: (conflict: NetworkConflict) => void
+  onShowRelationships: (conflict: NetworkConflict) => void
   pools: Pool[]
+  accounts: Account[]
 }) {
   const [actionMode, setActionMode] = useState<'link' | 'import' | 'placeholder_parent' | null>(null)
   const [linkDiscoveredID, setLinkDiscoveredID] = useState('')
@@ -1499,6 +1762,8 @@ export function NetworkConflictList({
   const allPoolOptions = poolOptions.length > 0 ? poolOptions : pools
   const canCreatePlaceholderParent = selected?.type === 'missing_parent' && (selected.discovered_ids?.length ?? 0) > 0
   const isRelinkCandidate = selected?.type === 'alternate_exact_pool'
+  const selectedPools = selected?.pool_ids?.map((id) => pools.find((pool) => pool.id === id) ?? null) ?? []
+  const selectedAccounts = selected?.account_ids?.map((id) => accounts.find((account) => account.id === id) ?? null) ?? []
 
   async function previewImport() {
     if (!selected) return
@@ -1553,7 +1818,11 @@ export function NetworkConflictList({
         {selected ? (
           <div className="space-y-3">
             <div>
-              <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{selected.title}</div>
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{selected.title}</div>
+                <StatusBadge label={selected.status || 'open'} />
+                {selected.resolution_state && <StatusBadge label={selected.resolution_state} />}
+              </div>
               <div className="mt-1 text-sm text-gray-500 dark:text-gray-400">{selected.description}</div>
             </div>
             {selected.recommended_action && (
@@ -1561,12 +1830,71 @@ export function NetworkConflictList({
                 {selected.recommended_action}
               </div>
             )}
-            <div className="space-y-1 text-xs text-gray-500 dark:text-gray-400">
-              {(selected.evidence ?? []).map((line) => (
-                <div key={line}>{line}</div>
-              ))}
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => onViewFlat(selected)}
+                className="inline-flex items-center gap-1 rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+              >
+                <ArrowRight className="h-3.5 w-3.5" />
+                View in flat
+              </button>
+              <button
+                type="button"
+                onClick={() => onViewHierarchy(selected)}
+                className="inline-flex items-center gap-1 rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+              >
+                <ArrowRight className="h-3.5 w-3.5" />
+                View in hierarchy
+              </button>
+              <button
+                type="button"
+                onClick={() => onShowRelationships(selected)}
+                className="inline-flex items-center gap-1 rounded border border-gray-300 px-2.5 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+              >
+                <GitBranch className="h-3.5 w-3.5" />
+                Show relationships
+              </button>
             </div>
-            <RelationshipBadges relationships={selected.relationships ?? []} />
+            <ConflictDetailSection title="Affected resources">
+              <DetailList label="Discovered" values={selected.discovered_ids ?? []} />
+              <DetailList label="Nodes" values={selected.node_ids ?? []} />
+              <DetailList label="Managed objects" values={evidenceValues(selected.evidence, ['network_object_id', 'object_id', 'placeholder_parent'])} />
+            </ConflictDetailSection>
+            <ConflictDetailSection title="Ownership">
+              <DetailList
+                label="Accounts"
+                values={selectedAccounts.map((account, index) => account ? `${account.name} (${account.id})` : String(selected.account_ids?.[index]))}
+              />
+              <DetailList label="Provider" values={selected.provider ? [selected.provider] : []} />
+              <DetailList label="Regions" values={selected.regions ?? []} />
+              <DetailList label="Object types" values={selected.object_types ?? []} />
+            </ConflictDetailSection>
+            <ConflictDetailSection title="Pools and parent chain">
+              <DetailList
+                label="Pools"
+                values={selectedPools.map((pool, index) => pool ? `${pool.name} (${pool.id}, ${pool.cidr})` : String(selected.pool_ids?.[index]))}
+              />
+              <DetailList label="Parent evidence" values={evidenceValues(selected.evidence, ['parent_resource_id', 'parent_id', 'placeholder_parent'])} />
+            </ConflictDetailSection>
+            <ConflictDetailSection title="CIDR/IP evidence">
+              <DetailList label="Conflict CIDR" values={selected.cidr ? [selected.cidr] : []} />
+              <DetailList label="Evidence" values={selected.evidence ?? []} />
+            </ConflictDetailSection>
+            <ConflictDetailSection title="Relationships">
+              {(selected.relationships ?? []).length > 0 ? (
+                <div className="space-y-1">
+                  {selected.relationships!.map((relationship) => (
+                    <div key={relationship.id} className="rounded bg-gray-50 p-2 text-xs text-gray-600 dark:bg-gray-900/40 dark:text-gray-300">
+                      <div className="font-medium text-gray-800 dark:text-gray-200">{relationship.type.replace(/_/g, ' ')} · {relationship.resolution_state}</div>
+                      <div className="font-mono">{relationship.source_kind}:{relationship.source_id} {'->'} {relationship.target_kind}:{relationship.target_id}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-xs text-gray-500 dark:text-gray-400">No attached relationships returned.</div>
+              )}
+            </ConflictDetailSection>
             <div className="border-t border-gray-100 pt-3 dark:border-gray-700">
               <div className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">Review</div>
               <div className="mt-2 flex flex-wrap gap-2">
@@ -1613,7 +1941,13 @@ export function NetworkConflictList({
                 )}
               </div>
               {actionError && <div className="mt-2 text-xs text-red-600 dark:text-red-400">{actionError}</div>}
-              {actionResult && <NetworkActionResultSummary result={actionResult} />}
+              {actionResult && (
+                <NetworkActionResultSummary
+                  result={actionResult}
+                  onViewFlat={onViewFlat}
+                  onShowRelationships={onShowRelationships}
+                />
+              )}
               {actionMode === 'link' && (
                 <div className="mt-3 space-y-2">
                   {isRelinkCandidate && (

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,10 +12,10 @@
         }
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-BrqLdKlE.js"></script>
+    <script type="module" crossorigin src="/assets/index-B7M_7Iqc.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-cLTP9fnK.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-BP3HTIYm.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-BOdEpQjX.css">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-Bkva2-iT.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-DZSUVV7o.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,7 +12,7 @@
         }
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-B7M_7Iqc.js"></script>
+    <script type="module" crossorigin src="/assets/index-3z93ILlf.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-cLTP9fnK.js">
     <link rel="modulepreload" crossorigin href="/assets/vendor-icons-Bkva2-iT.js">
     <link rel="stylesheet" crossorigin href="/assets/index-DZSUVV7o.css">

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,10 +12,10 @@
         }
       })();
     </script>
-    <script type="module" crossorigin src="/assets/index-DOApqCj9.js"></script>
+    <script type="module" crossorigin src="/assets/index-BrqLdKlE.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-react-cLTP9fnK.js">
-    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-CsdvKQLG.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DZp2w1lT.css">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-icons-BP3HTIYm.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-BOdEpQjX.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

Closes #207.

This completes the Discovery Merged Network UI surface for the recently added network APIs, excluding screenshot capture. Operators can now inspect managed network objects, inspect and resolve explicit relationships, choose request-scoped schema policy, use relink-specific conflict actions, navigate from conflict details back to affected merged rows, and filter relationship/object context without dropping to raw API calls.

## What Changed

- Added a schema policy selector to Discovery > Merged Network for `account_level`, `region_level`, `global`, and `manual`.
- Propagated `schema_policy` through hierarchy, flat, and conflict network queries.
- Added managed network object browser mode with columns for object type, name, provider/account/region, CIDR/IP, provider resource ID, state, parent object, pool, source discovered resource, and updated timestamp.
- Added relationship browser mode with filters for type, source kind/source ID, target kind/target ID, and resolution state.
- Scoped relationship browser filters to the selected account and aligned the UI with the backend `resolved` relationship state vocabulary.
- Added relationship resolution using the body-form `POST /api/v1/network/relationships/resolve` endpoint so IDs containing path separators are supported.
- Changed relationship resolution UX to use an explicit per-row Apply button with pending state and inline error handling.
- Added relationship badges to merged rows and conflict details when relationship data is returned.
- Added structured conflict details for affected discovered resources, affected pools, affected managed network object evidence, account/region ownership, parent evidence, CIDR/IP evidence, attached relationships, available decisions/actions, and current state.
- Added conflict detail navigation actions for “View in flat,” “View in hierarchy,” and “Show relationships.”
- Added row-level relationship navigation from flat/hierarchy/object rows into the relationship browser with source filters prefilled.
- Updated conflict actions to render inline result summaries for link/relink/import/placeholder-parent responses.
- Added action result navigation back to affected flat rows and relationship filters.
- Updated `alternate_exact_pool` UX to use relink-oriented wording and display `previous_pool_id`, target `pool_id`, discovered resource ID, and relationship count.
- Kept placeholder-parent actions gated to `missing_parent` conflicts and display returned network object details.
- Added provider, region, pool ID, and source discovered resource filters to the managed object browser.
- Added backend support for managed object `pool_id` and `source_discovered_id` filters across memory, SQLite, and PostgreSQL stores.
- Updated OpenAPI query params for the managed network object filters.
- Expanded TypeScript API types for network objects, object list responses, relationship list/create/resolve responses, hydrated relationships, and conflict action response fields.
- Added concrete `0.17.2` changelog entry.

## Tests

- `npm run test -- DiscoveryNetworkRelationshipTable DiscoveryNetworkConflictList useNetwork`
  - Passed: 3 files, 12 tests.
- `npm run build`
  - Passed: TypeScript build and Vite production build completed.
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop -c go test ./internal/api`
  - Passed: `ok cloudpam/internal/api`.

## Notes

- Direct `go test ./internal/api` was not available in this shell because `go` is not on PATH, so the backend API slice was run through the repo Nix dev shell.
- `web/dist/index.html` was updated by the UI build. The hashed assets under `web/dist/assets/` are generated but not tracked by Git in this repo.

## Remaining Follow-Up

- Add Playwright screenshots for the new Merged Network object, relationship, missing-parent, and relink flows.
- Add a live-backend browser fixture test to prove the object and relationship tables render seeded backend data end-to-end.
- Managed network object create/edit UI remains intentionally out of scope; this PR provides list/detail/filter context.
