### PR TITLE
Discovery: scope schema policy evaluation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.19.1] - 2026-06-29
+
+### Fixed
+- Merged Network schema policy evaluation now scopes duplicate CIDR and discovered-parent hierarchy checks according to the selected account, region, global, or manual policy, with policy scope evidence included in conflicts.
+- UI production builds now use a Vite 8/Rolldown-compatible manual chunk function instead of object-form `manualChunks`.
+
 ## [0.19.0] - 2026-06-28
 
 ### Added

--- a/docs/DISCOVERY.md
+++ b/docs/DISCOVERY.md
@@ -180,7 +180,12 @@ curl http://localhost:8080/api/v1/network/conflicts?schema_policy=global
 curl http://localhost:8080/api/v1/network/conflicts?schema_policy=manual
 ```
 
-`account_level` is the default conservative behavior. `region_level` scopes duplicate CIDR checks by region, `global` treats duplicate CIDRs anywhere as conflicts, and `manual` suppresses duplicate conflicts unless callers pass an explicit duplicate override.
+`account_level` is the default behavior and scopes duplicate CIDR checks and
+discovered parent lookup to each account. `region_level` scopes duplicate and
+parent checks to each account/region pair. `global` treats duplicate CIDRs and
+discovered parent IDs anywhere as shared. `manual` suppresses inferred duplicate
+and parent-placement conflicts unless callers pass an explicit duplicate
+override such as `duplicates=global`.
 
 ## AWS Setup
 

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -948,11 +948,11 @@ func duplicatePolicyKey(res domain.DiscoveredResource, policy domain.NetworkSche
 	case "manual":
 		return ""
 	case "region":
-		return strings.Join([]string{res.CIDR, res.Region}, "|")
+		return strings.Join([]string{res.CIDR, fmt.Sprintf("%d", res.AccountID), res.Region}, "|")
 	case "global":
 		return res.CIDR
 	default:
-		return res.CIDR
+		return strings.Join([]string{res.CIDR, fmt.Sprintf("%d", res.AccountID)}, "|")
 	}
 }
 
@@ -963,14 +963,30 @@ func duplicatePolicyConflict(matches []domain.DiscoveredResource, policy domain.
 	switch policy.DuplicateScope {
 	case "manual":
 		return false
-	case "global", "region":
-		return true
 	default:
-		accountsSeen := map[int64]bool{}
-		for _, res := range matches {
-			accountsSeen[res.AccountID] = true
-		}
-		return len(accountsSeen) > 1
+		return true
+	}
+}
+
+func duplicateConflictTitle(policy domain.NetworkSchemaPolicy) string {
+	switch policy.DuplicateScope {
+	case "region":
+		return "Duplicate CIDR in account region"
+	case "global":
+		return "Duplicate CIDR globally"
+	default:
+		return "Duplicate CIDR in account"
+	}
+}
+
+func duplicateConflictDescription(cidr string, policy domain.NetworkSchemaPolicy) string {
+	switch policy.DuplicateScope {
+	case "region":
+		return fmt.Sprintf("%s is discovered multiple times in the same account and region", cidr)
+	case "global":
+		return fmt.Sprintf("%s is discovered multiple times globally", cidr)
+	default:
+		return fmt.Sprintf("%s is discovered multiple times in the same account", cidr)
 	}
 }
 
@@ -1047,7 +1063,13 @@ func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkVi
 	}
 	resourceByProvider := make(map[string]domain.DiscoveredResource, len(resources))
 	for _, res := range resources {
-		resourceByProvider[resourceKey(res.AccountID, res.ResourceID)] = res
+		key := resourceKeyForPolicy(res, policy)
+		if key == "" {
+			continue
+		}
+		if _, exists := resourceByProvider[key]; !exists {
+			resourceByProvider[key] = res
+		}
 	}
 
 	issuesByNode, conflicts := ns.computeNetworkConflicts(resources, pools, accountByID, poolByID, resourceByProvider, policy)
@@ -1073,7 +1095,7 @@ func (ns *NetworkServer) buildNetworkView(ctx context.Context, filters networkVi
 		nodes = append(nodes, node)
 	}
 	for _, res := range resources {
-		node := ns.networkNodeFromResource(res, accountByID, poolByID, resourceByProvider)
+		node := ns.networkNodeFromResource(res, accountByID, poolByID, resourceByProvider, policy)
 		node.Relationships = relsByEntity["discovered:"+res.ID.String()]
 		if nodeIssues := issuesByNode[node.ID]; len(nodeIssues) > 0 {
 			node.Issues = append(node.Issues, nodeIssues...)
@@ -1160,7 +1182,7 @@ func networkNodeFromPool(pool domain.Pool, accounts map[int64]domain.Account) do
 	return node
 }
 
-func (ns *NetworkServer) networkNodeFromResource(res domain.DiscoveredResource, accounts map[int64]domain.Account, pools map[int64]domain.Pool, resources map[string]domain.DiscoveredResource) domain.NetworkNode {
+func (ns *NetworkServer) networkNodeFromResource(res domain.DiscoveredResource, accounts map[int64]domain.Account, pools map[int64]domain.Pool, resources map[string]domain.DiscoveredResource, policy domain.NetworkSchemaPolicy) domain.NetworkNode {
 	nodeID := resourceNodeID(res.ID)
 	state := "discovered"
 	source := "discovered"
@@ -1171,7 +1193,7 @@ func (ns *NetworkServer) networkNodeFromResource(res domain.DiscoveredResource, 
 		id := poolNodeID(*res.PoolID)
 		parentID = &id
 	} else if res.ParentResourceID != nil {
-		if parent, ok := resources[resourceKey(res.AccountID, *res.ParentResourceID)]; ok {
+		if parent, ok := resources[resourceParentKeyForPolicy(res, *res.ParentResourceID, policy)]; ok {
 			id := resourceNodeID(parent.ID)
 			parentID = &id
 		}
@@ -1285,8 +1307,8 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 				})
 			}
 		}
-		if res.ResourceType == domain.ResourceTypeSubnet && res.ParentResourceID != nil {
-			parent, ok := resourceByProvider[resourceKey(res.AccountID, *res.ParentResourceID)]
+		if res.ResourceType == domain.ResourceTypeSubnet && res.ParentResourceID != nil && policy.HierarchyScope != "manual" {
+			parent, ok := resourceByProvider[resourceParentKeyForPolicy(res, *res.ParentResourceID, policy)]
 			if !ok {
 				add(domain.NetworkConflict{
 					ID:                "missing-parent:" + res.ID.String(),
@@ -1302,7 +1324,7 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 					Regions:           []string{res.Region},
 					ObjectTypes:       []string{string(res.ResourceType)},
 					CIDR:              res.CIDR,
-					Evidence:          []string{"parent_provider_resource_id=" + *res.ParentResourceID, "policy=" + policy.Name},
+					Evidence:          []string{"parent_provider_resource_id=" + *res.ParentResourceID, "policy=" + policy.Name, "hierarchy_scope=" + policy.HierarchyScope},
 				})
 			} else if res.CIDR != "" && parent.CIDR != "" && !networkCIDRContains(parent.CIDR, res.CIDR) {
 				add(domain.NetworkConflict{
@@ -1319,7 +1341,7 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 					Regions:           []string{res.Region},
 					ObjectTypes:       []string{string(res.ResourceType), string(parent.ResourceType)},
 					CIDR:              res.CIDR,
-					Evidence:          []string{fmt.Sprintf("parent_cidr=%s", parent.CIDR), "policy=" + policy.Name},
+					Evidence:          []string{fmt.Sprintf("parent_cidr=%s", parent.CIDR), "policy=" + policy.Name, "hierarchy_scope=" + policy.HierarchyScope},
 				})
 			}
 		}
@@ -1451,8 +1473,8 @@ func (ns *NetworkServer) computeNetworkConflicts(resources []domain.DiscoveredRe
 			Type:              "duplicate_cidr",
 			Severity:          "critical",
 			Status:            "open",
-			Title:             "Duplicate CIDR across accounts",
-			Description:       fmt.Sprintf("%s is discovered in multiple accounts", cidr),
+			Title:             duplicateConflictTitle(policy),
+			Description:       duplicateConflictDescription(cidr, policy),
 			RecommendedAction: "Choose the authoritative account or mark the duplicate reviewed.",
 			NodeIDs:           nodeIDs,
 			DiscoveredIDs:     ids,
@@ -2044,6 +2066,23 @@ func networkObjectNodeID(id int64) string { return fmt.Sprintf("network_object:%
 
 func resourceKey(accountID int64, providerResourceID string) string {
 	return fmt.Sprintf("%d:%s", accountID, providerResourceID)
+}
+
+func resourceKeyForPolicy(res domain.DiscoveredResource, policy domain.NetworkSchemaPolicy) string {
+	return resourceParentKeyForPolicy(res, res.ResourceID, policy)
+}
+
+func resourceParentKeyForPolicy(res domain.DiscoveredResource, providerResourceID string, policy domain.NetworkSchemaPolicy) string {
+	switch policy.HierarchyScope {
+	case "manual":
+		return ""
+	case "region":
+		return strings.Join([]string{fmt.Sprintf("%d", res.AccountID), res.Region, providerResourceID}, ":")
+	case "global":
+		return providerResourceID
+	default:
+		return resourceKey(res.AccountID, providerResourceID)
+	}
 }
 
 func bestContainingPool(cidr string, pools map[int64]domain.Pool) *domain.Pool {

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -18,7 +18,7 @@ import (
 	"cloudpam/internal/storage"
 )
 
-func TestNetworkFlatShowsDiscoveredObjectsAndDuplicateConflict(t *testing.T) {
+func TestNetworkFlatShowsDiscoveredObjectsAndGlobalDuplicateConflict(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	a1, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:111111111111", Name: "prod", Provider: "aws"})
 	if err != nil {
@@ -41,7 +41,7 @@ func TestNetworkFlatShowsDiscoveredObjectsAndDuplicateConflict(t *testing.T) {
 		upsertDiscoveredForImportTest(t, ds, res)
 	}
 
-	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/flat", "", http.StatusOK)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/flat?schema_policy=global", "", http.StatusOK)
 	var resp domain.NetworkViewResponse
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal flat: %v", err)
@@ -395,6 +395,47 @@ func TestNetworkHierarchyPlacesVPCUnderPoolAndSubnetUnderVPC(t *testing.T) {
 	}
 }
 
+func TestNetworkSchemaPolicyChangesHierarchyEvaluation(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	subnetID := uuid.New()
+	parent := "vpc-shared"
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: vpcID, AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: parent, Name: "prod-vpc", CIDR: "10.81.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{ID: subnetID, AccountID: account.ID, Provider: "aws", Region: "us-west-2", ResourceType: domain.ResourceTypeSubnet, ResourceID: "subnet-cross-region", Name: "prod-subnet", CIDR: "10.81.1.0/24", ParentResourceID: &parent, Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/hierarchy?schema_policy=account_level", "", http.StatusOK)
+	var view domain.NetworkViewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &view); err != nil {
+		t.Fatalf("unmarshal account-level hierarchy: %v", err)
+	}
+	if !hierarchyHasParentChild(view.Items, "discovered:"+vpcID.String(), "discovered:"+subnetID.String()) {
+		t.Fatalf("account-level hierarchy should allow same-account cross-region parent: %+v", view.Items)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent&schema_policy=region_level", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal region-level conflicts: %v", err)
+	}
+	if conflicts.Total != 1 || !strings.Contains(strings.Join(conflicts.Items[0].Evidence, ","), "hierarchy_scope=region") {
+		t.Fatalf("region-level hierarchy should flag cross-region missing parent with policy evidence, got %+v", conflicts)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=missing_parent&schema_policy=manual", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal manual conflicts: %v", err)
+	}
+	if conflicts.Total != 0 {
+		t.Fatalf("manual hierarchy should suppress inferred missing-parent conflicts, got %+v", conflicts)
+	}
+}
+
 func TestNetworkConflictsExposeMissingParentAndResolveRequest(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
@@ -531,8 +572,24 @@ func TestNetworkSchemaPolicyChangesDuplicateDetection(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
 		t.Fatalf("unmarshal default conflicts: %v", err)
 	}
+	if conflicts.SchemaPolicy.Name != "account_level" || conflicts.Total != 1 {
+		t.Fatalf("default account-level policy should flag same-account duplicate, got %+v", conflicts)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=duplicate_cidr&schema_policy=account_level", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal account-level conflicts: %v", err)
+	}
+	if conflicts.Total != 1 || !strings.Contains(strings.Join(conflicts.Items[0].Evidence, ","), "duplicate_scope=account") {
+		t.Fatalf("account-level policy should flag same-account duplicate with evidence, got %+v", conflicts)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=duplicate_cidr&schema_policy=region_level", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal region-level conflicts: %v", err)
+	}
 	if conflicts.Total != 0 {
-		t.Fatalf("account-level policy should allow same-CIDR reuse inside one account, got %+v", conflicts)
+		t.Fatalf("region-level policy should allow same-CIDR reuse across regions in one account, got %+v", conflicts)
 	}
 
 	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=duplicate_cidr&schema_policy=global", "", http.StatusOK)
@@ -550,6 +607,14 @@ func TestNetworkSchemaPolicyChangesDuplicateDetection(t *testing.T) {
 	if conflicts.Total != 0 {
 		t.Fatalf("manual policy should suppress duplicate conflicts, got %+v", conflicts)
 	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=duplicate_cidr&schema_policy=custom&duplicates=global", "", http.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal custom global conflicts: %v", err)
+	}
+	if conflicts.SchemaPolicy.Name != "custom" || conflicts.SchemaPolicy.DuplicateScope != "global" || conflicts.Total != 1 {
+		t.Fatalf("custom policy with global duplicate override should flag duplicate, got %+v", conflicts)
+	}
 }
 
 func TestNetworkSchemaPolicyUsesPersistedDefaultAndQueryOverride(t *testing.T) {
@@ -558,10 +623,14 @@ func TestNetworkSchemaPolicyUsesPersistedDefaultAndQueryOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create account: %v", err)
 	}
+	otherAccount, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:210987654321", Name: "dev", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create other account: %v", err)
+	}
 	now := time.Now().UTC()
 	for _, res := range []domain.DiscoveredResource{
 		{ID: uuid.New(), AccountID: account.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-east", CIDR: "10.93.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
-		{ID: uuid.New(), AccountID: account.ID, Provider: "aws", Region: "us-west-2", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-west", CIDR: "10.93.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
+		{ID: uuid.New(), AccountID: otherAccount.ID, Provider: "aws", Region: "us-east-1", ResourceType: domain.ResourceTypeVPC, ResourceID: "vpc-dev", CIDR: "10.93.0.0/16", Status: domain.DiscoveryStatusActive, DiscoveredAt: now, LastSeenAt: now},
 	} {
 		upsertDiscoveredForImportTest(t, ds, res)
 	}
@@ -589,7 +658,7 @@ func TestNetworkSchemaPolicyUsesPersistedDefaultAndQueryOverride(t *testing.T) {
 		t.Fatalf("unmarshal override conflicts: %v", err)
 	}
 	if conflicts.SchemaPolicy.Name != "account_level" || conflicts.Total != 0 {
-		t.Fatalf("query override should use account-level policy, got %+v", conflicts)
+		t.Fatalf("query override should use account-scoped policy, got %+v", conflicts)
 	}
 }
 

--- a/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
+++ b/ui/src/__tests__/DiscoveryNetworkConflictList.test.tsx
@@ -80,8 +80,8 @@ const duplicateConflict: NetworkConflict = {
   id: 'duplicate-cidr:account:172.31.0.0_16',
   type: 'duplicate_cidr',
   severity: 'critical',
-  title: 'Duplicate CIDR across accounts',
-  description: '172.31.0.0/16 is discovered in multiple accounts',
+  title: 'Duplicate CIDR in account',
+  description: '172.31.0.0/16 is discovered multiple times in the same account',
   recommended_action: 'Choose the authoritative account or mark the duplicate reviewed.',
   pool_ids: [],
   account_ids: [7, 8],
@@ -276,6 +276,6 @@ describe('NetworkConflictList', () => {
     })
 
     expect(screen.getByText('Operator note: duplicate address space')).toBeTruthy()
-    expect(screen.getByText(/For AWS default VPC space, mark expected reuse ignored or defer it/i)).toBeTruthy()
+    expect(screen.getByText(/Mark expected reuse ignored or defer it/i)).toBeTruthy()
   })
 })

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -78,7 +78,7 @@ const NETWORK_TRIAGE_GUIDES = [
   {
     type: 'duplicate_cidr',
     label: 'Ignore expected reuse',
-    summary: 'Repeated CIDRs across accounts are often normal cloud tenancy. Review once, then ignore or defer expected reuse.',
+    summary: 'Repeated CIDRs can be normal in scoped tenancy. Review policy-scoped duplicates, then ignore or defer expected reuse.',
   },
 ] as const
 
@@ -1378,7 +1378,7 @@ function NetworkTriageGuide({
           </div>
           {schemaPolicy === 'account_level' && (
             <div className="mt-1 text-xs text-blue-800 dark:text-blue-300">
-              Account policy still flags same-CIDR resources across accounts. AWS default VPC ranges are usually review-and-ignore noise unless they share a real managed pool.
+              Account policy flags repeated CIDRs inside one account. Use region or global policy when tenancy boundaries follow regions or shared global pools.
             </div>
           )}
         </div>
@@ -2439,7 +2439,7 @@ function operatorNoteForConflict(conflict: NetworkConflict) {
     case 'duplicate_cidr':
       return {
         title: 'Operator note: duplicate address space',
-        body: 'Repeated CIDRs across cloud accounts can be normal. For AWS default VPC space, mark expected reuse ignored or defer it unless two records should point at the same managed pool.',
+        body: 'Repeated CIDRs can be normal when they cross the selected policy boundary. Mark expected reuse ignored or defer it unless two records should point at the same managed pool.',
       }
     case 'missing_parent':
       return {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -3,6 +3,16 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+function manualChunks(id: string): string | undefined {
+  const normalized = id.split('\\').join('/')
+  if (normalized.includes('/node_modules/react/') || normalized.includes('/node_modules/react-dom/') || normalized.includes('/node_modules/react-router-dom/')) {
+    return 'vendor-react'
+  }
+  if (normalized.includes('/node_modules/lucide-react/')) {
+    return 'vendor-icons'
+  }
+}
+
 export default defineConfig(({ mode }) => ({
   plugins: [react(), tailwindcss()],
   base: '/',
@@ -14,10 +24,7 @@ export default defineConfig(({ mode }) => ({
     cssMinify: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-icons': ['lucide-react'],
-        },
+        manualChunks,
         chunkFileNames: 'assets/[name]-[hash].js',
         entryFileNames: 'assets/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash][extname]',


### PR DESCRIPTION
## Summary
- scope merged-network duplicate CIDR detection by account, account/region, global, or manual/custom schema policy
- make discovered-parent hierarchy lookup follow the selected schema policy and include hierarchy scope evidence
- fix the Vite 8/Rolldown production build by changing `manualChunks` to a function
- update Discovery UI/docs/changelog copy for policy-scoped duplicate handling

Closes #193.

## Tests
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop -c go test ./internal/api -run 'TestNetworkSchemaPolicy|TestNetworkConflictsExposeMissingParent|TestNetworkHierarchy|TestNetworkFlatShowsDiscoveredObjectsAndGlobalDuplicateConflict'`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop -c go test ./internal/api`
- `npm run test -- DiscoveryNetworkConflictList.test.tsx`
- `npm run build` with Vite `8.0.16`

## Notes
- `npm ci --cache /tmp/cloudpam-npm-cache` initially hit registry DNS failure inside the sandbox; rerun with network access succeeded.
- Vite build output hash churn in `web/dist/index.html` was intentionally not committed.
