### PR TITLE
Discovery: enforce stale resource import policy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.21.0] - 2026-06-29
+
+### Changed
+- Discovery import and link workflows now block stale discovered resources until a fresh discovery marks them active, with preview evidence explaining the stale-resource decision.
+
 ## [0.20.0] - 2026-06-29
 
 ### Added

--- a/internal/api/discovery_handlers.go
+++ b/internal/api/discovery_handlers.go
@@ -238,6 +238,10 @@ func (d *DiscoveryServer) handleLink(w http.ResponseWriter, r *http.Request, id 
 			d.srv.writeErr(r.Context(), w, http.StatusBadRequest, "pool account does not match discovered resource account", "")
 			return
 		}
+		if err := validateDiscoveredResourceActiveForMutation(*resource); err != nil {
+			d.srv.writeErr(r.Context(), w, http.StatusBadRequest, err.Error(), "")
+			return
+		}
 
 		if err := d.store.LinkResourceToPool(r.Context(), id, body.PoolID); err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -561,6 +565,7 @@ func discoveryRelationshipEvidence(res domain.DiscoveredResource, values ...stri
 		"region=" + res.Region,
 		"resource_id=" + res.ResourceID,
 		"resource_type=" + string(res.ResourceType),
+		"discovery_status=" + string(res.Status),
 	}
 	if res.CIDR != "" {
 		evidence = append(evidence, "cidr="+res.CIDR)
@@ -569,6 +574,24 @@ func discoveryRelationshipEvidence(res domain.DiscoveredResource, values ...stri
 		if strings.TrimSpace(value) != "" {
 			evidence = append(evidence, value)
 		}
+	}
+	return evidence
+}
+
+func validateDiscoveredResourceActiveForMutation(res domain.DiscoveredResource) error {
+	if res.Status == domain.DiscoveryStatusActive {
+		return nil
+	}
+	return fmt.Errorf("discovered resource is %s; run discovery again before linking or importing it", res.Status)
+}
+
+func staleDiscoveryEvidence(res domain.DiscoveredResource) []string {
+	evidence := []string{
+		"discovery_status=" + string(res.Status),
+		"stale resources cannot be imported or linked until a fresh discovery marks them active",
+	}
+	if !res.LastSeenAt.IsZero() {
+		evidence = append(evidence, "last_seen_at="+res.LastSeenAt.UTC().Format(time.RFC3339))
 	}
 	return evidence
 }
