### PR TITLE
Updates: harden completed upgrade status lifecycle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.18.1] - 2026-06-28
+
+### Fixed
+- Upgrade status now includes a stable `upgrade_id` and completed upgrades can be acknowledged through `POST /api/v1/updates/status/ack`, preventing `/api/v1/updates/status` from returning the same completed state indefinitely.
+- Completed upgrade status now expires back to an idle active state after a short backend TTL if no client acknowledges it.
+
 ## [0.18.0] - 2026-06-28
 
 ### Added

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -240,13 +240,26 @@ type openAPIUpdateCheckResponse struct {
 
 type openAPIUpgradeRequestResponse struct {
 	Status        string `json:"status"`
+	UpgradeID     string `json:"upgrade_id"`
 	TargetVersion string `json:"target_version"`
 	Message       string `json:"message"`
 }
 
 type openAPIUpgradeStatusResponse struct {
-	Status    string `json:"status"`
-	Supported bool   `json:"supported"`
+	Status                 string         `json:"status"`
+	Supported              bool           `json:"supported"`
+	UpgradeID              string         `json:"upgrade_id,omitempty"`
+	Acknowledged           bool           `json:"acknowledged,omitempty"`
+	CompletedStatusExpired bool           `json:"completed_status_expired,omitempty"`
+	LastUpgrade            map[string]any `json:"last_upgrade,omitempty"`
+}
+
+type openAPIUpgradeStatusAckResponse struct {
+	Status       string         `json:"status"`
+	Supported    bool           `json:"supported"`
+	UpgradeID    string         `json:"upgrade_id,omitempty"`
+	Acknowledged bool           `json:"acknowledged,omitempty"`
+	LastUpgrade  map[string]any `json:"last_upgrade,omitempty"`
 }
 
 type openAPISystemInfoResponse struct {
@@ -558,6 +571,7 @@ func openAPIComponentTypes() []openAPIComponentType {
 		{"UpdateCheckResponse", reflect.TypeOf(openAPIUpdateCheckResponse{})},
 		{"UpgradeRequestResponse", reflect.TypeOf(openAPIUpgradeRequestResponse{})},
 		{"UpgradeStatusResponse", reflect.TypeOf(openAPIUpgradeStatusResponse{})},
+		{"UpgradeStatusAckResponse", reflect.TypeOf(openAPIUpgradeStatusAckResponse{})},
 	}
 	sort.Slice(types, func(i, j int) bool { return types[i].name < types[j].name })
 	return types
@@ -909,6 +923,8 @@ func openAPIRoutesForPattern(pattern string) []openAPIRoute {
 		return routesForMethodPath(http.MethodPost, "/api/v1/updates/upgrade")
 	case "/api/v1/updates/status":
 		return routesForMethodPath(http.MethodGet, "/api/v1/updates/status")
+	case "/api/v1/updates/status/ack":
+		return routesForMethodPath(http.MethodPost, "/api/v1/updates/status/ack")
 	default:
 		if strings.HasPrefix(pattern, "GET ") || strings.HasPrefix(pattern, "POST ") ||
 			strings.HasPrefix(pattern, "PATCH ") || strings.HasPrefix(pattern, "DELETE ") {
@@ -1120,6 +1136,7 @@ func openAPIOperationCatalog() map[string]openAPIRoute {
 		{Method: "GET", Path: "/api/v1/updates", Summary: "Check for updates", Tag: "Updates", ResponseSchema: "UpdateCheckResponse", Parameters: []openAPIParameter{queryParam("force", "Force refresh release metadata", "boolean")}},
 		{Method: "POST", Path: "/api/v1/updates/upgrade", Summary: "Request in-app upgrade", Tag: "Updates", SuccessStatus: "202", ResponseSchema: "UpgradeRequestResponse"},
 		{Method: "GET", Path: "/api/v1/updates/status", Summary: "Get upgrade status", Tag: "Updates", ResponseSchema: "UpgradeStatusResponse"},
+		{Method: "POST", Path: "/api/v1/updates/status/ack", Summary: "Acknowledge completed upgrade status", Tag: "Updates", ResponseSchema: "UpgradeStatusAckResponse"},
 	}
 	catalog := make(map[string]openAPIRoute, len(routes))
 	for _, route := range routes {

--- a/internal/api/update_handlers.go
+++ b/internal/api/update_handlers.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -16,10 +19,14 @@ import (
 )
 
 const (
-	updateCacheTTL       = time.Hour
-	defaultControlDir    = "/var/lib/cloudpam-control"
-	defaultCloudPAMRepo  = "BadgerOps/cloudpam"
-	defaultGitHubAPIRoot = "https://api.github.com"
+	updateCacheTTL            = time.Hour
+	completedUpgradeStatusTTL = 10 * time.Minute
+	defaultControlDir         = "/var/lib/cloudpam-control"
+	defaultCloudPAMRepo       = "BadgerOps/cloudpam"
+	defaultGitHubAPIRoot      = "https://api.github.com"
+	upgradeStatusFile         = "upgrade-status.json"
+	upgradeAckFile            = "upgrade-status-ack.json"
+	upgradeRequestedFile      = "upgrade-requested"
 )
 
 type updateRelease struct {
@@ -77,12 +84,15 @@ func (us *UpdateServer) RegisterProtectedUpdateRoutes(dualMW func(http.Handler) 
 		dualMW(adminWrite(http.HandlerFunc(us.handleTriggerUpgrade))))
 	us.handleOpenAPIRoute("GET /api/v1/updates/status",
 		dualMW(adminRead(http.HandlerFunc(us.handleGetUpgradeStatus))))
+	us.handleOpenAPIRoute("POST /api/v1/updates/status/ack",
+		dualMW(adminWrite(http.HandlerFunc(us.handleAcknowledgeUpgradeStatus))))
 }
 
 func (us *UpdateServer) RegisterUpdateRoutesNoAuth() {
 	us.handleOpenAPIRouteFunc("GET /api/v1/updates", us.handleCheckUpdates)
 	us.handleOpenAPIRouteFunc("POST /api/v1/updates/upgrade", us.handleTriggerUpgrade)
 	us.handleOpenAPIRouteFunc("GET /api/v1/updates/status", us.handleGetUpgradeStatus)
+	us.handleOpenAPIRouteFunc("POST /api/v1/updates/status/ack", us.handleAcknowledgeUpgradeStatus)
 }
 
 func (us *UpdateServer) handleCheckUpdates(w http.ResponseWriter, r *http.Request) {
@@ -132,7 +142,7 @@ func (us *UpdateServer) handleTriggerUpgrade(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	statusPath := filepath.Join(controlDir, "upgrade-status.json")
+	statusPath := filepath.Join(controlDir, upgradeStatusFile)
 	if status, err := readJSONFile(statusPath); err == nil {
 		if state, _ := status["status"].(string); state == "running" {
 			us.writeErr(r.Context(), w, http.StatusConflict, "upgrade already in progress", "")
@@ -152,8 +162,11 @@ func (us *UpdateServer) handleTriggerUpgrade(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	now := time.Now().UTC()
+	upgradeID := newUpgradeID(now)
 	request := map[string]any{
-		"requested_at":       time.Now().UTC().Format(time.RFC3339),
+		"upgrade_id":         upgradeID,
+		"requested_at":       now.Format(time.RFC3339),
 		"current_version":    cleanVersion(currentAppVersion()),
 		"target_version":     cleanVersion(latest.TagName),
 		"target_release_tag": latest.TagName,
@@ -169,7 +182,7 @@ func (us *UpdateServer) handleTriggerUpgrade(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	requestPath := filepath.Join(controlDir, "upgrade-requested")
+	requestPath := filepath.Join(controlDir, upgradeRequestedFile)
 	f, err := os.Create(requestPath)
 	if err != nil {
 		us.writeErr(r.Context(), w, http.StatusInternalServerError, "failed to write upgrade request", err.Error())
@@ -193,6 +206,7 @@ func (us *UpdateServer) handleTriggerUpgrade(w http.ResponseWriter, r *http.Requ
 	us.logAudit(r.Context(), "update", "system", cleanVersion(latest.TagName), "cloudpam_upgrade", http.StatusAccepted)
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"status":         "upgrade_requested",
+		"upgrade_id":     upgradeID,
 		"target_version": cleanVersion(latest.TagName),
 		"message":        "Upgrade request submitted",
 	})
@@ -208,7 +222,7 @@ func (us *UpdateServer) handleGetUpgradeStatus(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	statusPath := filepath.Join(controlDir, "upgrade-status.json")
+	statusPath := filepath.Join(controlDir, upgradeStatusFile)
 	status, err := readJSONFile(statusPath)
 	if errors.Is(err, os.ErrNotExist) {
 		writeJSON(w, http.StatusOK, map[string]any{
@@ -221,8 +235,91 @@ func (us *UpdateServer) handleGetUpgradeStatus(w http.ResponseWriter, r *http.Re
 		us.writeErr(r.Context(), w, http.StatusInternalServerError, "failed to read upgrade status", err.Error())
 		return
 	}
+	info, _ := os.Stat(statusPath)
+	ensureUpgradeID(status)
+	if idle, ok := us.completedUpgradeIdleResponse(controlDir, status, info); ok {
+		writeJSON(w, http.StatusOK, idle)
+		return
+	}
 	status["supported"] = true
 	writeJSON(w, http.StatusOK, status)
+}
+
+func (us *UpdateServer) handleAcknowledgeUpgradeStatus(w http.ResponseWriter, r *http.Request) {
+	controlDir := strings.TrimSpace(us.controlDir)
+	if controlDir == "" {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":    "unsupported",
+			"supported": false,
+		})
+		return
+	}
+
+	statusPath := filepath.Join(controlDir, upgradeStatusFile)
+	status, err := readJSONFile(statusPath)
+	if errors.Is(err, os.ErrNotExist) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":    "idle",
+			"supported": true,
+		})
+		return
+	}
+	if err != nil {
+		us.writeErr(r.Context(), w, http.StatusInternalServerError, "failed to read upgrade status", err.Error())
+		return
+	}
+	if normalizeUpgradeStatus(status["status"]) != "completed" {
+		us.writeErr(r.Context(), w, http.StatusConflict, "upgrade is not completed", "")
+		return
+	}
+
+	upgradeID := ensureUpgradeID(status)
+	ack := map[string]any{
+		"upgrade_id":      upgradeID,
+		"acknowledged_at": time.Now().UTC().Format(time.RFC3339),
+	}
+	if target, ok := status["target_version"].(string); ok && strings.TrimSpace(target) != "" {
+		ack["target_version"] = target
+	}
+	if err := writeJSONFile(filepath.Join(controlDir, upgradeAckFile), ack); err != nil {
+		us.writeErr(r.Context(), w, http.StatusInternalServerError, "failed to acknowledge upgrade status", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":       "idle",
+		"supported":    true,
+		"upgrade_id":   upgradeID,
+		"acknowledged": true,
+		"last_upgrade": status,
+	})
+}
+
+func (us *UpdateServer) completedUpgradeIdleResponse(controlDir string, status map[string]any, info os.FileInfo) (map[string]any, bool) {
+	if normalizeUpgradeStatus(status["status"]) != "completed" {
+		return nil, false
+	}
+	upgradeID := ensureUpgradeID(status)
+	if ackedUpgradeStatus(controlDir, upgradeID) {
+		return map[string]any{
+			"status":       "idle",
+			"supported":    true,
+			"upgrade_id":   upgradeID,
+			"acknowledged": true,
+			"last_upgrade": status,
+		}, true
+	}
+	completedAt := completedUpgradeTime(status, info)
+	if !completedAt.IsZero() && time.Since(completedAt) > completedUpgradeStatusTTL {
+		return map[string]any{
+			"status":                   "idle",
+			"supported":                true,
+			"upgrade_id":               upgradeID,
+			"completed_status_expired": true,
+			"last_upgrade":             status,
+		}, true
+	}
+	return nil, false
 }
 
 func (us *UpdateServer) loadReleases(force bool) ([]updateRelease, bool, error) {
@@ -357,6 +454,101 @@ func readJSONFile(path string) (map[string]any, error) {
 		return nil, closeErr
 	}
 	return data, nil
+}
+
+func writeJSONFile(path string, data map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(data); err != nil {
+		if closeErr := f.Close(); closeErr != nil {
+			return errors.Join(err, closeErr)
+		}
+		return err
+	}
+	return f.Close()
+}
+
+func newUpgradeID(t time.Time) string {
+	return "upg_" + t.UTC().Format("20060102T150405.000000000Z")
+}
+
+func ensureUpgradeID(status map[string]any) string {
+	if id, ok := status["upgrade_id"].(string); ok && strings.TrimSpace(id) != "" {
+		return strings.TrimSpace(id)
+	}
+	id := derivedUpgradeID(status)
+	status["upgrade_id"] = id
+	return id
+}
+
+func derivedUpgradeID(status map[string]any) string {
+	fields := []string{
+		stringValue(status["current_version"]),
+		stringValue(status["target_version"]),
+		stringValue(status["target_image_tag"]),
+		stringValue(status["requested_at"]),
+		stringValue(status["started_at"]),
+		stringValue(status["release_url"]),
+	}
+	sum := sha1.Sum([]byte(strings.Join(fields, "|")))
+	return "upg_" + hex.EncodeToString(sum[:])[:16]
+}
+
+func ackedUpgradeStatus(controlDir string, upgradeID string) bool {
+	ack, err := readJSONFile(filepath.Join(controlDir, upgradeAckFile))
+	if err != nil {
+		return false
+	}
+	ackID, _ := ack["upgrade_id"].(string)
+	return strings.TrimSpace(ackID) == upgradeID
+}
+
+func completedUpgradeTime(status map[string]any, info os.FileInfo) time.Time {
+	for _, key := range []string{"finished_at", "completed_at", "updated_at"} {
+		if parsed, ok := parseStatusTime(status[key]); ok {
+			return parsed
+		}
+	}
+	if info != nil {
+		return info.ModTime()
+	}
+	return time.Time{}
+}
+
+func parseStatusTime(value any) (time.Time, bool) {
+	text := stringValue(value)
+	if text == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		parsed, err := time.Parse(layout, text)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func normalizeUpgradeStatus(value any) string {
+	return strings.ToLower(strings.TrimSpace(stringValue(value)))
+}
+
+func stringValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case fmt.Stringer:
+		return strings.TrimSpace(v.String())
+	default:
+		return ""
+	}
 }
 
 func getenvDefault(key, def string) string {

--- a/internal/api/update_handlers.go
+++ b/internal/api/update_handlers.go
@@ -490,11 +490,14 @@ func ensureUpgradeID(status map[string]any) string {
 
 func derivedUpgradeID(status map[string]any) string {
 	fields := []string{
+		stringValue(status["status"]),
+		stringValue(status["message"]),
 		stringValue(status["current_version"]),
 		stringValue(status["target_version"]),
 		stringValue(status["target_image_tag"]),
 		stringValue(status["requested_at"]),
 		stringValue(status["started_at"]),
+		stringValue(status["updated_at"]),
 		stringValue(status["release_url"]),
 	}
 	sum := sha1.Sum([]byte(strings.Join(fields, "|")))

--- a/internal/api/update_handlers_test.go
+++ b/internal/api/update_handlers_test.go
@@ -257,6 +257,25 @@ func TestUpdateServerCompletedStatusExpiresToIdle(t *testing.T) {
 	}
 }
 
+func TestDerivedUpgradeIDUsesLegacyStatusFields(t *testing.T) {
+	first := map[string]any{
+		"status":     "completed",
+		"message":    "Upgrade completed to v0.9.0",
+		"step":       float64(4),
+		"updated_at": "2026-06-28T22:00:00Z",
+	}
+	second := map[string]any{
+		"status":     "completed",
+		"message":    "Upgrade completed to v0.9.1",
+		"step":       float64(4),
+		"updated_at": "2026-06-28T22:10:00Z",
+	}
+
+	if got, wantDifferentFrom := derivedUpgradeID(first), derivedUpgradeID(second); got == wantDifferentFrom {
+		t.Fatalf("expected legacy completed statuses to derive distinct upgrade IDs, got %q", got)
+	}
+}
+
 func TestUpdateServerAcknowledgeRequiresCompletedStatus(t *testing.T) {
 	updateSrv := newTestUpdateServer(t, nil)
 	statusPath := filepath.Join(updateSrv.controlDir, upgradeStatusFile)

--- a/internal/api/update_handlers_test.go
+++ b/internal/api/update_handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"cloudpam/internal/storage"
 )
@@ -115,6 +116,9 @@ func TestUpdateServerTriggerUpgrade(t *testing.T) {
 	if err := json.Unmarshal(raw, &reqFile); err != nil {
 		t.Fatalf("decode upgrade request: %v", err)
 	}
+	if got, ok := reqFile["upgrade_id"].(string); !ok || got == "" {
+		t.Fatalf("expected upgrade_id in request file, got %v", reqFile["upgrade_id"])
+	}
 	if got := reqFile["target_version"]; got != "0.9.0" {
 		t.Fatalf("expected target_version=0.9.0, got %v", got)
 	}
@@ -123,6 +127,14 @@ func TestUpdateServerTriggerUpgrade(t *testing.T) {
 	}
 	if got := reqFile["target_release_tag"]; got != "v0.9.0" {
 		t.Fatalf("expected target_release_tag=v0.9.0, got %v", got)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode trigger response: %v", err)
+	}
+	if got, ok := resp["upgrade_id"].(string); !ok || got == "" || got != reqFile["upgrade_id"] {
+		t.Fatalf("expected matching response upgrade_id, got %v request=%v", got, reqFile["upgrade_id"])
 	}
 }
 
@@ -156,6 +168,107 @@ func TestUpdateServerGetStatus(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), `"status":"running"`) {
 		t.Fatalf("expected running status, got %s", rr.Body.String())
+	}
+
+	if err := os.WriteFile(statusPath, []byte(`{"status":"completed","target_version":"0.9.0","finished_at":"`+time.Now().UTC().Format(time.RFC3339)+`"}`), 0o644); err != nil {
+		t.Fatalf("write completed status file: %v", err)
+	}
+	rr = httptest.NewRecorder()
+	updateSrv.handleGetUpgradeStatus(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var completedResp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &completedResp); err != nil {
+		t.Fatalf("decode completed response: %v", err)
+	}
+	if completedResp["status"] != "completed" {
+		t.Fatalf("expected completed status, got %+v", completedResp)
+	}
+	if got, ok := completedResp["upgrade_id"].(string); !ok || got == "" {
+		t.Fatalf("expected derived upgrade_id, got %+v", completedResp)
+	}
+}
+
+func TestUpdateServerAcknowledgeCompletedStatus(t *testing.T) {
+	updateSrv := newTestUpdateServer(t, nil)
+	statusPath := filepath.Join(updateSrv.controlDir, upgradeStatusFile)
+	if err := os.WriteFile(statusPath, []byte(`{"status":"completed","upgrade_id":"upg-test","target_version":"0.9.0","finished_at":"`+time.Now().UTC().Format(time.RFC3339)+`"}`), 0o644); err != nil {
+		t.Fatalf("write completed status file: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/updates/status/ack", nil)
+	rr := httptest.NewRecorder()
+	updateSrv.handleAcknowledgeUpgradeStatus(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var ackResp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &ackResp); err != nil {
+		t.Fatalf("decode ack response: %v", err)
+	}
+	if ackResp["status"] != "idle" || ackResp["acknowledged"] != true || ackResp["upgrade_id"] != "upg-test" {
+		t.Fatalf("unexpected ack response: %+v", ackResp)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/updates/status", nil)
+	rr = httptest.NewRecorder()
+	updateSrv.handleGetUpgradeStatus(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var statusResp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &statusResp); err != nil {
+		t.Fatalf("decode status response: %v", err)
+	}
+	if statusResp["status"] != "idle" || statusResp["acknowledged"] != true {
+		t.Fatalf("expected acknowledged idle status, got %+v", statusResp)
+	}
+	if _, ok := statusResp["last_upgrade"].(map[string]any); !ok {
+		t.Fatalf("expected last_upgrade payload, got %+v", statusResp["last_upgrade"])
+	}
+}
+
+func TestUpdateServerCompletedStatusExpiresToIdle(t *testing.T) {
+	updateSrv := newTestUpdateServer(t, nil)
+	statusPath := filepath.Join(updateSrv.controlDir, upgradeStatusFile)
+	oldFinishedAt := time.Now().UTC().Add(-completedUpgradeStatusTTL - time.Minute)
+	if err := os.WriteFile(statusPath, []byte(`{"status":"completed","upgrade_id":"upg-old","target_version":"0.9.0","finished_at":"`+oldFinishedAt.Format(time.RFC3339)+`"}`), 0o644); err != nil {
+		t.Fatalf("write completed status file: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/updates/status", nil)
+	rr := httptest.NewRecorder()
+	updateSrv.handleGetUpgradeStatus(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var statusResp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &statusResp); err != nil {
+		t.Fatalf("decode status response: %v", err)
+	}
+	if statusResp["status"] != "idle" || statusResp["completed_status_expired"] != true || statusResp["upgrade_id"] != "upg-old" {
+		t.Fatalf("expected expired idle status, got %+v", statusResp)
+	}
+	if _, ok := statusResp["last_upgrade"].(map[string]any); !ok {
+		t.Fatalf("expected last_upgrade payload, got %+v", statusResp["last_upgrade"])
+	}
+}
+
+func TestUpdateServerAcknowledgeRequiresCompletedStatus(t *testing.T) {
+	updateSrv := newTestUpdateServer(t, nil)
+	statusPath := filepath.Join(updateSrv.controlDir, upgradeStatusFile)
+	if err := os.WriteFile(statusPath, []byte(`{"status":"running","upgrade_id":"upg-running"}`), 0o644); err != nil {
+		t.Fatalf("write running status file: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/updates/status/ack", nil)
+	rr := httptest.NewRecorder()
+	updateSrv.handleAcknowledgeUpgradeStatus(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/scripts/cloudpam-upgrade.sh
+++ b/scripts/cloudpam-upgrade.sh
@@ -11,6 +11,21 @@ SERVER_IMAGE="${SERVER_IMAGE:-ghcr.io/badgerops/cloudpam/server}"
 SERVICE_NAME="${SERVICE_NAME:-cloudpam.service}"
 TOTAL_STEPS=4
 
+read_request_field() {
+  local field="$1"
+  python3 - "$REQUEST_FILE" "$field" <<'PY' 2>/dev/null || true
+import json
+import sys
+
+path, field = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as handle:
+    value = json.load(handle).get(field, "")
+if value is None:
+    value = ""
+print(value)
+PY
+}
+
 write_status() {
   local status="$1"
   local step="$2"
@@ -24,16 +39,51 @@ write_status() {
   fi
 
   mkdir -p "${DATA_DIR}"
-  cat > "${STATUS_FILE}" <<EOF
-{
-  "status": "${status}",
-  "message": "${message}",
-  "step": ${step},
-  "total_steps": ${TOTAL_STEPS},
-  "progress": ${progress},
-  "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  STATUS_VALUE="${status}" \
+    MESSAGE_VALUE="${message}" \
+    STEP_VALUE="${step}" \
+    TOTAL_STEPS_VALUE="${TOTAL_STEPS}" \
+    PROGRESS_VALUE="${progress}" \
+    UPDATED_AT_VALUE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    UPGRADE_ID_VALUE="${UPGRADE_ID:-}" \
+    CURRENT_VERSION_VALUE="${CURRENT_VERSION:-}" \
+    TARGET_VERSION_VALUE="${TARGET_VERSION:-}" \
+    TARGET_IMAGE_TAG_VALUE="${TARGET_IMAGE_TAG:-}" \
+    TARGET_RELEASE_TAG_VALUE="${TARGET_RELEASE_TAG:-}" \
+    REQUESTED_AT_VALUE="${REQUESTED_AT:-}" \
+    RELEASE_URL_VALUE="${RELEASE_URL:-}" \
+    REQUESTED_BY_VALUE="${REQUESTED_BY:-}" \
+    python3 - "${STATUS_FILE}" <<'PY'
+import json
+import os
+import sys
+
+payload = {
+    "status": os.environ["STATUS_VALUE"],
+    "message": os.environ["MESSAGE_VALUE"],
+    "step": int(os.environ["STEP_VALUE"]),
+    "total_steps": int(os.environ["TOTAL_STEPS_VALUE"]),
+    "progress": int(os.environ["PROGRESS_VALUE"]),
+    "updated_at": os.environ["UPDATED_AT_VALUE"],
 }
-EOF
+for key, env_name in (
+    ("upgrade_id", "UPGRADE_ID_VALUE"),
+    ("current_version", "CURRENT_VERSION_VALUE"),
+    ("target_version", "TARGET_VERSION_VALUE"),
+    ("target_image_tag", "TARGET_IMAGE_TAG_VALUE"),
+    ("target_release_tag", "TARGET_RELEASE_TAG_VALUE"),
+    ("requested_at", "REQUESTED_AT_VALUE"),
+    ("release_url", "RELEASE_URL_VALUE"),
+    ("requested_by", "REQUESTED_BY_VALUE"),
+):
+    value = os.environ.get(env_name, "").strip()
+    if value:
+        payload[key] = value
+
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2)
+    handle.write("\n")
+PY
 }
 
 cleanup() {
@@ -44,7 +94,15 @@ if [[ ! -f "${REQUEST_FILE}" ]]; then
   exit 0
 fi
 
-TARGET_VERSION="$(python3 -c "import json; print(json.load(open('${REQUEST_FILE}')).get('target_version', ''))" 2>/dev/null || true)"
+UPGRADE_ID="$(read_request_field "upgrade_id")"
+REQUESTED_AT="$(read_request_field "requested_at")"
+CURRENT_VERSION="$(read_request_field "current_version")"
+TARGET_VERSION="$(read_request_field "target_version")"
+TARGET_IMAGE_TAG="$(read_request_field "target_image_tag")"
+TARGET_RELEASE_TAG="$(read_request_field "target_release_tag")"
+RELEASE_URL="$(read_request_field "release_url")"
+REQUESTED_BY="$(read_request_field "requested_by")"
+
 if [[ -z "${TARGET_VERSION}" ]]; then
   write_status "failed" 0 "Could not read target version from upgrade request"
   cleanup

--- a/ui/src/__tests__/UpdatesPage.test.tsx
+++ b/ui/src/__tests__/UpdatesPage.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../utils/upgradeReload', () => ({
 describe('UpdatesPage', () => {
   const showToast = vi.fn()
   const triggerUpgrade = vi.fn()
+  const acknowledgeUpgradeStatus = vi.fn()
   const refreshSummary = vi.fn()
   const refreshStatus = vi.fn()
 
@@ -54,6 +55,7 @@ describe('UpdatesPage', () => {
       refreshSummary,
       refreshStatus,
       triggerUpgrade,
+      acknowledgeUpgradeStatus,
     })
 
     triggerUpgrade.mockResolvedValue({
@@ -62,6 +64,7 @@ describe('UpdatesPage', () => {
     })
     refreshSummary.mockResolvedValue(undefined)
     refreshStatus.mockResolvedValue(undefined)
+    acknowledgeUpgradeStatus.mockResolvedValue({ status: 'idle', acknowledged: true })
   })
 
   it('shows updater details for admins', () => {
@@ -102,6 +105,7 @@ describe('UpdatesPage', () => {
       refreshSummary,
       refreshStatus,
       triggerUpgrade,
+      acknowledgeUpgradeStatus,
     })
     scheduleFrontendResetAfterUpgrade.mockReturnValue(123)
 
@@ -110,6 +114,7 @@ describe('UpdatesPage', () => {
     await waitFor(() => {
       expect(showToast).toHaveBeenCalledWith('Upgrade completed. Refreshing the frontend...', 'success')
       expect(scheduleFrontendResetAfterUpgrade).toHaveBeenCalledTimes(1)
+      expect(acknowledgeUpgradeStatus).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1,5 +1,5 @@
 import type { ApiError } from './types'
-import type { SystemInfoResponse, UpdateCheckResponse, UpgradeStatusResponse } from './types'
+import type { SystemInfoResponse, UpdateCheckResponse, UpgradeStatusAckResponse, UpgradeStatusResponse } from './types'
 
 export class ApiRequestError extends Error {
   constructor(
@@ -110,12 +110,16 @@ export function checkForUpdates(force = false): Promise<UpdateCheckResponse> {
   return get<UpdateCheckResponse>(`/api/v1/updates${suffix}`)
 }
 
-export function triggerUpgrade(): Promise<{ status: string; target_version: string; message: string }> {
-  return post<{ status: string; target_version: string; message: string }>('/api/v1/updates/upgrade', {})
+export function triggerUpgrade(): Promise<{ status: string; upgrade_id?: string; target_version: string; message: string }> {
+  return post<{ status: string; upgrade_id?: string; target_version: string; message: string }>('/api/v1/updates/upgrade', {})
 }
 
 export function getUpgradeStatus(): Promise<UpgradeStatusResponse> {
   return get<UpgradeStatusResponse>('/api/v1/updates/status')
+}
+
+export function acknowledgeUpgradeStatus(): Promise<UpgradeStatusAckResponse> {
+  return post<UpgradeStatusAckResponse>('/api/v1/updates/status/ack', {})
 }
 
 export interface SSECallbacks {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -276,6 +276,7 @@ export interface UpdateCheckResponse {
 
 export interface UpgradeTriggerResponse {
   status: string
+  upgrade_id?: string
   target_version: string
   message?: string
 }
@@ -283,6 +284,10 @@ export interface UpgradeTriggerResponse {
 export interface UpdateStatusResponse {
   status: string
   supported?: boolean
+  upgrade_id?: string
+  acknowledged?: boolean
+  completed_status_expired?: boolean
+  last_upgrade?: Record<string, unknown>
   message?: string
   step?: number | string
   total_steps?: number
@@ -303,6 +308,8 @@ export interface UpdateStatusResponse {
 }
 
 export type UpgradeStatusResponse = UpdateStatusResponse
+
+export type UpgradeStatusAckResponse = UpdateStatusResponse
 
 // --- User types ---
 

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { checkForUpdates, getUpgradeStatus, triggerUpgrade } from '../api/client'
+import { acknowledgeUpgradeStatus, checkForUpdates, getUpgradeStatus, triggerUpgrade } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { scheduleFrontendResetAfterUpgrade } from '../utils/upgradeReload'
 
@@ -80,6 +80,9 @@ export default function UpdateBanner() {
             setUpgradeStep('completed')
             setUpgradeMessage(status.message || 'Upgrade complete. Reloading...')
             reloadTimeoutRef.current = scheduleFrontendResetAfterUpgrade()
+            void acknowledgeUpgradeStatus().catch(() => {
+              // The backend TTL still clears stale completed state if acknowledgment fails.
+            })
           } else if (status.status === 'failed') {
             if (statusPollRef.current) window.clearInterval(statusPollRef.current)
             setUpgradeStep('failed')

--- a/ui/src/hooks/useUpdates.ts
+++ b/ui/src/hooks/useUpdates.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { get, post } from '../api/client'
-import type { UpdateCheckResponse, UpdateStatusResponse, UpgradeTriggerResponse } from '../api/types'
+import type { UpdateCheckResponse, UpdateStatusResponse, UpgradeStatusAckResponse, UpgradeTriggerResponse } from '../api/types'
 
 export function useUpdates() {
   const [summary, setSummary] = useState<UpdateCheckResponse | null>(null)
@@ -61,6 +61,12 @@ export function useUpdates() {
     }
   }, [refreshStatus, refreshSummary])
 
+  const acknowledgeUpgradeStatus = useCallback(async () => {
+    const data = await post<UpgradeStatusAckResponse>('/api/v1/updates/status/ack', {})
+    setStatus(data)
+    return data
+  }, [])
+
   useEffect(() => {
     void refreshSummary()
     void refreshStatus()
@@ -78,5 +84,6 @@ export function useUpdates() {
     refreshSummary,
     refreshStatus,
     triggerUpgrade,
+    acknowledgeUpgradeStatus,
   }
 }

--- a/ui/src/pages/UpdatesPage.tsx
+++ b/ui/src/pages/UpdatesPage.tsx
@@ -156,6 +156,7 @@ export default function UpdatesPage() {
     refreshSummary,
     refreshStatus,
     triggerUpgrade,
+    acknowledgeUpgradeStatus,
   } = useUpdates()
   const [pendingTargetVersion, setPendingTargetVersion] = useState<string | null>(null)
   const reloadTimeoutRef = useRef<number | null>(null)
@@ -191,7 +192,10 @@ export default function UpdatesPage() {
     reloadScheduledRef.current = true
     showToast('Upgrade completed. Refreshing the frontend...', 'success')
     reloadTimeoutRef.current = scheduleFrontendResetAfterUpgrade()
-  }, [showToast, status?.status])
+    void acknowledgeUpgradeStatus().catch(() => {
+      // The backend TTL still clears stale completed state if acknowledgment fails.
+    })
+  }, [acknowledgeUpgradeStatus, showToast, status?.status])
 
   async function handleRefresh() {
     const results = await Promise.allSettled([refreshSummary(true), refreshStatus()])


### PR DESCRIPTION
## Summary

Closes #185.

This hardens the in-app upgrade status lifecycle so a completed host-side upgrade does not remain the active `/api/v1/updates/status` response forever.

## What changed

- Added a stable `upgrade_id` to upgrade trigger responses and the `upgrade-requested` control file.
- Ensured upgrade status responses include an `upgrade_id`, deriving one for legacy host status files that do not provide it.
- Added `POST /api/v1/updates/status/ack`.
- Added backend completed-status lifecycle handling:
  - acknowledged completed upgrades return top-level `status: "idle"`
  - unacknowledged completed upgrades expire back to idle after a 10-minute TTL
  - completed payload details are preserved under `last_upgrade`
- Added an `upgrade-status-ack.json` marker in the existing control directory instead of mutating host-managed status files.
- Updated `UpdatesPage` and `UpdateBanner` to acknowledge completed upgrades after scheduling the existing frontend reload.
- Updated generated OpenAPI metadata and TypeScript API types/client/hook.
- Added `0.18.1` changelog entry.

## Behavior notes

- The existing frontend reload dedupe remains as a fallback.
- `POST /api/v1/updates/status/ack` requires the same write permission boundary as triggering upgrades.
- Acknowledging a non-completed status returns conflict.
- Unsupported or missing status states keep returning the existing unsupported/idle responses.
- Legacy host scripts work without changes, but host-provided `upgrade_id` is preferred.

## Testing

Ran through the Nix dev shell:

```bash
nix develop -c go test ./internal/api -run 'TestUpdateServer'
nix develop -c go test ./internal/api -run TestOpenAPI
nix develop -c go test ./...
nix develop -c npm --prefix ui test -- --run UpdatesPage
nix develop -c npm --prefix ui run build
```

Also ran gofmt:

```bash
nix develop -c gofmt -w internal/api/update_handlers.go internal/api/update_handlers_test.go internal/api/openapi.go
```

## Review notes

- Pipeline handoffs were written under `.pipeline/` locally:
  - `.pipeline/spec.md`
  - `.pipeline/changes.md`
  - `.pipeline/tests.md`
  - `.pipeline/review.md`
- Reviewer verdict: `approve`.

## Residual risks

- Legacy host scripts that do not echo `upgrade_id` receive a derived ID. Normal status payloads with target/request/start metadata should be stable, but host-provided IDs are more robust.
- `UpdateBanner` does not have direct unit coverage for the ack call; TypeScript build validates the path and `UpdatesPage` covers the same lifecycle behavior.
