### PR TITLE
AI: allow authless OpenAI-compatible endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,9 +433,9 @@ When adding endpoints:
 - `CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS`: Comma-separated account IDs to skip
 
 ### AI Planning
-- `CLOUDPAM_LLM_API_KEY`: API key for OpenAI-compatible endpoint (empty = AI disabled)
+- `CLOUDPAM_LLM_API_KEY`: API key for OpenAI-compatible endpoint (optional when using an authless custom endpoint)
 - `CLOUDPAM_LLM_MODEL`: Model name (default: `gpt-4o`)
-- `CLOUDPAM_LLM_ENDPOINT`: Base URL override for Ollama/vLLM/Azure (empty = OpenAI default)
+- `CLOUDPAM_LLM_ENDPOINT`: Base URL override for Ollama/vLLM/Azure; with no API key, a non-empty endpoint enables authless custom-provider mode
 - `CLOUDPAM_LLM_MAX_TOKENS`: Max response tokens (default: `4096`)
 - `CLOUDPAM_LLM_TEMPERATURE`: Temperature (default: `0.7`)
 

--- a/cmd/cloudpam/main.go
+++ b/cmd/cloudpam/main.go
@@ -203,13 +203,11 @@ func main() {
 
 	// Initialize AI planning subsystem
 	llmCfg := llm.ConfigFromEnv()
-	var llmProvider llm.Provider
-	if llmCfg.APIKey != "" {
-		llmProvider = llm.NewOpenAIProvider(llmCfg)
+	llmProvider := llm.NewOpenAIProvider(llmCfg)
+	if llmProvider.Available() {
 		logger.Info("ai planning enabled", "model", llmCfg.Model, "endpoint", llmCfg.Endpoint)
 	} else {
-		llmProvider = llm.NewOpenAIProvider(llmCfg) // unconfigured; Available() returns false
-		logger.Info("ai planning disabled (set CLOUDPAM_LLM_API_KEY to enable)")
+		logger.Info("ai planning disabled (set CLOUDPAM_LLM_API_KEY or CLOUDPAM_LLM_ENDPOINT to enable)")
 	}
 	convStore := selectConversationStore(logger, store)
 	aiService := planning.NewAIPlanningService(analysisService, convStore, store, llmProvider)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This repository does not use an `Unreleased` changelog section. Add a concrete
 patch or minor version entry for every user-facing change.
 
+## [0.21.1] - 2026-06-30
+
+### Fixed
+- Authless OpenAI-compatible LLM endpoints configured with `CLOUDPAM_LLM_ENDPOINT` are now treated as available without requiring `CLOUDPAM_LLM_API_KEY`.
+
 ## [0.21.0] - 2026-06-29
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ patch or minor version entry for every user-facing change.
 
 ### Fixed
 - Authless OpenAI-compatible LLM endpoints configured with `CLOUDPAM_LLM_ENDPOINT` are now treated as available without requiring `CLOUDPAM_LLM_API_KEY`.
+- Whitespace-only `CLOUDPAM_LLM_ENDPOINT` values now fall back to the default OpenAI endpoint, and AI planning unavailable messages now mention the endpoint-based configuration path.
 
 ## [0.21.0] - 2026-06-29
 

--- a/internal/api/ai_handlers.go
+++ b/internal/api/ai_handlers.go
@@ -56,7 +56,7 @@ func (a *AIPlanningServer) handleChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !a.aiSvc.Available() {
-		a.srv.writeErr(r.Context(), w, http.StatusServiceUnavailable, "ai planning not available", "set CLOUDPAM_LLM_API_KEY to enable")
+		a.srv.writeErr(r.Context(), w, http.StatusServiceUnavailable, "ai planning not available", "set CLOUDPAM_LLM_API_KEY or CLOUDPAM_LLM_ENDPOINT to enable")
 		return
 	}
 

--- a/internal/planning/llm/openai.go
+++ b/internal/planning/llm/openai.go
@@ -31,8 +31,8 @@ func (p *OpenAIProvider) Available() bool {
 }
 
 func (p *OpenAIProvider) baseURL() string {
-	if p.cfg.Endpoint != "" {
-		return strings.TrimRight(strings.TrimSpace(p.cfg.Endpoint), "/")
+	if endpoint := strings.TrimSpace(p.cfg.Endpoint); endpoint != "" {
+		return strings.TrimRight(endpoint, "/")
 	}
 	return "https://api.openai.com/v1"
 }

--- a/internal/planning/llm/openai.go
+++ b/internal/planning/llm/openai.go
@@ -25,12 +25,14 @@ func NewOpenAIProvider(cfg Config) *OpenAIProvider {
 	}
 }
 
-func (p *OpenAIProvider) Name() string     { return "openai" }
-func (p *OpenAIProvider) Available() bool   { return p.cfg.APIKey != "" }
+func (p *OpenAIProvider) Name() string { return "openai" }
+func (p *OpenAIProvider) Available() bool {
+	return strings.TrimSpace(p.cfg.APIKey) != "" || strings.TrimSpace(p.cfg.Endpoint) != ""
+}
 
 func (p *OpenAIProvider) baseURL() string {
 	if p.cfg.Endpoint != "" {
-		return strings.TrimRight(p.cfg.Endpoint, "/")
+		return strings.TrimRight(strings.TrimSpace(p.cfg.Endpoint), "/")
 	}
 	return "https://api.openai.com/v1"
 }
@@ -107,8 +109,8 @@ func (p *OpenAIProvider) Complete(ctx context.Context, messages []Message, opts 
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if p.cfg.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+p.cfg.APIKey)
+	if apiKey := strings.TrimSpace(p.cfg.APIKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 
 	resp, err := p.client.Do(req)
@@ -179,8 +181,8 @@ func (p *OpenAIProvider) StreamComplete(ctx context.Context, messages []Message,
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "text/event-stream")
-	if p.cfg.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+p.cfg.APIKey)
+	if apiKey := strings.TrimSpace(p.cfg.APIKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 
 	resp, err := p.client.Do(req)

--- a/internal/planning/llm/openai_test.go
+++ b/internal/planning/llm/openai_test.go
@@ -199,6 +199,17 @@ func TestOpenAIProviderAvailableWithAuthlessEndpoint(t *testing.T) {
 	}
 }
 
+func TestOpenAIProviderBaseURLIgnoresWhitespaceEndpoint(t *testing.T) {
+	provider := NewOpenAIProvider(Config{
+		APIKey:   "test-key",
+		Endpoint: " \t",
+	})
+
+	if got := provider.baseURL(); got != "https://api.openai.com/v1" {
+		t.Errorf("expected default OpenAI base URL, got %q", got)
+	}
+}
+
 func TestOpenAIProviderAPIError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)

--- a/internal/planning/llm/openai_test.go
+++ b/internal/planning/llm/openai_test.go
@@ -92,6 +92,50 @@ func TestOpenAIProviderComplete(t *testing.T) {
 	}
 }
 