@@ -593,6 +616,9 @@ func canForceDiscoveryImport(item domain.DiscoveryImportPreviewItem, opts discov
 		return false
 	}
 	if item.Status == "not_found" || item.Status == "already_linked" || item.Status == "linked_only" {
+		return false
+	}
+	if hasAnyIssue(item.Issues, "stale_resource") {
 		return false
 	}
 	if item.ResourceType != domain.ResourceTypeVPC && item.ResourceType != domain.ResourceTypeSubnet {
@@ -713,6 +739,9 @@ func (d *DiscoveryServer) previewDiscoveryImport(ctx context.Context, req domain
 		}
 		if res.Status != domain.DiscoveryStatusActive {
 			item.Issues = append(item.Issues, "stale_resource")
+			item.Evidence = append(item.Evidence, staleDiscoveryEvidence(*res)...)
+			addDiscoveryPreviewItem(&resp, item)
+			continue
 		}
 		if res.ResourceType != domain.ResourceTypeVPC && res.ResourceType != domain.ResourceTypeSubnet {
 			item.Status = "linked_only"

--- a/internal/api/discovery_import_test.go
+++ b/internal/api/discovery_import_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -229,6 +230,110 @@ func TestDiscoveryImportPreviewAndApplySelectedResources(t *testing.T) {
 	}
 	if len(pools) != 2 {
 		t.Fatalf("len(pools) = %d, want 2", len(pools))
+	}
+}
+
+func TestDiscoveryImportPreviewBlocksStaleResourcesAndApplySkips(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	now := time.Now().UTC()
+	staleID := uuid.New()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           staleID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-stale",
+		Name:         "stale-vpc",
+		CIDR:         "10.12.0.0/16",
+		Status:       domain.DiscoveryStatusStale,
+		DiscoveredAt: now.Add(-2 * time.Hour),
+		LastSeenAt:   now.Add(-1 * time.Hour),
+	})
+
+	body := fmt.Sprintf(`{"account_id":%d,"resource_ids":["%s"]}`, account.ID, staleID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/preview", body, http.StatusOK)
+	item := singleDiscoveryPreviewItem(t, rr)
+	if item.Status != "blocked" || item.ProposedAction != "none" || !containsString(item.Issues, "stale_resource") {
+		t.Fatalf("stale resource should be blocked: %+v", item)
+	}
+	if !containsString(item.Evidence, "discovery_status=stale") {
+		t.Fatalf("stale evidence missing status: %+v", item.Evidence)
+	}
+	if item.ProposedPoolID != nil || item.ProposedParentPoolID != nil {
+		t.Fatalf("stale resource should not receive import targets: %+v", item)
+	}
+
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, "/api/v1/discovery/import/apply", body, http.StatusOK)
+	var applied domain.DiscoveryImportApplyResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &applied); err != nil {
+		t.Fatalf("unmarshal apply: %v", err)
+	}
+	if applied.PoolsCreated != 0 || applied.ResourcesLinked != 0 || applied.Skipped != 1 {
+		t.Fatalf("stale resource should be skipped by apply: %+v", applied)
+	}
+	if applied.Summary.Blocked != 1 || applied.Summary.Imported != 0 || len(applied.Summary.AffectedResourceIDs) != 0 {
+		t.Fatalf("unexpected stale apply summary: %+v", applied.Summary)
+	}
+}
+
+func TestDiscoveryImportForceDoesNotAllowStaleResources(t *testing.T) {
+	item := domain.DiscoveryImportPreviewItem{
+		ResourceID:     uuid.New(),
+		ResourceType:   domain.ResourceTypeVPC,
+		CIDR:           "10.12.0.0/16",
+		Status:         "blocked",
+		ProposedAction: "create_pool",
+		Issues:         []string{"stale_resource"},
+	}
+	if canForceDiscoveryImport(item, discoveryImportApplyOptions{AllowBlocked: true}) {
+		t.Fatalf("stale blocked resource must not be force importable")
+	}
+}
+
+func TestDiscoveryLinkRejectsStaleResource(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	pool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-vpc", CIDR: "10.13.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	staleID := uuid.New()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           staleID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-stale-link",
+		Name:         "stale-link-vpc",
+		CIDR:         "10.13.0.0/16",
+		Status:       domain.DiscoveryStatusStale,
+		DiscoveredAt: now.Add(-2 * time.Hour),
+		LastSeenAt:   now.Add(-1 * time.Hour),
+	})
+
+	body := fmt.Sprintf(`{"pool_id":%d}`, pool.ID)
+	rr := doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/discovery/resources/%s/link", staleID), body, http.StatusBadRequest)
+	if !strings.Contains(rr.Body.String(), "run discovery again") {
+		t.Fatalf("expected stale link error, got %s", rr.Body.String())
+	}
+	res, err := ds.GetDiscoveredResource(t.Context(), staleID)
+	if err != nil {
+		t.Fatalf("get stale resource: %v", err)
+	}
+	if res.PoolID != nil {
+		t.Fatalf("stale resource should not be linked: %+v", res.PoolID)
 	}
 }
 

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -1789,6 +1789,9 @@ func validateNetworkConflictLinkAction(conflict domain.NetworkConflict, res doma
 	if res.PoolID != nil && *res.PoolID == req.PoolID {
 		return fmt.Errorf("discovered resource is already linked to this pool")
 	}
+	if err := validateDiscoveredResourceActiveForMutation(res); err != nil {
+		return err
+	}
 	if !req.Override {
 		if pool.AccountID != nil && *pool.AccountID != res.AccountID {
 			return fmt.Errorf("pool account does not match discovered resource account; set override to force")

--- a/internal/api/network_handlers_test.go
+++ b/internal/api/network_handlers_test.go
@@ -748,6 +748,56 @@ func TestNetworkConflictLinkActionLinksExactPoolAndResolves(t *testing.T) {
 	assertNetworkConflictAuditAction(t, discSrv.srv, conflicts.Items[0].ID, "network_conflict.link")
 }
 
+func TestNetworkConflictLinkActionRejectsStaleResourceEvenWithOverride(t *testing.T) {
+	discSrv, st, ds, _ := setupDiscoveryTestServer()
+	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	pool, err := st.CreatePool(t.Context(), domain.CreatePool{Name: "prod-vpc", CIDR: "10.101.0.0/16", Type: domain.PoolTypeVPC, AccountID: &account.ID})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	now := time.Now().UTC()
+	vpcID := uuid.New()
+	upsertDiscoveredForImportTest(t, ds, domain.DiscoveredResource{
+		ID:           vpcID,
+		AccountID:    account.ID,
+		Provider:     "aws",
+		Region:       "us-east-1",
+		ResourceType: domain.ResourceTypeVPC,
+		ResourceID:   "vpc-stale-link",
+		Name:         "stale-vpc",
+		CIDR:         "10.101.0.0/16",
+		Status:       domain.DiscoveryStatusStale,
+		DiscoveredAt: now.Add(-2 * time.Hour),
+		LastSeenAt:   now.Add(-1 * time.Hour),
+	})
+
+	rr := doJSON(t, discSrv.srv.mux, http.MethodGet, "/api/v1/network/conflicts?conflict_type=unlinked_exact_pool", "", http.StatusOK)
+	var conflicts domain.NetworkConflictListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &conflicts); err != nil {
+		t.Fatalf("unmarshal conflicts: %v", err)
+	}
+	if conflicts.Total != 1 {
+		t.Fatalf("expected one exact-pool conflict, got %+v", conflicts)
+	}
+
+	body := fmt.Sprintf(`{"discovered_id":"%s","pool_id":%d,"override":true}`, vpcID, pool.ID)
+	rr = doJSON(t, discSrv.srv.mux, http.MethodPost, fmt.Sprintf("/api/v1/network/conflicts/%s/actions/link", conflicts.Items[0].ID), body, http.StatusBadRequest)
+	if !strings.Contains(rr.Body.String(), "run discovery again") {
+		t.Fatalf("expected stale link error, got %s", rr.Body.String())
+	}
+	linked, err := ds.GetDiscoveredResource(t.Context(), vpcID)
+	if err != nil {
+		t.Fatalf("load stale resource: %v", err)
+	}
+	if linked.PoolID != nil {
+		t.Fatalf("stale resource should not be linked: %+v", linked)
+	}
+}
+
 func TestNetworkConflictLinkActionUpdatesExistingAssociation(t *testing.T) {
 	discSrv, st, ds, _ := setupDiscoveryTestServer()
 	account, err := st.CreateAccount(t.Context(), domain.CreateAccount{Key: "aws:123456789012", Name: "prod", Provider: "aws"})

--- a/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
+++ b/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { useState, type ComponentProps } from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import type { Account, DiscoveredResource, DiscoveryImportApplyResponse, Pool } from '../api/types'
-import { ImportApplySummaryPanel, ResourcesTab, importApplyResultQuery } from '../pages/DiscoveryPage'
+import type { Account, DiscoveredResource, DiscoveryImportApplyResponse, DiscoveryImportPreviewResponse, Pool } from '../api/types'
+import { ImportApplySummaryPanel, ImportPreviewModal, ResourcesTab, importApplyResultQuery } from '../pages/DiscoveryPage'
 
 const resources: DiscoveredResource[] = [
   {
@@ -160,7 +160,7 @@ function renderResourcesTab(overrides: Partial<ComponentProps<typeof ResourcesTa
 }
 
 describe('ResourcesTab', () => {
-  it('selects multiple unlinked resources and links them to a pool', () => {
+  it('links selected active resources to a pool', () => {
     const { onBulkLink } = renderResourcesTab()
 
     const activeCheckbox = screen.getAllByLabelText('Select prod-vpc')[0] as HTMLInputElement
@@ -172,14 +172,30 @@ describe('ResourcesTab', () => {
     expect(linkedCheckbox.disabled).toBe(true)
 
     fireEvent.click(activeCheckbox)
-    fireEvent.click(staleCheckbox)
 
-    expect(screen.getByText('2 selected')).toBeTruthy()
+    expect(screen.getByText('1 selected')).toBeTruthy()
 
     fireEvent.change(screen.getByLabelText('Pool for selected resources'), { target: { value: '42' } })
     fireEvent.click(screen.getByRole('button', { name: /Link selected/i }))
 
-    expect(onBulkLink).toHaveBeenCalledWith(['resource-active-vpc', 'resource-stale-subnet'], 42)
+    expect(onBulkLink).toHaveBeenCalledWith(['resource-active-vpc'], 42)
+  })
+
+  it('keeps stale resources selectable but blocks bulk linking', () => {
+    const { onBulkLink } = renderResourcesTab()
+
+    const staleCheckbox = screen.getAllByLabelText('Select stale-subnet')[0] as HTMLInputElement
+    expect(staleCheckbox.disabled).toBe(false)
+
+    fireEvent.click(staleCheckbox)
+    fireEvent.change(screen.getByLabelText('Pool for selected resources'), { target: { value: '42' } })
+
+    const linkButton = screen.getByRole('button', { name: /Link selected/i }) as HTMLButtonElement
+    expect(linkButton.disabled).toBe(true)
+    expect(screen.getByText(/1 stale selected; run discovery again before linking/i)).toBeTruthy()
+
+    fireEvent.click(linkButton)
+    expect(onBulkLink).not.toHaveBeenCalled()
   })
 
   it('filters bulk link pools to the selected account', () => {
@@ -234,6 +250,48 @@ describe('ResourcesTab', () => {
 
     expect(onPageChange).toHaveBeenCalledWith(3)
     expect(onPageSizeChange).toHaveBeenCalledWith(100)
+  })
+})
+
+describe('ImportPreviewModal', () => {
+  it('shows stale resource block evidence and disables apply when nothing is importable', () => {
+    const preview: DiscoveryImportPreviewResponse = {
+      importable: 0,
+      blocked: 1,
+      linked_only: 0,
+      already_linked: 0,
+      conflict_count: 0,
+      items: [
+        {
+          resource_id: 'resource-stale-vpc',
+          provider_resource_id: 'vpc-stale',
+          name: 'stale-vpc',
+          resource_type: 'vpc',
+          cidr: '10.80.0.0/16',
+          status: 'blocked',
+          proposed_action: 'none',
+          issues: ['stale_resource'],
+          evidence: [
+            'discovery_status=stale',
+            'stale resources cannot be imported or linked until a fresh discovery marks them active',
+          ],
+        },
+      ],
+    }
+
+    render(
+      <ImportPreviewModal
+        preview={preview}
+        pools={pools}
+        loading={false}
+        onClose={vi.fn()}
+        onApply={vi.fn()}
+      />,
+    )
+
+    expect(screen.getAllByText('stale resource requires fresh discovery').length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/fresh discovery marks them active/i).length).toBeGreaterThan(0)
+    expect((screen.getByRole('button', { name: /Apply import/i }) as HTMLButtonElement).disabled).toBe(true)
   })
 })
 

--- a/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
+++ b/ui/src/__tests__/DiscoveryResourcesTab.test.tsx
@@ -97,6 +97,7 @@ const accounts: Account[] = [
 ]
 
 function renderResourcesTab(overrides: Partial<ComponentProps<typeof ResourcesTab>> = {}) {
+  const onLink = vi.fn()
   const onBulkLink = vi.fn()
   const onPageChange = vi.fn()
   const onPageSizeChange = vi.fn()
@@ -124,7 +125,7 @@ function renderResourcesTab(overrides: Partial<ComponentProps<typeof ResourcesTa
       onTypeChange: vi.fn(),
       linkedFilter: '',
       onLinkedChange: vi.fn(),
-      onLink: vi.fn(),
+      onLink,
       onUnlink: vi.fn(),
       accounts,
       selectedAccountId: 1,
@@ -156,7 +157,7 @@ function renderResourcesTab(overrides: Partial<ComponentProps<typeof ResourcesTa
   }
 
   render(<Wrapper />)
-  return { onBulkLink, onPageChange, onPageSizeChange }
+  return { onLink, onBulkLink, onPageChange, onPageSizeChange }
 }
 
 describe('ResourcesTab', () => {
@@ -196,6 +197,17 @@ describe('ResourcesTab', () => {
 
     fireEvent.click(linkButton)
     expect(onBulkLink).not.toHaveBeenCalled()
+  })
+
+  it('disables row-level linking for stale resources', () => {
+    const { onLink } = renderResourcesTab()
+
+    const staleLinkButtons = screen.getAllByTitle('Stale resources require fresh discovery before linking') as HTMLButtonElement[]
+    expect(staleLinkButtons.length).toBeGreaterThan(0)
+    staleLinkButtons.forEach((button) => expect(button.disabled).toBe(true))
+
+    fireEvent.click(staleLinkButtons[0])
+    expect(onLink).not.toHaveBeenCalled()
   })
 
   it('filters bulk link pools to the selected account', () => {

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -397,10 +397,18 @@ export default function DiscoveryPage() {
   }
 
   async function handleLink(resource: DiscoveredResource) {
+    if (!isLinkableDiscoveryResource(resource)) {
+      showToast('Run discovery again before linking stale resources', 'error')
+      return
+    }
     setLinkingResource(resource)
   }
 
   async function handleApplyLink(resource: DiscoveredResource, poolId: number) {
+    if (!isLinkableDiscoveryResource(resource)) {
+      showToast('Run discovery again before linking stale resources', 'error')
+      return
+    }
     setLinkingLoading(true)
     try {
       await linkToPool(resource.id, poolId)
@@ -446,6 +454,10 @@ export default function DiscoveryPage() {
   }
 
   async function handleCreateAndLink(resource: DiscoveredResource, data: CreatePoolRequest) {
+    if (!isLinkableDiscoveryResource(resource)) {
+      showToast('Run discovery again before building from stale resources', 'error')
+      return
+    }
     setLinkingLoading(true)
     try {
       const pool = await createPool(data)
@@ -744,6 +756,10 @@ export default function DiscoveryPage() {
 
 function isSelectableDiscoveryResource(resource: DiscoveredResource) {
   return !resource.pool_id
+}
+
+function isLinkableDiscoveryResource(resource: DiscoveredResource) {
+  return isSelectableDiscoveryResource(resource) && resource.status === 'active'
 }
 
 type ResourceColumnKey =
@@ -2994,8 +3010,9 @@ export function ResourcesTab({
                     ) : (
                       <button
                         onClick={() => onLink(r)}
-                        title="Link to pool"
-                        className="p-1 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
+                        disabled={!isLinkableDiscoveryResource(r)}
+                        title={isLinkableDiscoveryResource(r) ? 'Link to pool' : 'Stale resources require fresh discovery before linking'}
+                        className="p-1 text-gray-400 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:text-blue-400"
                       >
                         <Link2 className="w-4 h-4" />
                       </button>
@@ -3459,8 +3476,9 @@ function ResourceCard({
         ) : (
           <button
             onClick={() => onLink(resource)}
-            title="Link to pool"
-            className="shrink-0 rounded p-1.5 text-gray-400 hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
+            disabled={!isLinkableDiscoveryResource(resource)}
+            title={isLinkableDiscoveryResource(resource) ? 'Link to pool' : 'Stale resources require fresh discovery before linking'}
+            className="shrink-0 rounded p-1.5 text-gray-400 hover:bg-blue-50 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
           >
             <Link2 className="h-4 w-4" />
           </button>

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -2759,6 +2759,9 @@ export function ResourcesTab({
   )
   const selectableResources = resources.filter(isSelectableDiscoveryResource)
   const selectableVisibleIds = selectableResources.map((resource) => resource.id)
+  const selectedVisibleResources = resources.filter((resource) => selectedResourceIds.includes(resource.id))
+  const selectedStaleResources = selectedVisibleResources.filter((resource) => resource.status !== 'active')
+  const staleSelectionBlocksLink = selectedStaleResources.length > 0
   const selectedVisibleCount = selectableVisibleIds.filter((id) => selectedResourceIds.includes(id)).length
   const allVisibleSelected = selectableVisibleIds.length > 0 && selectedVisibleCount === selectableVisibleIds.length
   const someVisibleSelected = selectedVisibleCount > 0 && selectedVisibleCount < selectableVisibleIds.length
@@ -2897,12 +2900,18 @@ export function ResourcesTab({
           <button
             type="button"
             onClick={() => bulkLinkPool > 0 && onBulkLink(selectedResourceIds, bulkLinkPool)}
-            disabled={bulkLinking || selectedResourceIds.length === 0 || bulkLinkPool <= 0}
+            disabled={bulkLinking || selectedResourceIds.length === 0 || bulkLinkPool <= 0 || staleSelectionBlocksLink}
+            title={staleSelectionBlocksLink ? 'Stale resources require fresh discovery before linking' : undefined}
             className="inline-flex items-center gap-1.5 rounded bg-blue-600 px-3 py-1.5 text-white hover:bg-blue-700 disabled:opacity-50"
           >
             {bulkLinking ? <Loader2 className="h-4 w-4 animate-spin" /> : <Link2 className="h-4 w-4" />}
             Link selected
           </button>
+          {staleSelectionBlocksLink && (
+            <div className="basis-full text-xs text-yellow-700 dark:text-yellow-300">
+              {selectedStaleResources.length} stale selected; run discovery again before linking.
+            </div>
+          )}
         </div>
       </div>
 
@@ -3234,7 +3243,7 @@ function PoolLabel({ poolId, pools }: { poolId: number; pools: Pool[] }) {
   )
 }
 
-function ImportPreviewModal({
+export function ImportPreviewModal({
   preview,
   pools,
   loading,
@@ -3389,6 +3398,7 @@ function importActionLabel(item: DiscoveryImportPreviewItem) {
 }
 
 function issueLabel(issue: string) {
+  if (issue === 'stale_resource') return 'stale resource requires fresh discovery'
   return issue.replace(/_/g, ' ')
 }
 


### PR DESCRIPTION
## Summary
- block stale discovered resources from import preview/apply and direct pool linking
- prevent conflict import/link overrides from mutating stale discovered resources
- show stale import-preview evidence and disable bulk linking when selected rows are stale
- add 0.21.0 changelog entry

Closes #199

## Tests
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./internal/api -run 'TestDiscoveryImportPreviewBlocksStaleResourcesAndApplySkips|TestDiscoveryImportForceDoesNotAllowStaleResources|TestDiscoveryLinkRejectsStaleResource|TestNetworkConflictLinkActionRejectsStaleResourceEvenWithOverride'`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./internal/api`
- `npm test -- --run DiscoveryResourcesTab`
- `npm run build`
- `git diff --check`

## Review
- Pipeline reviewer verdict: approve

## Residual risks
- Full `go test ./...` was not run; changed backend package `internal/api` passed.
- UI stale selection blocking is based on currently loaded table rows; backend validation remains the source of truth for stale IDs selected from another page.
- No Playwright screenshot was captured.
