### PR TITLE
Discovery: persist schema policy settings

### DIFF
--- a/cmd/cloudpam/main.go
+++ b/cmd/cloudpam/main.go
@@ -219,15 +219,17 @@ func main() {
 	driftDetector := discovery.NewDriftDetector(store, discoveryStore, driftStore)
 	driftSrv := api.NewDriftServer(srv, driftDetector, driftStore)
 	logger.Info("drift detection subsystem initialized")
-	networkSrv := api.NewNetworkServer(srv, store, discoveryStore, driftStore)
-	networkSrv.SetNetworkStore(selectNetworkStore(logger, store))
-	logger.Info("merged network view subsystem initialized")
 
 	// Initialize settings subsystem
 	settingsStore := selectSettingsStore(logger, store)
 	settingsSrv := api.NewSettingsServer(srv, settingsStore)
 	srv.SetSettingsStore(settingsStore)
 	logger.Info("settings subsystem initialized")
+
+	networkSrv := api.NewNetworkServer(srv, store, discoveryStore, driftStore)
+	networkSrv.SetNetworkStore(selectNetworkStore(logger, store))
+	networkSrv.SetSettingsStore(settingsStore)
+	logger.Info("merged network view subsystem initialized")
 
 	// OIDC subsystem
 	oidcStore := selectOIDCProviderStore(logger, store)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.18.0] - 2026-06-28
+
+### Added
+- Merged Network schema policy can now be persisted through `GET/PATCH /api/v1/settings/network-schema-policy`, with per-request query overrides still taking precedence over the stored default.
+- Network merged-view and conflict responses now include the active schema policy used for duplicate and hierarchy evaluation.
+
 ## [0.17.4] - 2026-06-07
 
 ### Security

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -152,7 +152,26 @@ curl -X POST http://localhost:8080/api/v1/network/relationships/resolve \
 
 ### Schema Policy
 