+func TestOpenAIProviderCompleteWithoutAPIKeyOmitsAuthorization(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("expected no auth header, got %q", auth)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := openaiResponse{
+			Choices: []struct {
+				Message      openaiMessage `json:"message"`
+				FinishReason string        `json:"finish_reason"`
+			}{
+				{
+					Message:      openaiMessage{Role: "assistant", Content: "Hello authless!"},
+					FinishReason: "stop",
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	provider := NewOpenAIProvider(Config{
+		APIKey:   " \t",
+		Model:    "local-model",
+		Endpoint: " " + ts.URL + "/v1/ ",
+	})
+
+	if !provider.Available() {
+		t.Fatal("expected provider to be available with custom endpoint and no API key")
+	}
+
+	resp, err := provider.Complete(context.Background(), []Message{
+		{Role: "user", Content: "Hello"},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	if resp.Content != "Hello authless!" {
+		t.Errorf("expected authless response, got %q", resp.Content)
+	}
+}
+
 func TestOpenAIProviderStreamComplete(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -140,6 +184,18 @@ func TestOpenAIProviderNotAvailable(t *testing.T) {
 	provider := NewOpenAIProvider(Config{})
 	if provider.Available() {
 		t.Error("expected provider to not be available with empty API key")
+	}
+
+	provider = NewOpenAIProvider(Config{APIKey: " \t", Endpoint: " \n"})
+	if provider.Available() {
+		t.Error("expected provider to not be available with whitespace-only config")
+	}
+}
+
+func TestOpenAIProviderAvailableWithAuthlessEndpoint(t *testing.T) {
+	provider := NewOpenAIProvider(Config{Endpoint: "http://127.0.0.1:11434/v1"})
+	if !provider.Available() {
+		t.Error("expected provider to be available with custom endpoint and no API key")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes one scoped finding from #223: authless OpenAI-compatible endpoints were rejected by provider availability even though request code already supported omitting Authorization.
- Treats `CLOUDPAM_LLM_ENDPOINT` as sufficient LLM provider configuration without `CLOUDPAM_LLM_API_KEY`.
- Trims endpoint and API-key configuration before request use, and omits Authorization for empty or whitespace-only keys.
- Adds focused LLM provider regression tests and a `0.21.1` changelog entry.

## Tests

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./internal/planning/llm`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./cmd/cloudpam ./internal/planning/llm`

## Review

- Pipeline reviewer verdict: approve.

## Residual Risks

- Full repository test suite was not run.
- No live end-to-end request was performed against an external authless OpenAI-compatible server.
- #223 is a broad tracker; this PR addresses only the first scoped finding.
