### PR TITLE
Discovery: show import apply summaries

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.19.0] - 2026-06-28
+
+### Added
+- Discovery import apply responses now include a structured aggregate summary for imported, linked-only, skipped, blocked, conflict, created-record, and linked-record outcomes, and the Discovery UI keeps that post-apply summary visible with affected-resource navigation.
+
 ## [0.18.1] - 2026-06-28
 
 ### Fixed

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -367,7 +367,11 @@ func (d *DiscoveryServer) applyDiscoveryImport(ctx context.Context, req domain.D
 		return domain.DiscoveryImportApplyResponse{}, err
 	}
 
-	resp := domain.DiscoveryImportApplyResponse{Preview: preview, Errors: []string{}}
+	resp := domain.DiscoveryImportApplyResponse{
+		Preview: preview,
+		Summary: discoveryImportApplyPreviewSummary(preview),
+		Errors:  []string{},
+	}
 	items := append([]domain.DiscoveryImportPreviewItem{}, preview.Items...)
 	sort.SliceStable(items, func(i, j int) bool {
 		if items[i].ResourceType == items[j].ResourceType {
@@ -447,10 +451,32 @@ func (d *DiscoveryServer) applyDiscoveryImport(ctx context.Context, req domain.D
 		createdPoolByProviderID[res.ResourceID] = pool.ID
 		resp.PoolsCreated++
 		resp.ResourcesLinked++
+		resp.Summary.Imported++
 		resp.LinkedResourceIDs = append(resp.LinkedResourceIDs, item.ResourceID)
 	}
 
+	resp.Summary.Skipped = resp.Skipped
+	resp.Summary.CreatedRecords = resp.PoolsCreated
+	resp.Summary.LinkedRecords = resp.ResourcesLinked
+	resp.Summary.AffectedResourceIDs = resp.LinkedResourceIDs
+	resp.Summary.CreatedPoolIDs = resp.CreatedPoolIDs
+
 	return resp, nil
+}
+
+func discoveryImportApplyPreviewSummary(preview domain.DiscoveryImportPreviewResponse) domain.DiscoveryImportApplySummary {
+	var summary domain.DiscoveryImportApplySummary
+	for _, item := range preview.Items {
+		switch item.Status {
+		case "linked_only":
+			summary.LinkedOnly++
+		case "blocked":
+			summary.Blocked++
+		case "conflict":
+			summary.Conflicts++
+		}
+	}
+	return summary
 }
 
 func canForceDiscoveryImport(item domain.DiscoveryImportPreviewItem, opts discoveryImportApplyOptions) bool {

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -217,12 +217,157 @@ func TestDiscoveryImportPreviewAndApplySelectedResources(t *testing.T) {
 	if applied.PoolsCreated != 2 || applied.ResourcesLinked != 2 || applied.Skipped != 0 {
 		t.Fatalf("unexpected apply response: %+v", applied)
 	}
+	if applied.Summary.Imported != 2 || applied.Summary.LinkedOnly != 0 || applied.Summary.CreatedRecords != 2 || applied.Summary.LinkedRecords != 2 {
+		t.Fatalf("unexpected apply summary: %+v", applied.Summary)
+	}
+	if len(applied.Summary.AffectedResourceIDs) != 2 || !containsDiscoveryUUID(applied.Summary.AffectedResourceIDs, vpcID) || !containsDiscoveryUUID(applied.Summary.AffectedResourceIDs, subnetID) {
+		t.Fatalf("unexpected affected resources: %+v", applied.Summary.AffectedResourceIDs)
+	}
 	pools, err := st.ListPools(t.Context())
 	if err != nil {
 		t.Fatalf("list pools: %v", err)
 	}
 	if len(pools) != 2 {
 		t.Fatalf("len(pools) = %d, want 2", len(pools))
+	}
+}
+
+func TestDiscoveryImportApplyReturnsMixedResultSummary(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	otherAccount, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:210987654321", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create other account: %v", err)
+	}
+	if _, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "linked-vpc", CIDR: "10.71.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID}); err != nil {
+		t.Fatalf("create matching pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	importID := uuid.New()
+	linkID := uuid.New()
+	eipID := uuid.New()
+	blockedID := uuid.New()
+	conflictID := uuid.New()
+	duplicateID := uuid.New()
+	missingParent := "vpc-missing"
+	for _, res := range []domain.DiscoveredResource{
+		{
+			ID:           importID,
+			AccountID:    account.ID,
+			Provider:     "aws",
+			Region:       "us-east-1",
+			ResourceType: domain.ResourceTypeVPC,
+			ResourceID:   "vpc-import",
+			Name:         "import-vpc",
+			CIDR:         "10.70.0.0/16",
+			Status:       domain.DiscoveryStatusActive,
+			DiscoveredAt: now,
+			LastSeenAt:   now,
+		},
+		{
+			ID:           linkID,
+			AccountID:    account.ID,
+			Provider:     "aws",
+			Region:       "us-east-1",
+			ResourceType: domain.ResourceTypeVPC,
+			ResourceID:   "vpc-link",
+			Name:         "link-vpc",
+			CIDR:         "10.71.0.0/16",
+			Status:       domain.DiscoveryStatusActive,
+			DiscoveredAt: now,
+			LastSeenAt:   now,
+		},
+		{
+			ID:           eipID,
+			AccountID:    account.ID,
+			Provider:     "aws",
+			Region:       "us-east-1",
+			ResourceType: domain.ResourceTypeElasticIP,
+			ResourceID:   "eipalloc-summary",
+			Name:         "summary-eip",
+			Status:       domain.DiscoveryStatusActive,
+			DiscoveredAt: now,
+			LastSeenAt:   now,
+		},
+		{
+			ID:               blockedID,
+			AccountID:        account.ID,
+			Provider:         "aws",
+			Region:           "us-east-1",
+			ResourceType:     domain.ResourceTypeSubnet,
+			ResourceID:       "subnet-blocked",
+			Name:             "blocked-subnet",
+			CIDR:             "10.72.1.0/24",
+			ParentResourceID: &missingParent,
+			Status:           domain.DiscoveryStatusActive,
+			DiscoveredAt:     now,
+			LastSeenAt:       now,
+		},
+		{
+			ID:           conflictID,
+			AccountID:    account.ID,
+			Provider:     "aws",
+			Region:       "us-east-1",
+			ResourceType: domain.ResourceTypeVPC,
+			ResourceID:   "vpc-conflict",
+			Name:         "conflict-vpc",
+			CIDR:         "10.73.0.0/16",
+			Status:       domain.DiscoveryStatusActive,
+			DiscoveredAt: now,
+			LastSeenAt:   now,
+		},
+		{
+			ID:           duplicateID,
+			AccountID:    otherAccount.ID,
+			Provider:     "aws",
+			Region:       "us-east-1",
+			ResourceType: domain.ResourceTypeVPC,
+			ResourceID:   "vpc-conflict-other",
+			Name:         "conflict-vpc-other",
+			CIDR:         "10.73.0.0/16",
+			Status:       domain.DiscoveryStatusActive,
+			DiscoveredAt: now,
+			LastSeenAt:   now,
+		},
+	} {
+		upsertDiscoveredForImportTest(t, ds, res)
+	}
+
+	body := fmt.Sprintf(
+		`{"account_id":%d,"resource_ids":["%s","%s","%s","%s","%s"]}`,
+		account.ID,
+		importID,
+		linkID,
+		eipID,
+		blockedID,
+		conflictID,
+	)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/apply", body, http.StatusOK)
+	var applied domain.DiscoveryImportApplyResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &applied); err != nil {
+		t.Fatalf("unmarshal apply: %v", err)
+	}
+	if applied.PoolsCreated != 1 || applied.ResourcesLinked != 2 || applied.Skipped != 3 {
+		t.Fatalf("unexpected apply response: %+v", applied)
+	}
+	if applied.Summary.Imported != 1 ||
+		applied.Summary.LinkedOnly != 1 ||
+		applied.Summary.Skipped != 3 ||
+		applied.Summary.Blocked != 1 ||
+		applied.Summary.Conflicts != 1 ||
+		applied.Summary.CreatedRecords != 1 ||
+		applied.Summary.LinkedRecords != 2 {
+		t.Fatalf("unexpected summary: %+v", applied.Summary)
+	}
+	if len(applied.Summary.CreatedPoolIDs) != 1 || len(applied.CreatedPoolIDs) != 1 || applied.Summary.CreatedPoolIDs[0] != applied.CreatedPoolIDs[0] {
+		t.Fatalf("unexpected created pool ids: summary=%v top-level=%v", applied.Summary.CreatedPoolIDs, applied.CreatedPoolIDs)
+	}
+	if !containsDiscoveryUUID(applied.Summary.AffectedResourceIDs, importID) || !containsDiscoveryUUID(applied.Summary.AffectedResourceIDs, linkID) || containsDiscoveryUUID(applied.Summary.AffectedResourceIDs, eipID) {
+		t.Fatalf("unexpected affected resource ids: %+v", applied.Summary.AffectedResourceIDs)
 	}
 }
 
@@ -694,6 +839,15 @@ func singleDiscoveryPreviewItem(t *testing.T, rr *httptest.ResponseRecorder) dom
 }
 
 func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsDiscoveryUUID(items []uuid.UUID, want uuid.UUID) bool {
 	for _, item := range items {
 		if item == want {
 			return true

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -500,6 +500,10 @@ func openAPIComponentTypes() []openAPIComponentType {
 		{"DiscoveryResourcesResponse", reflect.TypeOf(domain.DiscoveryResourcesResponse{})},
 		{"DiscoveryImportRequest", reflect.TypeOf(openAPIDiscoveryImportRequest{})},
 		{"DiscoveryImportResponse", reflect.TypeOf(openAPIDiscoveryImportResponse{})},
+		{"DiscoveryImportPreviewRequest", reflect.TypeOf(domain.DiscoveryImportPreviewRequest{})},
+		{"DiscoveryImportPreviewResponse", reflect.TypeOf(domain.DiscoveryImportPreviewResponse{})},
+		{"DiscoveryImportApplyRequest", reflect.TypeOf(domain.DiscoveryImportApplyRequest{})},
+		{"DiscoveryImportApplyResponse", reflect.TypeOf(domain.DiscoveryImportApplyResponse{})},
 		{"LinkResourceRequest", reflect.TypeOf(openAPILinkResourceRequest{})},
 		{"SyncRequest", reflect.TypeOf(openAPISyncRequest{})},
 		{"SyncJob", reflect.TypeOf(domain.SyncJob{})},
@@ -775,6 +779,11 @@ func openAPIRoutesForPattern(pattern string) []openAPIRoute {
 		})
 	case "/api/v1/discovery/import":
 		return routesForMethodPath(http.MethodPost, "/api/v1/discovery/import")
+	case "/api/v1/discovery/import/":
+		return routesForKnown([][2]string{
+			{http.MethodPost, "/api/v1/discovery/import/preview"},
+			{http.MethodPost, "/api/v1/discovery/import/apply"},
+		})
 	case "/api/v1/discovery/sync":
 		return routesForMethodsPath([]string{http.MethodGet, http.MethodPost}, "/api/v1/discovery/sync")
 	case "/api/v1/discovery/sync/":
@@ -1048,6 +1057,8 @@ func openAPIOperationCatalog() map[string]openAPIRoute {
 		{Method: "POST", Path: "/api/v1/discovery/resources/{resourceId}/link", Summary: "Link discovered resource to pool", Tag: "Discovery", RequestSchema: "LinkResourceRequest", ResponseSchema: "StatusResponse"},
 		{Method: "DELETE", Path: "/api/v1/discovery/resources/{resourceId}/link", Summary: "Unlink discovered resource from pool", Tag: "Discovery", SuccessStatus: "200", ResponseSchema: "StatusResponse"},
 		{Method: "POST", Path: "/api/v1/discovery/import", Summary: "Import discovered resources as pools", Tag: "Discovery", RequestSchema: "DiscoveryImportRequest", ResponseSchema: "DiscoveryImportResponse"},
+		{Method: "POST", Path: "/api/v1/discovery/import/preview", Summary: "Preview selected discovery import", Tag: "Discovery", RequestSchema: "DiscoveryImportPreviewRequest", ResponseSchema: "DiscoveryImportPreviewResponse"},
+		{Method: "POST", Path: "/api/v1/discovery/import/apply", Summary: "Apply selected discovery import", Tag: "Discovery", RequestSchema: "DiscoveryImportApplyRequest", ResponseSchema: "DiscoveryImportApplyResponse"},
 		{Method: "GET", Path: "/api/v1/discovery/sync", Summary: "List discovery sync jobs", Tag: "Discovery", ResponseSchema: "SyncJobsResponse", Parameters: []openAPIParameter{queryParam("account_id", "Account ID", "integer"), queryParam("limit", "Maximum jobs to return", "integer")}},
 		{Method: "POST", Path: "/api/v1/discovery/sync", Summary: "Trigger discovery sync", Tag: "Discovery", RequestSchema: "SyncRequest", ResponseSchema: "Object"},
 		{Method: "GET", Path: "/api/v1/discovery/sync/{syncJobId}", Summary: "Get discovery sync job", Tag: "Discovery", ResponseSchema: "SyncJob"},

--- a/internal/domain/discovery.go
+++ b/internal/domain/discovery.go
@@ -179,12 +179,27 @@ type DiscoveryImportPreviewResponse struct {
 // importable discovery preview rows.
 type DiscoveryImportApplyResponse struct {
 	Preview           DiscoveryImportPreviewResponse `json:"preview"`
+	Summary           DiscoveryImportApplySummary    `json:"summary"`
 	PoolsCreated      int                            `json:"pools_created"`
 	ResourcesLinked   int                            `json:"resources_linked"`
 	Skipped           int                            `json:"skipped"`
 	Errors            []string                       `json:"errors"`
 	CreatedPoolIDs    []int64                        `json:"created_pool_ids,omitempty"`
 	LinkedResourceIDs []uuid.UUID                    `json:"linked_resource_ids,omitempty"`
+}
+
+// DiscoveryImportApplySummary provides aggregate import outcomes for operator
+// review after a bulk apply.
+type DiscoveryImportApplySummary struct {
+	Imported            int         `json:"imported"`
+	LinkedOnly          int         `json:"linked_only"`
+	Skipped             int         `json:"skipped"`
+	Blocked             int         `json:"blocked"`
+	Conflicts           int         `json:"conflicts"`
+	CreatedRecords      int         `json:"created_records"`
+	LinkedRecords       int         `json:"linked_records"`
+	AffectedResourceIDs []uuid.UUID `json:"affected_resource_ids,omitempty"`
+	CreatedPoolIDs      []int64     `json:"created_pool_ids,omitempty"`
 }
 
 // SyncJobsResponse is the response for listing sync jobs.

--- a/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
+++ b/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { useState, type ComponentProps } from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import type { Account, DiscoveredResource, Pool } from '../api/types'
-import { ResourcesTab } from '../pages/DiscoveryPage'
+import type { Account, DiscoveredResource, DiscoveryImportApplyResponse, Pool } from '../api/types'
+import { ImportApplySummaryPanel, ResourcesTab, importApplyResultQuery } from '../pages/DiscoveryPage'
 
 const resources: DiscoveredResource[] = [
   {
@@ -234,5 +234,99 @@ describe('ResourcesTab', () => {
 
     expect(onPageChange).toHaveBeenCalledWith(3)
     expect(onPageSizeChange).toHaveBeenCalledWith(100)
+  })
+})
+
+describe('ImportApplySummaryPanel', () => {
+  const applyResult: DiscoveryImportApplyResponse = {
+    pools_created: 1,
+    resources_linked: 2,
+    skipped: 2,
+    errors: ['resource warning'],
+    created_pool_ids: [101],
+    linked_resource_ids: ['resource-imported', 'resource-linked'],
+    summary: {
+      imported: 1,
+      linked_only: 1,
+      skipped: 2,
+      blocked: 1,
+      conflicts: 1,
+      created_records: 1,
+      linked_records: 2,
+      affected_resource_ids: ['resource-imported', 'resource-linked'],
+      created_pool_ids: [101],
+    },
+    preview: {
+      importable: 2,
+      blocked: 1,
+      linked_only: 1,
+      already_linked: 0,
+      conflict_count: 1,
+      items: [
+        {
+          resource_id: 'resource-imported',
+          provider_resource_id: 'vpc-imported',
+          name: 'imported-vpc',
+          resource_type: 'vpc',
+          cidr: '10.70.0.0/16',
+          status: 'importable',
+          proposed_action: 'create_pool',
+          issues: [],
+        },
+        {
+          resource_id: 'resource-linked',
+          provider_resource_id: 'vpc-linked',
+          name: 'linked-vpc',
+          resource_type: 'vpc',
+          cidr: '10.71.0.0/16',
+          status: 'importable',
+          proposed_action: 'link_pool',
+          proposed_pool_id: 42,
+          issues: [],
+        },
+        {
+          resource_id: 'resource-blocked',
+          provider_resource_id: 'subnet-blocked',
+          name: 'blocked-subnet',
+          resource_type: 'subnet',
+          cidr: '10.72.1.0/24',
+          status: 'blocked',
+          proposed_action: 'none',
+          issues: ['missing_parent'],
+        },
+        {
+          resource_id: 'resource-conflict',
+          provider_resource_id: 'vpc-conflict',
+          name: 'conflict-vpc',
+          resource_type: 'vpc',
+          cidr: '10.73.0.0/16',
+          status: 'conflict',
+          proposed_action: 'none',
+          issues: ['duplicate_cidr'],
+        },
+      ],
+    },
+  }
+
+  it('renders aggregate and item-level apply outcomes', () => {
+    const onViewAffected = vi.fn()
+    render(<ImportApplySummaryPanel result={applyResult} onViewAffected={onViewAffected} />)
+
+    expect(screen.getByText('Import apply summary')).toBeTruthy()
+    expect(screen.getAllByText('Imported').length).toBeGreaterThan(0)
+    expect(screen.getByText('Linked-only')).toBeTruthy()
+    expect(screen.getAllByText('Blocked').length).toBeGreaterThan(0)
+    expect(screen.getByText('Conflicts')).toBeTruthy()
+    expect(screen.getByText('Linked existing pool')).toBeTruthy()
+    expect(screen.getByText('missing_parent')).toBeTruthy()
+    expect(screen.getByText('duplicate_cidr')).toBeTruthy()
+    expect(screen.getByText('1 warning while applying import')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /View affected resources/i }))
+    expect(onViewAffected).toHaveBeenCalled()
+  })
+
+  it('uses the first affected provider resource as the merged-network query', () => {
+    expect(importApplyResultQuery(applyResult)).toBe('vpc-imported')
   })
 })

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -526,10 +526,25 @@ export interface DiscoveryImportPreviewResponse {
 
 export interface DiscoveryImportApplyResponse {
   preview: DiscoveryImportPreviewResponse
+  summary: DiscoveryImportApplySummary
   pools_created: number
   resources_linked: number
   skipped: number
   errors: string[]
+  created_pool_ids?: number[]
+  linked_resource_ids?: string[]
+}
+
+export interface DiscoveryImportApplySummary {
+  imported: number
+  linked_only: number
+  skipped: number
+  blocked: number
+  conflicts: number
+  created_records: number
+  linked_records: number
+  affected_resource_ids?: string[]
+  created_pool_ids?: number[]
 }
 
 export interface NetworkIssue {

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -42,6 +42,7 @@ import type {
   AgentStatus,
   DiscoveryImportPreviewResponse,
   DiscoveryImportPreviewItem,
+  DiscoveryImportApplyResponse,
   NetworkNode,
   NetworkConflict,
   NetworkIssue,
@@ -51,6 +52,12 @@ import type {
 } from '../api/types'
 
 type Tab = 'resources' | 'network' | 'sync' | 'agents'
+type NetworkMode = 'hierarchy' | 'flat' | 'conflicts' | 'objects' | 'relationships'
+type NetworkJumpRequest = {
+  mode: NetworkMode
+  query: string
+  token: number
+}
 
 const NETWORK_TRIAGE_GUIDES = [
   {
@@ -131,6 +138,8 @@ export default function DiscoveryPage() {
   const [applyImportLoading, setApplyImportLoading] = useState(false)
   const [selectedResourceIds, setSelectedResourceIds] = useState<string[]>([])
   const [importPreview, setImportPreview] = useState<DiscoveryImportPreviewResponse | null>(null)
+  const [importApplyResult, setImportApplyResult] = useState<DiscoveryImportApplyResponse | null>(null)
+  const [networkJumpRequest, setNetworkJumpRequest] = useState<NetworkJumpRequest | null>(null)
   const [trackedScanJobs, setTrackedScanJobs] = useState<SyncJob[]>([])
   const [linkingResource, setLinkingResource] = useState<DiscoveredResource | null>(null)
   const [linkingLoading, setLinkingLoading] = useState(false)
@@ -180,6 +189,7 @@ export default function DiscoveryPage() {
   useEffect(() => {
     setSelectedResourceIds([])
     setImportPreview(null)
+    setImportApplyResult(null)
   }, [selectedAccountId])
 
   useEffect(() => {
@@ -308,6 +318,7 @@ export default function DiscoveryPage() {
     }
     setImportLoading(true)
     try {
+      setImportApplyResult(null)
       const preview = await previewDiscoveryImport(selectedAccountId, selectedResourceIds)
       setImportPreview(preview)
     } catch (err) {
@@ -319,21 +330,21 @@ export default function DiscoveryPage() {
 
   async function handleApplyImport() {
     if (!selectedAccountId || !importPreview) return
-    const importableIds = importPreview.items
-      .filter((item) => item.status === 'importable')
-      .map((item) => item.resource_id)
+    const previewResourceIds = importPreview.items.map((item) => item.resource_id)
+    const importableIds = importPreview.items.filter((item) => item.status === 'importable')
     if (importableIds.length === 0) {
       showToast('No importable resources in this preview', 'error')
       return
     }
     setApplyImportLoading(true)
     try {
-      const result = await applyDiscoveryImport(selectedAccountId, importableIds)
+      const result = await applyDiscoveryImport(selectedAccountId, previewResourceIds)
       const detail = result.errors.length > 0 ? ` (${result.errors.length} warning${result.errors.length === 1 ? '' : 's'})` : ''
       showToast(
         `Imported ${result.pools_created} pools and linked ${result.resources_linked} resources${detail}`,
         result.errors.length > 0 ? 'info' : 'success',
       )
+      setImportApplyResult(result)
       setImportPreview(null)
       setSelectedResourceIds([])
       fetchPools()
@@ -362,6 +373,13 @@ export default function DiscoveryPage() {
       return
     }
     setSelectedResourceIds((current) => current.filter((id) => !ids.includes(id)))
+  }
+
+  function handleViewImportResultResources(result: DiscoveryImportApplyResponse) {
+    const query = importApplyResultQuery(result)
+    if (!query) return
+    setNetworkJumpRequest({ mode: 'flat', query, token: Date.now() })
+    setTab('network')
   }
 
   async function handleDeleteAgent(agent: DiscoveryAgent) {
@@ -620,45 +638,54 @@ export default function DiscoveryPage() {
       </div>
 
       {tab === 'resources' && (
-        <ResourcesTab
-          resources={filteredResources}
-          loading={resLoading}
-          error={resError}
-          searchQuery={searchQuery}
-          onSearchChange={(query) => {
-            setSearchQuery(query)
-            setResourcePage(1)
-          }}
-          statusFilter={statusFilter}
-          onStatusChange={setStatusFilter}
-          typeFilter={typeFilter}
-          onTypeChange={setTypeFilter}
-          linkedFilter={linkedFilter}
-          onLinkedChange={setLinkedFilter}
-          onLink={handleLink}
-          onUnlink={handleUnlink}
-          accounts={accounts}
-          selectedAccountId={selectedAccountId}
-          pools={pools}
-          selectedResourceIds={selectedResourceIds}
-          onToggleSelection={toggleResourceSelection}
-          onSetVisibleSelection={setVisibleImportableResources}
-          onClearSelection={() => setSelectedResourceIds([])}
-          onBulkLink={handleBulkLink}
-          bulkLinking={bulkLinkingLoading}
-          total={resourcesData?.total ?? filteredResources.length}
-          page={resourcesData?.page ?? resourcePage}
-          pageSize={resourcesData?.page_size ?? resourcePageSize}
-          onPageChange={setResourcePage}
-          onPageSizeChange={(pageSize) => {
-            setResourcePageSize(pageSize)
-            setResourcePage(1)
-          }}
-        />
+        <div className="space-y-4">
+          {importApplyResult && (
+            <ImportApplySummaryPanel
+              result={importApplyResult}
+              onViewAffected={() => handleViewImportResultResources(importApplyResult)}
+              onDismiss={() => setImportApplyResult(null)}
+            />
+          )}
+          <ResourcesTab
+            resources={filteredResources}
+            loading={resLoading}
+            error={resError}
+            searchQuery={searchQuery}
+            onSearchChange={(query) => {
+              setSearchQuery(query)
+              setResourcePage(1)
+            }}
+            statusFilter={statusFilter}
+            onStatusChange={setStatusFilter}
+            typeFilter={typeFilter}
+            onTypeChange={setTypeFilter}
+            linkedFilter={linkedFilter}
+            onLinkedChange={setLinkedFilter}
+            onLink={handleLink}
+            onUnlink={handleUnlink}
+            accounts={accounts}
+            selectedAccountId={selectedAccountId}
+            pools={pools}
+            selectedResourceIds={selectedResourceIds}
+            onToggleSelection={toggleResourceSelection}
+            onSetVisibleSelection={setVisibleImportableResources}
+            onClearSelection={() => setSelectedResourceIds([])}
+            onBulkLink={handleBulkLink}
+            bulkLinking={bulkLinkingLoading}
+            total={resourcesData?.total ?? filteredResources.length}
+            page={resourcesData?.page ?? resourcePage}
+            pageSize={resourcesData?.page_size ?? resourcePageSize}
+            onPageChange={setResourcePage}
+            onPageSizeChange={(pageSize) => {
+              setResourcePageSize(pageSize)
+              setResourcePage(1)
+            }}
+          />
+        </div>
       )}
 
       {tab === 'network' && (
-        <NetworkTab selectedAccountId={selectedAccountId} accounts={accounts} pools={pools} />
+        <NetworkTab selectedAccountId={selectedAccountId} accounts={accounts} pools={pools} jumpRequest={networkJumpRequest} />
       )}
 
       {tab === 'sync' && (
@@ -750,16 +777,16 @@ const DEFAULT_RESOURCE_COLUMNS: ResourceColumnKey[] = [
   'last_seen',
 ]
 
-type NetworkMode = 'hierarchy' | 'flat' | 'conflicts' | 'objects' | 'relationships'
-
 function NetworkTab({
   selectedAccountId,
   accounts,
   pools,
+  jumpRequest,
 }: {
   selectedAccountId: number | null
   accounts: Account[]
   pools: Pool[]
+  jumpRequest?: NetworkJumpRequest | null
 }) {
   const [mode, setMode] = useState<NetworkMode>('hierarchy')
   const [query, setQuery] = useState('')
@@ -847,6 +874,12 @@ function NetworkTab({
   useEffect(() => {
     load()
   }, [load])
+
+  useEffect(() => {
+    if (!jumpRequest) return
+    setMode(jumpRequest.mode)
+    setQuery(jumpRequest.query)
+  }, [jumpRequest])
 
   const activeItems = mode === 'hierarchy' ? hierarchy?.items : flat?.items
   const activeTotal = mode === 'hierarchy' ? hierarchy?.total : flat?.total
@@ -1785,6 +1818,133 @@ function DetailList({ label, values }: { label: string; values: Array<string | n
 
 function evidenceValues(evidence: string[] | undefined, keys: string[]) {
   return (evidence ?? []).filter((line) => keys.some((key) => line.startsWith(`${key}=`) || line.includes(`${key}=`)))
+}
+
+export function importApplyResultQuery(result: DiscoveryImportApplyResponse) {
+  const affected = new Set(result.summary.affected_resource_ids ?? result.linked_resource_ids ?? [])
+  const affectedItem = result.preview.items.find((item) => affected.has(item.resource_id))
+  const fallbackItem = result.preview.items.find((item) => item.status === 'importable') ?? result.preview.items[0]
+  const item = affectedItem ?? fallbackItem
+  if (item?.provider_resource_id) return item.provider_resource_id
+  if (item?.name) return item.name
+  if (item?.cidr) return item.cidr
+  const createdPoolID = result.summary.created_pool_ids?.[0] ?? result.created_pool_ids?.[0]
+  return createdPoolID ? String(createdPoolID) : ''
+}
+
+export function ImportApplySummaryPanel({
+  result,
+  onViewAffected,
+  onDismiss,
+}: {
+  result: DiscoveryImportApplyResponse
+  onViewAffected?: () => void
+  onDismiss?: () => void
+}) {
+  const summary = result.summary
+  const canViewAffected = importApplyResultQuery(result) !== ''
+  const countCards = [
+    { label: 'Imported', value: summary.imported },
+    { label: 'Linked-only', value: summary.linked_only },
+    { label: 'Skipped', value: summary.skipped },
+    { label: 'Blocked', value: summary.blocked },
+    { label: 'Conflicts', value: summary.conflicts },
+    { label: 'Created records', value: summary.created_records },
+    { label: 'Linked records', value: summary.linked_records },
+  ]
+
+  return (
+    <section className="rounded border border-green-200 bg-green-50 p-4 text-sm dark:border-green-800 dark:bg-green-900/20">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-green-950 dark:text-green-100">Import apply summary</h2>
+          <p className="mt-1 text-xs text-green-800 dark:text-green-300">
+            {summary.created_records} records created, {summary.linked_records} records linked, {summary.skipped} skipped
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {onViewAffected && (
+            <button
+              type="button"
+              onClick={onViewAffected}
+              disabled={!canViewAffected}
+              className="inline-flex items-center gap-1 rounded border border-green-300 px-2.5 py-1.5 text-xs font-medium text-green-900 hover:bg-green-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-green-700 dark:text-green-200 dark:hover:bg-green-900/40"
+            >
+              <ArrowRight className="h-3.5 w-3.5" />
+              View affected resources
+            </button>
+          )}
+          {onDismiss && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="rounded p-1.5 text-green-700 hover:bg-green-100 hover:text-green-950 dark:text-green-300 dark:hover:bg-green-900/40 dark:hover:text-green-100"
+              title="Dismiss summary"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-7">
+        {countCards.map((card) => (
+          <div key={card.label} className="rounded border border-green-200 bg-white px-3 py-2 dark:border-green-800 dark:bg-gray-900">
+            <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">{card.value}</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">{card.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {result.errors.length > 0 && (
+        <div className="mt-3 rounded border border-yellow-200 bg-yellow-50 p-2 text-xs text-yellow-900 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-200">
+          {result.errors.length} warning{result.errors.length === 1 ? '' : 's'} while applying import
+        </div>
+      )}
+
+      <div className="mt-3 overflow-hidden rounded border border-green-200 bg-white dark:border-green-800 dark:bg-gray-900">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-green-100 bg-green-100/60 text-left dark:border-green-800 dark:bg-green-900/30">
+              <th className="px-3 py-2 font-medium text-green-950 dark:text-green-100">Resource</th>
+              <th className="px-3 py-2 font-medium text-green-950 dark:text-green-100">Outcome</th>
+              <th className="px-3 py-2 font-medium text-green-950 dark:text-green-100">Action</th>
+              <th className="px-3 py-2 font-medium text-green-950 dark:text-green-100">Issues</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.preview.items.map((item) => (
+              <tr key={item.resource_id} className="border-b border-green-50 last:border-b-0 dark:border-green-900/40">
+                <td className="px-3 py-2">
+                  <div className="font-medium text-gray-900 dark:text-gray-100">{item.name || item.provider_resource_id || item.resource_id}</div>
+                  {item.provider_resource_id && item.name && (
+                    <div className="font-mono text-[11px] text-gray-500 dark:text-gray-400">{item.provider_resource_id}</div>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{importApplyItemOutcome(result, item)}</td>
+                <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{importActionLabel(item)}</td>
+                <td className="px-3 py-2 text-gray-500 dark:text-gray-400">{item.issues.length > 0 ? item.issues.join(', ') : '-'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function importApplyItemOutcome(result: DiscoveryImportApplyResponse, item: DiscoveryImportPreviewItem) {
+  const affected = new Set(result.summary.affected_resource_ids ?? result.linked_resource_ids ?? [])
+  if (affected.has(item.resource_id)) {
+    if (item.proposed_action === 'link_pool') return 'Linked existing pool'
+    return 'Imported'
+  }
+  if (item.status === 'conflict') return 'Conflict'
+  if (item.status === 'blocked') return 'Blocked'
+  if (item.status === 'linked_only') return 'Skipped link-only object'
+  if (item.status === 'already_linked') return 'Already linked'
+  if (item.status === 'not_found') return 'Not found'
+  return 'Skipped'
 }
 
 function NetworkActionResultSummary({


### PR DESCRIPTION
## Summary

Closes #197.

Adds a structured post-apply summary for selected discovery imports so operators can quickly see aggregate outcomes after bulk apply while still keeping item-level detail for troubleshooting.

## What changed

- Added `summary` to `POST /api/v1/discovery/import/apply` responses.
- Preserved existing top-level apply response fields for compatibility.
- Added summary counts for:
  - imported resources
  - linked-only resources
  - skipped resources
  - blocked resources
  - conflict resources
  - created records
  - linked records
- Included affected discovered resource IDs and created pool IDs in the summary.
- Added explicit OpenAPI entries for:
  - `POST /api/v1/discovery/import/preview`
  - `POST /api/v1/discovery/import/apply`
- Updated TypeScript API types for the apply summary and ID arrays.
- Added a persistent Discovery UI post-apply summary panel with aggregate counts, warnings, and item-level outcomes.
- Added a "View affected resources" action that switches to Merged Network flat view and seeds the search query with an affected resource identifier.
- Updated the Discovery UI apply call to send the full preview selection so skipped, blocked, conflict, and link-only rows remain visible in the returned post-apply details while the backend still only mutates importable rows.
- Added a `0.19.0` changelog entry.

## Behavior notes

- Existing clients can ignore `summary`; existing top-level fields remain.
- `linked_only`, `blocked`, and `conflicts` are derived from preview item statuses, so conflicts are not double-counted as blocked in the summary.
- The backend still skips non-importable rows during apply.
- The Merged Network jump uses the first affected provider resource, name, CIDR, or created pool ID because there is not yet a dedicated multi-resource merged-view filter.

## Testing

Ran through the Nix dev shell:

```bash
nix develop -c gofmt -w internal/domain/discovery.go internal/api/discovery_handlers.go internal/api/discovery_import_test.go internal/api/openapi.go
nix develop -c go test ./internal/api -run 'TestDiscoveryImport'
nix develop -c go test ./internal/api -run TestOpenAPI
nix develop -c npm --prefix ui test -- --run DiscoveryResourcesTab
nix develop -c go test ./...
nix develop -c npm --prefix ui run build
```

## Review notes

- Pipeline handoffs were written under `.pipeline/` locally:
  - `.pipeline/spec.md`
  - `.pipeline/changes.md`
  - `.pipeline/tests.md`
  - `.pipeline/review.md`
- Reviewer verdict: `approve`.

## Residual risks

- The "View affected resources" behavior is covered at component/helper level, but there is no full `DiscoveryPage` integration test that clicks through to `NetworkTab`.
- Browser screenshot coverage was not run; this change has focused component coverage plus a successful TypeScript/Vite build.