-Duplicate and hierarchy evidence can be evaluated with a schema policy:
+Duplicate and hierarchy evidence can be evaluated with a schema policy. If no
+query override is supplied, CloudPAM uses the persisted default from
+`/api/v1/settings/network-schema-policy`; if that setting does not exist, it
+falls back to `account_level`.
+
+Persist the default policy:
+
+```bash
+curl -X PATCH http://localhost:8080/api/v1/settings/network-schema-policy \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"global"}'
+```
+
+Read the active persisted default:
+
+```bash
+curl http://localhost:8080/api/v1/settings/network-schema-policy
+```
+
+Override the policy for one request:
 
 ```bash
 curl http://localhost:8080/api/v1/network/conflicts?schema_policy=account_level

--- a/internal/api/bootstrap_handlers_test.go
+++ b/internal/api/bootstrap_handlers_test.go
@@ -27,7 +27,11 @@ func setupDiscoveryTestServer() (*DiscoveryServer, *storage.MemoryStore, *storag
 	discSrv.RegisterDiscoveryRoutes()
 	networkSrv := NewNetworkServer(srv, st, ds, storage.NewMemoryDriftStore(st))
 	networkSrv.SetNetworkStore(storage.NewMemoryNetworkStore(st))
+	settingsStore := storage.NewMemorySettingsStore()
+	networkSrv.SetSettingsStore(settingsStore)
 	networkSrv.RegisterNetworkRoutes()
+	settingsSrv := NewSettingsServer(srv, settingsStore)
+	settingsSrv.RegisterSettingsRoutes()
 	return discSrv, st, ds, ks
 }
 

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -25,11 +25,12 @@ import (
 
 // NetworkServer handles merged network view endpoints.
 type NetworkServer struct {
-	srv          *Server
-	store        storage.Store
-	discStore    storage.DiscoveryStore
-	driftStore   storage.DriftStore
-	networkStore storage.NetworkStore
+	srv           *Server
+	store         storage.Store
+	discStore     storage.DiscoveryStore
+	driftStore    storage.DriftStore
+	networkStore  storage.NetworkStore
+	settingsStore storage.SettingsStore
 }
 
 // NewNetworkServer creates a merged network view server.
@@ -40,6 +41,11 @@ func NewNetworkServer(srv *Server, store storage.Store, discStore storage.Discov
 // SetNetworkStore attaches durable managed network object and relationship storage.
 func (ns *NetworkServer) SetNetworkStore(networkStore storage.NetworkStore) {
 	ns.networkStore = networkStore
+}
+
+// SetSettingsStore attaches persisted operator settings.
+func (ns *NetworkServer) SetSettingsStore(settingsStore storage.SettingsStore) {
+	ns.settingsStore = settingsStore
 }
 
 // RegisterNetworkRoutes registers network routes without RBAC.
@@ -89,6 +95,7 @@ func (ns *NetworkServer) handleFlat(w http.ResponseWriter, r *http.Request) {
 		Total:         len(view.flat),
 		ConflictCount: len(view.conflicts),
 		Conflicts:     view.conflicts,
+		SchemaPolicy:  view.schemaPolicy,
 	})
 }
 
@@ -108,6 +115,7 @@ func (ns *NetworkServer) handleHierarchy(w http.ResponseWriter, r *http.Request)
 		Total:         len(view.flat),
 		ConflictCount: len(view.conflicts),
 		Conflicts:     view.conflicts,
+		SchemaPolicy:  view.schemaPolicy,
 	})
 }
 
@@ -126,7 +134,7 @@ func (ns *NetworkServer) handleConflicts(w http.ResponseWriter, r *http.Request)
 		ns.srv.writeErr(r.Context(), w, http.StatusInternalServerError, "network conflicts failed", err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, domain.NetworkConflictListResponse{Items: view.conflicts, Total: len(view.conflicts)})
+	writeJSON(w, http.StatusOK, domain.NetworkConflictListResponse{Items: view.conflicts, Total: len(view.conflicts), SchemaPolicy: view.schemaPolicy})
 }
 
 func (ns *NetworkServer) handleConflictSubroutes(w http.ResponseWriter, r *http.Request) {
@@ -798,9 +806,10 @@ type networkViewFilters struct {
 }
 
 type builtNetworkView struct {
-	flat      []domain.NetworkNode
-	hierarchy []domain.NetworkNode
-	conflicts []domain.NetworkConflict
+	flat         []domain.NetworkNode
+	hierarchy    []domain.NetworkNode
+	conflicts    []domain.NetworkConflict
+	schemaPolicy domain.NetworkSchemaPolicy
 }
 
 func networkFiltersFromRequest(r *http.Request) networkViewFilters {
@@ -913,24 +922,25 @@ func (ns *NetworkServer) relationshipEndpointBelongsToAccount(ctx context.Contex
 }
 
 func schemaPolicyFromFilters(filters networkViewFilters) domain.NetworkSchemaPolicy {
-	name := filters.schemaPolicy
-	if name == "" {
-		name = "account_level"
+	policy := domain.NormalizeNetworkSchemaPolicy(&domain.NetworkSchemaPolicy{Name: filters.schemaPolicy})
+	if policy.ManualRelationships && filters.duplicates == "global" {
+		policy.DuplicateScope = "global"
 	}
-	switch name {
-	case "region_level":
-		return domain.NetworkSchemaPolicy{Name: name, OwnershipStrategy: "region", DuplicateScope: "region", HierarchyScope: "region"}
-	case "global":
-		return domain.NetworkSchemaPolicy{Name: name, OwnershipStrategy: "global", DuplicateScope: "global", HierarchyScope: "global"}
-	case "custom", "manual":
-		policy := domain.NetworkSchemaPolicy{Name: name, OwnershipStrategy: "manual", DuplicateScope: "manual", HierarchyScope: "manual", ManualRelationships: true}
-		if filters.duplicates == "global" {
-			policy.DuplicateScope = "global"
-		}
-		return policy
-	default:
-		return domain.NetworkSchemaPolicy{Name: "account_level", OwnershipStrategy: "account", DuplicateScope: "account", HierarchyScope: "account"}
+	return *policy
+}
+
+func (ns *NetworkServer) schemaPolicyForView(ctx context.Context, filters networkViewFilters) (domain.NetworkSchemaPolicy, error) {
+	if filters.schemaPolicy != "" {
+		return schemaPolicyFromFilters(filters), nil
 	}
+	if ns.settingsStore == nil {
+		return domain.DefaultNetworkSchemaPolicy(), nil
+	}
+	policy, err := ns.settingsStore.GetNetworkSchemaPolicy(ctx)
+	if err != nil {
+		return domain.NetworkSchemaPolicy{}, err
+	}
+	return *domain.NormalizeNetworkSchemaPolicy(policy), nil
 }
 
 func duplicatePolicyKey(res domain.DiscoveredResource, policy domain.NetworkSchemaPolicy) string {
@@ -1002,6 +1012,10 @@ func relationshipIDsForConflict(conflict domain.NetworkConflict) map[string]stru
 }
 
 func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkViewFilters) (builtNetworkView, error) {
+	policy, err := ns.schemaPolicyForView(ctx, filters)
+	if err != nil {
+		return builtNetworkView{}, err
+	}
 	accounts, err := ns.store.ListAccounts(ctx)
 	if err != nil {
 		return builtNetworkView{}, err
@@ -1036,7 +1050,7 @@ func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkVi
 		resourceByProvider[resourceKey(res.AccountID, res.ResourceID)] = res
 	}
 
-	issuesByNode, conflicts := ns.computeNetworkConflicts(resources, pools, accountByID, poolByID, resourceByProvider, schemaPolicyFromFilters(filters))
+	issuesByNode, conflicts := ns.computeNetworkConflicts(resources, pools, accountByID, poolByID, resourceByProvider, policy)
 	ns.persistComputedNetworkRelationships(ctx, conflicts)
 	conflicts = ns.applyStoredConflictResolutions(ctx, conflicts)
 	var relationships []domain.NetworkRelationship
@@ -1094,9 +1108,10 @@ func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkVi
 
 	filteredConflicts := filterNetworkConflicts(conflicts, filters)
 	return builtNetworkView{
-		flat:      filtered,
-		hierarchy: buildNetworkHierarchy(filtered),
-		conflicts: filteredConflicts,
+		flat:         filtered,
+		hierarchy:    buildNetworkHierarchy(filtered),
+		conflicts:    filteredConflicts,
+		schemaPolicy: policy,
 	}, nil
 }
 

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -552,6 +552,47 @@ func TestNetworkSchemaPolicyChangesDuplicateDetection(t *testing.T) {
 	}
 }
 
+func TestNetworkSchemaPolicyUsesPersistedDefaultAndQueryOverride(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	now := time.Now().UTC()
+	for _, res := range []domain.DiscoveredResource{
+		{ID: uuid.New(), AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-east", CIDR: "10.93.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
+		{ID: uuid.New(), AccountID: account.ID, Provider: "aws", Region: "us-west-2", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-west", CIDR: "10.93.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
+	} {
+		upsertDiscoveredForImportTest(t, ds, res)
+	}
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPatch, "/api/v1/settings/network-schema-policy", `{"name":"global"}`, http.StatusOK)
+	var policy domain.NetworkSchemaPolicy
+	if err := json.Unmarshal(rr.Body.Bytes(), &policy); err != nil {
+		t.Fatalf("unmarshal policy: %v", err)
+	}
+	if policy.Name != "global" || policy.DuplicateScope != "global" {
+		t.Fatalf("unexpected persisted policy: %+v", policy)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=duplicate_cidr", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal persisted-default conflicts: %v", err)
+	}
+	if conflicts.SchemaPolicy.Name != "global" || conflicts.Total != 1 {
+		t.Fatalf("persisted global policy should flag duplicate, got %+v", conflicts)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=duplicate_cidr&schema_policy=account_level", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal override conflicts: %v", err)
+	}
+	if conflicts.SchemaPolicy.Name != "account_level" || conflicts.Total != 0 {
+		t.Fatalf("query override should use account-level policy, got %+v", conflicts)
+	}
+}
+
 func TestNetworkConflictRoutesAppearInOpenAPISpec(t *testing.T) {
 	discSrv, _, _, _ := setupDiscoveryTestServer()
 

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -523,6 +523,7 @@ func openAPIComponentTypes() []openAPIComponentType {
 		{"DriftItem", reflect.TypeOf(domain.DriftItem{})},
 		{"IgnoreDriftRequest", reflect.TypeOf(domain.IgnoreDriftRequest{})},
 		{"SecuritySettings", reflect.TypeOf(domain.SecuritySettings{})},
+		{"NetworkSchemaPolicy", reflect.TypeOf(domain.NetworkSchemaPolicy{})},
 		{"LoginRequest", reflect.TypeOf(openAPILoginRequest{})},
 		{"LoginResponse", reflect.TypeOf(openAPILoginResponse{})},
 		{"MeResponse", reflect.TypeOf(openAPIMeResponse{})},
@@ -839,6 +840,8 @@ func openAPIRoutesForPattern(pattern string) []openAPIRoute {
 		})
 	case "/api/v1/settings/security":
 		return routesForMethodsPath([]string{http.MethodGet, http.MethodPatch}, "/api/v1/settings/security")
+	case "/api/v1/settings/network-schema-policy":
+		return routesForMethodsPath([]string{http.MethodGet, http.MethodPatch}, "/api/v1/settings/network-schema-policy")
 	case "/api/v1/settings/oidc/providers":
 		return routesForMethodsPath([]string{http.MethodGet, http.MethodPost}, "/api/v1/settings/oidc/providers")
 	case "/api/v1/settings/oidc/providers/{id}":
@@ -1074,6 +1077,8 @@ func openAPIOperationCatalog() map[string]openAPIRoute {
 		{Method: "POST", Path: "/api/v1/drift/{driftItemId}/ignore", Summary: "Ignore drift item", Tag: "Drift", RequestSchema: "IgnoreDriftRequest", ResponseSchema: "DriftItem"},
 		{Method: "GET", Path: "/api/v1/settings/security", Summary: "Get security settings", Tag: "Settings", ResponseSchema: "SecuritySettings"},
 		{Method: "PATCH", Path: "/api/v1/settings/security", Summary: "Update security settings", Tag: "Settings", RequestSchema: "SecuritySettings", ResponseSchema: "SecuritySettings"},
+		{Method: "GET", Path: "/api/v1/settings/network-schema-policy", Summary: "Get network schema policy", Tag: "Settings", ResponseSchema: "NetworkSchemaPolicy"},
+		{Method: "PATCH", Path: "/api/v1/settings/network-schema-policy", Summary: "Update network schema policy", Tag: "Settings", RequestSchema: "NetworkSchemaPolicy", ResponseSchema: "NetworkSchemaPolicy"},
 		{Method: "GET", Path: "/api/v1/auth/login", Summary: "Login", Tag: "Auth", Security: false, RequestSchema: "LoginRequest", ResponseSchema: "LoginResponse"},
 		{Method: "POST", Path: "/api/v1/auth/login", Summary: "Login", Tag: "Auth", Security: false, RequestSchema: "LoginRequest", ResponseSchema: "LoginResponse"},
 		{Method: "POST", Path: "/api/v1/auth/logout", Summary: "Logout", Tag: "Auth", ResponseDescription: "Session cleared"},

--- a/internal/api/settings_handlers.go
+++ b/internal/api/settings_handlers.go
@@ -31,12 +31,18 @@ func (ss *SettingsServer) RegisterProtectedSettingsRoutes(dualMW func(http.Handl
 		dualMW(adminRead(http.HandlerFunc(ss.handleGetSecuritySettings))))
 	ss.handleOpenAPIRoute("PATCH /api/v1/settings/security",
 		dualMW(adminWrite(http.HandlerFunc(ss.handleUpdateSecuritySettings))))
+	ss.handleOpenAPIRoute("GET /api/v1/settings/network-schema-policy",
+		dualMW(adminRead(http.HandlerFunc(ss.handleGetNetworkSchemaPolicy))))
+	ss.handleOpenAPIRoute("PATCH /api/v1/settings/network-schema-policy",
+		dualMW(adminWrite(http.HandlerFunc(ss.handleUpdateNetworkSchemaPolicy))))
 }
 
 // RegisterSettingsRoutes registers settings endpoints without RBAC (for tests).
 func (ss *SettingsServer) RegisterSettingsRoutes() {
 	ss.handleOpenAPIRouteFunc("GET /api/v1/settings/security", ss.handleGetSecuritySettings)
 	ss.handleOpenAPIRouteFunc("PATCH /api/v1/settings/security", ss.handleUpdateSecuritySettings)
+	ss.handleOpenAPIRouteFunc("GET /api/v1/settings/network-schema-policy", ss.handleGetNetworkSchemaPolicy)
+	ss.handleOpenAPIRouteFunc("PATCH /api/v1/settings/network-schema-policy", ss.handleUpdateNetworkSchemaPolicy)
 }
 
 func (ss *SettingsServer) handleGetSecuritySettings(w http.ResponseWriter, r *http.Request) {
@@ -116,6 +122,36 @@ func (ss *SettingsServer) handleUpdateSecuritySettings(w http.ResponseWriter, r 
 
 	ss.logAudit(r.Context(), "update", "settings", "security", "security_settings", http.StatusOK)
 	writeJSON(w, http.StatusOK, input)
+}
+
+func (ss *SettingsServer) handleGetNetworkSchemaPolicy(w http.ResponseWriter, r *http.Request) {
+	policy, err := ss.settingsStore.GetNetworkSchemaPolicy(r.Context())
+	if err != nil {
+		ss.writeErr(r.Context(), w, http.StatusInternalServerError, "failed to load network schema policy", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, policy)
+}
+
+func (ss *SettingsServer) handleUpdateNetworkSchemaPolicy(w http.ResponseWriter, r *http.Request) {
+	var input domain.NetworkSchemaPolicy
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		ss.writeErr(r.Context(), w, http.StatusBadRequest, "invalid request body", err.Error())
+		return
+	}
+	if denied := domain.ValidateNetworkSchemaPolicy(&input); denied != "" {
+		ss.writeErr(r.Context(), w, http.StatusBadRequest, "invalid network schema policy", denied)
+		return
+	}
+
+	policy := domain.NormalizeNetworkSchemaPolicy(&input)
+	if err := ss.settingsStore.UpdateNetworkSchemaPolicy(r.Context(), policy); err != nil {
+		ss.writeErr(r.Context(), w, http.StatusInternalServerError, "failed to save network schema policy", err.Error())
+		return
+	}
+
+	ss.logAudit(r.Context(), "update", "settings", "network_schema_policy", "network_schema_policy", http.StatusOK)
+	writeJSON(w, http.StatusOK, policy)
 }
 
 func validateAPIKeyScopePolicy(policy map[string][]string) string {

--- a/internal/api/settings_handlers_test.go
+++ b/internal/api/settings_handlers_test.go
@@ -147,6 +147,83 @@ func TestSettingsHandler_UpdateValid(t *testing.T) {
 	}
 }
 
+func TestSettingsHandler_GetDefaultNetworkSchemaPolicy(t *testing.T) {
+	mux := setupSettingsServer()
+
+	req := httptest.NewRequest(stdhttp.MethodGet, "/api/v1/settings/network-schema-policy", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != stdhttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var policy domain.NetworkSchemaPolicy
+	if err := json.NewDecoder(rr.Body).Decode(&policy); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if policy != domain.DefaultNetworkSchemaPolicy() {
+		t.Fatalf("default policy mismatch: got %+v want %+v", policy, domain.DefaultNetworkSchemaPolicy())
+	}
+}
+
+func TestSettingsHandler_UpdateNetworkSchemaPolicy(t *testing.T) {
+	mux := setupSettingsServer()
+
+	body := `{"name":"manual","duplicate_scope":"global"}`
+	req := httptest.NewRequest(stdhttp.MethodPatch, "/api/v1/settings/network-schema-policy", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != stdhttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var policy domain.NetworkSchemaPolicy
+	if err := json.NewDecoder(rr.Body).Decode(&policy); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if policy.Name != "manual" || policy.OwnershipStrategy != "manual" || policy.DuplicateScope != "global" || policy.HierarchyScope != "manual" || !policy.ManualRelationships {
+		t.Fatalf("unexpected policy: %+v", policy)
+	}
+
+	getReq := httptest.NewRequest(stdhttp.MethodGet, "/api/v1/settings/network-schema-policy", nil)
+	getRR := httptest.NewRecorder()
+	mux.ServeHTTP(getRR, getReq)
+	if err := json.NewDecoder(getRR.Body).Decode(&policy); err != nil {
+		t.Fatalf("decode stored policy: %v", err)
+	}
+	if policy.DuplicateScope != "global" {
+		t.Fatalf("stored policy duplicate scope = %q, want global", policy.DuplicateScope)
+	}
+}
+
+func TestSettingsHandler_UpdateNetworkSchemaPolicyRejectsInvalid(t *testing.T) {
+	mux := setupSettingsServer()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "unknown name", body: `{"name":"workspace"}`},
+		{name: "mismatched duplicate scope", body: `{"name":"region_level","duplicate_scope":"global"}`},
+		{name: "bad manual duplicate scope", body: `{"name":"manual","duplicate_scope":"region"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(stdhttp.MethodPatch, "/api/v1/settings/network-schema-policy", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+			if rr.Code != stdhttp.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
 func TestSettingsHandler_UpdateInvalidBounds(t *testing.T) {
 	mux := setupSettingsServer()
 

--- a/internal/domain/network.go
+++ b/internal/domain/network.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -169,6 +170,74 @@ type NetworkSchemaPolicy struct {
 	ManualRelationships bool   `json:"manual_relationships,omitempty"`
 }
 
+// DefaultNetworkSchemaPolicy returns the conservative merged-network policy.
+func DefaultNetworkSchemaPolicy() NetworkSchemaPolicy {
+	return NetworkSchemaPolicy{Name: "account_level", OwnershipStrategy: "account", DuplicateScope: "account", HierarchyScope: "account"}
+}
+
+// NormalizeNetworkSchemaPolicy fills derived policy fields and falls back to
+// the conservative account-level policy when the name is empty or unknown.
+func NormalizeNetworkSchemaPolicy(policy *NetworkSchemaPolicy) *NetworkSchemaPolicy {
+	if policy == nil {
+		defaults := DefaultNetworkSchemaPolicy()
+		return &defaults
+	}
+	name := strings.ToLower(strings.TrimSpace(policy.Name))
+	switch name {
+	case "region_level":
+		normalized := NetworkSchemaPolicy{Name: name, OwnershipStrategy: "region", DuplicateScope: "region", HierarchyScope: "region"}
+		return &normalized
+	case "global":
+		normalized := NetworkSchemaPolicy{Name: name, OwnershipStrategy: "global", DuplicateScope: "global", HierarchyScope: "global"}
+		return &normalized
+	case "custom", "manual":
+		normalized := NetworkSchemaPolicy{Name: name, OwnershipStrategy: "manual", DuplicateScope: "manual", HierarchyScope: "manual", ManualRelationships: true}
+		if strings.ToLower(strings.TrimSpace(policy.DuplicateScope)) == "global" {
+			normalized.DuplicateScope = "global"
+		}
+		return &normalized
+	default:
+		defaults := DefaultNetworkSchemaPolicy()
+		return &defaults
+	}
+}
+
+// ValidateNetworkSchemaPolicy returns a user-facing validation error, or an
+// empty string when the policy can be persisted.
+func ValidateNetworkSchemaPolicy(policy *NetworkSchemaPolicy) string {
+	if policy == nil {
+		return "policy is required"
+	}
+	name := strings.ToLower(strings.TrimSpace(policy.Name))
+	switch name {
+	case "account_level", "region_level", "global":
+		normalized := NormalizeNetworkSchemaPolicy(policy)
+		if policy.OwnershipStrategy != "" && strings.ToLower(strings.TrimSpace(policy.OwnershipStrategy)) != normalized.OwnershipStrategy {
+			return "ownership_strategy does not match schema policy"
+		}
+		if policy.DuplicateScope != "" && strings.ToLower(strings.TrimSpace(policy.DuplicateScope)) != normalized.DuplicateScope {
+			return "duplicate_scope does not match schema policy"
+		}
+		if policy.HierarchyScope != "" && strings.ToLower(strings.TrimSpace(policy.HierarchyScope)) != normalized.HierarchyScope {
+			return "hierarchy_scope does not match schema policy"
+		}
+	case "custom", "manual":
+		if policy.OwnershipStrategy != "" && strings.ToLower(strings.TrimSpace(policy.OwnershipStrategy)) != "manual" {
+			return "ownership_strategy does not match schema policy"
+		}
+		duplicateScope := strings.ToLower(strings.TrimSpace(policy.DuplicateScope))
+		if duplicateScope != "" && duplicateScope != "manual" && duplicateScope != "global" {
+			return "duplicate_scope for manual policy must be manual or global"
+		}
+		if policy.HierarchyScope != "" && strings.ToLower(strings.TrimSpace(policy.HierarchyScope)) != "manual" {
+			return "hierarchy_scope does not match schema policy"
+		}
+	default:
+		return "schema policy must be account_level, region_level, global, manual, or custom"
+	}
+	return ""
+}
+
 // NetworkIssue describes an actionable issue attached to a merged network row
 // or hierarchy node.
 type NetworkIssue struct {
@@ -230,16 +299,18 @@ type NetworkConflict struct {
 
 // NetworkViewResponse returns the flat or hierarchical merged network view.
 type NetworkViewResponse struct {
-	Items         []NetworkNode     `json:"items"`
-	Total         int               `json:"total"`
-	ConflictCount int               `json:"conflict_count"`
-	Conflicts     []NetworkConflict `json:"conflicts,omitempty"`
+	Items         []NetworkNode       `json:"items"`
+	Total         int                 `json:"total"`
+	ConflictCount int                 `json:"conflict_count"`
+	Conflicts     []NetworkConflict   `json:"conflicts,omitempty"`
+	SchemaPolicy  NetworkSchemaPolicy `json:"schema_policy"`
 }
 
 // NetworkConflictListResponse returns computed network conflicts.
 type NetworkConflictListResponse struct {
-	Items []NetworkConflict `json:"items"`
-	Total int               `json:"total"`
+	Items        []NetworkConflict   `json:"items"`
+	Total        int                 `json:"total"`
+	SchemaPolicy NetworkSchemaPolicy `json:"schema_policy"`
 }
 
 // ResolveNetworkConflictRequest asks the API to resolve or mark a computed

--- a/internal/storage/postgres/settings.go
+++ b/internal/storage/postgres/settings.go
@@ -47,3 +47,40 @@ func (s *Store) UpdateSecuritySettings(ctx context.Context, settings *domain.Sec
 	)
 	return err
 }
+
+// GetNetworkSchemaPolicy retrieves the persisted merged-network schema policy.
+func (s *Store) GetNetworkSchemaPolicy(ctx context.Context) (*domain.NetworkSchemaPolicy, error) {
+	var raw string
+	err := s.pool.QueryRow(ctx, `SELECT value FROM settings WHERE key = 'network_schema_policy'`).Scan(&raw)
+	if err == pgx.ErrNoRows {
+		defaults := domain.DefaultNetworkSchemaPolicy()
+		return &defaults, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var policy domain.NetworkSchemaPolicy
+	if err := json.Unmarshal([]byte(raw), &policy); err != nil {
+		return nil, err
+	}
+	return domain.NormalizeNetworkSchemaPolicy(&policy), nil
+}
+
+// UpdateNetworkSchemaPolicy saves the merged-network schema policy.
+func (s *Store) UpdateNetworkSchemaPolicy(ctx context.Context, policy *domain.NetworkSchemaPolicy) error {
+	policy = domain.NormalizeNetworkSchemaPolicy(policy)
+	raw, err := json.Marshal(policy)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.pool.Exec(ctx,
+		`INSERT INTO settings (key, value, updated_at)
+		 VALUES ('network_schema_policy', $1, NOW())
+		 ON CONFLICT (key) DO UPDATE
+		 SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at`,
+		string(raw),
+	)
+	return err
+}

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -10,4 +10,6 @@ import (
 type SettingsStore interface {
 	GetSecuritySettings(ctx context.Context) (*domain.SecuritySettings, error)
 	UpdateSecuritySettings(ctx context.Context, settings *domain.SecuritySettings) error
+	GetNetworkSchemaPolicy(ctx context.Context) (*domain.NetworkSchemaPolicy, error)
+	UpdateNetworkSchemaPolicy(ctx context.Context, policy *domain.NetworkSchemaPolicy) error
 }

--- a/internal/storage/settings_memory.go
+++ b/internal/storage/settings_memory.go
@@ -9,14 +9,16 @@ import (
 
 // MemorySettingsStore is an in-memory implementation of SettingsStore.
 type MemorySettingsStore struct {
-	mu       sync.RWMutex
-	security *domain.SecuritySettings
+	mu                  sync.RWMutex
+	security            *domain.SecuritySettings
+	networkSchemaPolicy *domain.NetworkSchemaPolicy
 }
 
 // NewMemorySettingsStore creates a new in-memory settings store with defaults.
 func NewMemorySettingsStore() *MemorySettingsStore {
 	defaults := domain.DefaultSecuritySettings()
-	return &MemorySettingsStore{security: &defaults}
+	policy := domain.DefaultNetworkSchemaPolicy()
+	return &MemorySettingsStore{security: &defaults, networkSchemaPolicy: &policy}
 }
 
 func (s *MemorySettingsStore) GetSecuritySettings(_ context.Context) (*domain.SecuritySettings, error) {
@@ -30,5 +32,19 @@ func (s *MemorySettingsStore) UpdateSecuritySettings(_ context.Context, settings
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.security = domain.NormalizeSecuritySettings(settings)
+	return nil
+}
+
+func (s *MemorySettingsStore) GetNetworkSchemaPolicy(_ context.Context) (*domain.NetworkSchemaPolicy, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	copy := *s.networkSchemaPolicy
+	return domain.NormalizeNetworkSchemaPolicy(&copy), nil
+}
+
+func (s *MemorySettingsStore) UpdateNetworkSchemaPolicy(_ context.Context, policy *domain.NetworkSchemaPolicy) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.networkSchemaPolicy = domain.NormalizeNetworkSchemaPolicy(policy)
 	return nil
 }

--- a/internal/storage/sqlite/settings.go
+++ b/internal/storage/sqlite/settings.go
@@ -41,3 +41,35 @@ func (s *Store) UpdateSecuritySettings(ctx context.Context, settings *domain.Sec
 		string(raw))
 	return err
 }
+
+// GetNetworkSchemaPolicy retrieves the persisted merged-network schema policy.
+func (s *Store) GetNetworkSchemaPolicy(ctx context.Context) (*domain.NetworkSchemaPolicy, error) {
+	var raw string
+	err := s.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = 'network_schema_policy'`).Scan(&raw)
+	if err == sql.ErrNoRows {
+		defaults := domain.DefaultNetworkSchemaPolicy()
+		return &defaults, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var policy domain.NetworkSchemaPolicy
+	if err := json.Unmarshal([]byte(raw), &policy); err != nil {
+		return nil, err
+	}
+	return domain.NormalizeNetworkSchemaPolicy(&policy), nil
+}
+
+// UpdateNetworkSchemaPolicy saves the merged-network schema policy.
+func (s *Store) UpdateNetworkSchemaPolicy(ctx context.Context, policy *domain.NetworkSchemaPolicy) error {
+	policy = domain.NormalizeNetworkSchemaPolicy(policy)
+	raw, err := json.Marshal(policy)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO settings (key, value, updated_at) VALUES ('network_schema_policy', ?, datetime('now'))
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		string(raw))
+	return err
+}

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -578,16 +578,26 @@ export interface NetworkConflict {
   resolution_requested?: string
 }
 
+export interface NetworkSchemaPolicy {
+  name: string
+  ownership_strategy: string
+  duplicate_scope: string
+  hierarchy_scope: string
+  manual_relationships?: boolean
+}
+
 export interface NetworkViewResponse {
   items: NetworkNode[]
   total: number
   conflict_count: number
   conflicts?: NetworkConflict[]
+  schema_policy: NetworkSchemaPolicy
 }
 
 export interface NetworkConflictListResponse {
   items: NetworkConflict[]
   total: number
+  schema_policy: NetworkSchemaPolicy
 }
 
 export interface NetworkConflictLinkActionRequest {


### PR DESCRIPTION
## Summary

Closes #204.

This adds a persisted Merged Network schema policy setting so operators no longer need to pass `schema_policy` query parameters on every merged network or conflict request.

## What changed

- Added `GET /api/v1/settings/network-schema-policy` and `PATCH /api/v1/settings/network-schema-policy`.
- Reused existing `settings:read` and `settings:write` RBAC for the new settings endpoint.
- Extended the existing settings storage path with `network_schema_policy` support for:
  - in-memory settings
  - SQLite-backed settings
  - PostgreSQL-backed settings
- Wired the selected settings store into `NetworkServer`.
- Updated merged network policy precedence:
  1. request query override, such as `?schema_policy=global`
  2. persisted network schema policy setting
  3. conservative `account_level` fallback
- Added `schema_policy` to merged network and conflict list responses so clients can see the effective policy used for evaluation.
- Added policy normalization and validation helpers for `account_level`, `region_level`, `global`, `manual`, and `custom`.
- Updated generated OpenAPI route/schema registration.
- Updated TypeScript API response types.
- Documented persisted policy configuration and request-scoped overrides in `docs/DISCOVERY.md`.
- Added `docs/CHANGELOG.md` entry for `0.18.0`.

## Behavior notes

- Existing request-scoped query behavior still works and takes precedence over the stored default.
- Missing persisted settings fall back to `account_level`.
- Invalid persisted policy updates are rejected with `400`.
- `manual` policy still suppresses duplicate conflicts by default.
- `manual` with `duplicate_scope: "global"` is supported for persisted settings, matching the existing request override behavior.

## Testing

Ran through the Nix dev shell:

```bash
nix develop -c go test ./internal/api -run 'TestNetworkSchemaPolicy|TestSettingsHandler'
nix develop -c go test ./internal/domain ./internal/storage
nix develop -c go test ./internal/api -run TestOpenAPI
nix develop -c go test ./...
nix develop -c go test -tags sqlite ./cmd/cloudpam ./internal/storage/sqlite
nix develop -c npm --prefix ui run build
```

Also ran:

```bash
nix develop -c go test -tags postgres ./cmd/cloudpam ./internal/storage/postgres
```

`cmd/cloudpam` passed under the Postgres tag, but `internal/storage/postgres` requires `DATABASE_URL` and did not run in this environment.

## Review notes

- Pipeline handoffs were written under `.pipeline/` locally:
  - `.pipeline/spec.md`
  - `.pipeline/changes.md`
  - `.pipeline/tests.md`
  - `.pipeline/review.md`
- Reviewer verdict: `approve`.
