### PR TITLE
API: cache block account metadata per request

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ patch or minor version entry for every user-facing change.
 
 ## [0.21.1] - 2026-06-30
 
+### Changed
+- Blocks listing now uses request-local account metadata caching so repeated account references do not trigger duplicate account lookups while account updates remain visible on the next request.
+
 ### Fixed
 - Authless OpenAI-compatible LLM endpoints configured with `CLOUDPAM_LLM_ENDPOINT` are now treated as available without requiring `CLOUDPAM_LLM_API_KEY`.
 - Whitespace-only `CLOUDPAM_LLM_ENDPOINT` values now fall back to the default OpenAI endpoint, and AI planning unavailable messages now mention the endpoint-based configuration path.

--- a/internal/api/block_handlers.go
+++ b/internal/api/block_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/netip"
@@ -8,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"cloudpam/internal/domain"
 )
 
 type blockInfo struct {
@@ -24,6 +27,62 @@ type blockInfo struct {
 	ExistsElsewhereName string `json:"exists_elsewhere_name,omitempty"`
 }
 
+type blockAccountMeta struct {
+	Name        string
+	Platform    string
+	Tier        string
+	Environment string
+	Regions     []string
+}
+
+type blockAccountResolver struct {
+	load func(context.Context) ([]domain.Account, error)
+
+	loaded   bool
+	accounts map[int64]blockAccountMeta
+}
+
+func newBlockAccountResolver(load func(context.Context) ([]domain.Account, error)) *blockAccountResolver {
+	return &blockAccountResolver{load: load}
+}
+
+// metadata returns account metadata from a request-local cache. The resolver is
+// created inside each blocks request and discarded when the response is written,
+// so account creates, updates, and deletes are automatically visible on the next
+// request without explicit cross-request invalidation.
+func (r *blockAccountResolver) metadata(ctx context.Context, accountID int64) (blockAccountMeta, bool, error) {
+	if err := r.ensureLoaded(ctx); err != nil {
+		return blockAccountMeta{}, false, err
+	}
+	meta, ok := r.accounts[accountID]
+	if ok {
+		meta.Regions = append([]string(nil), meta.Regions...)
+	}
+	return meta, ok, nil
+}
+
+func (r *blockAccountResolver) ensureLoaded(ctx context.Context) error {
+	if r.loaded {
+		return nil
+	}
+	accs, err := r.load(ctx)
+	if err != nil {
+		return err
+	}
+	r.accounts = make(map[int64]blockAccountMeta, len(accs))
+	for _, a := range accs {
+		r.accounts[a.ID] = blockAccountMeta{
+			Name:        a.Name,
+			Platform:    a.Platform,
+			Tier:        a.Tier,
+			Environment: a.Environment,
+			Regions:     append([]string(nil), a.Regions...),
+		}
+	}
+	r.loaded = true
+	return nil
+}
+
 // GET /api/v1/blocks?accounts=1,2&pools=10,11
 // Returns all assigned blocks (sub-pools), optionally filtered by account IDs and parent pool IDs.
 func (s *Server) handleBlocksList(w http.ResponseWriter, r *http.Request) {
@@ -33,24 +92,7 @@ func (s *Server) handleBlocksList(w http.ResponseWriter, r *http.Request) {
 		s.writeErr(r.Context(), w, http.StatusInternalServerError, "internal error", err.Error())
 		return
 	}
-	accs, err := s.store.ListAccounts(ctx)
-	if err != nil {
-		s.writeErr(r.Context(), w, http.StatusInternalServerError, "internal error", err.Error())
-		return
-	}
-	// Build lookups
-	accName := map[int64]string{}
-	accMeta := map[int64]struct {
-		Platform, Tier, Environment string
-		Regions                     []string
-	}{}
-	for _, a := range accs {
-		accName[a.ID] = a.Name
-		accMeta[a.ID] = struct {
-			Platform, Tier, Environment string
-			Regions                     []string
-		}{Platform: a.Platform, Tier: a.Tier, Environment: a.Environment, Regions: a.Regions}
-	}
+	accountResolver := newBlockAccountResolver(s.store.ListAccounts)
 	poolName := map[int64]string{}
 	for _, p := range ps {
 		poolName[p.ID] = p.Name
@@ -157,10 +199,13 @@ func (s *Server) handleBlocksList(w http.ResponseWriter, r *http.Request) {
 			r.ParentName = poolName[*p.ParentID]
 		}
 		if p.AccountID != nil {
-			if n, ok := accName[*p.AccountID]; ok {
-				r.AccountName = n
+			m, ok, err := accountResolver.metadata(ctx, *p.AccountID)
+			if err != nil {
+				s.writeErr(ctx, w, http.StatusInternalServerError, "internal error", err.Error())
+				return
 			}
-			if m, ok := accMeta[*p.AccountID]; ok {
+			if ok {
+				r.AccountName = m.Name
 				r.AccountPlatform = m.Platform
 				r.AccountTier = m.Tier
 				r.AccountEnvironment = m.Environment
@@ -283,16 +328,7 @@ func (s *Server) blocksForPool(w http.ResponseWriter, r *http.Request, id int64)
 			}
 		}
 	}
-	// Account id -> name map
-	accs, err := s.store.ListAccounts(ctx)
-	if err != nil {
-		s.writeErr(r.Context(), w, http.StatusInternalServerError, "internal error", err.Error())
-		return
-	}
-	accName := map[int64]string{}
-	for _, a := range accs {
-		accName[a.ID] = a.Name
-	}
+	accountResolver := newBlockAccountResolver(s.store.ListAccounts)
 	out := make([]blockInfo, 0, len(blocks))
 	for _, b := range blocks {
 		bi := blockInfo{CIDR: b, PrefixLen: npl, Hosts: hosts}
@@ -302,8 +338,13 @@ func (s *Server) blocksForPool(w http.ResponseWriter, r *http.Request, id int64)
 			bi.AssignedName = info.name
 			if info.accountID != nil {
 				bi.AssignedAccountID = *info.accountID
-				if n, ok := accName[*info.accountID]; ok {
-					bi.AssignedAccountName = n
+				meta, ok, err := accountResolver.metadata(ctx, *info.accountID)
+				if err != nil {
+					s.writeErr(r.Context(), w, http.StatusInternalServerError, "internal error", err.Error())
+					return
+				}
+				if ok {
+					bi.AssignedAccountName = meta.Name
 				}
 			}
 		} else {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -37,6 +37,29 @@ func setupTestServer() (*Server, *storage.MemoryStore) {
 	return srv, st
 }
 
+type countingAccountStore struct {
+	*storage.MemoryStore
+	listAccountsCalls int
+}
+
+func (s *countingAccountStore) ListAccounts(ctx context.Context) ([]domain.Account, error) {
+	s.listAccountsCalls++
+	return s.MemoryStore.ListAccounts(ctx)
+}
+
+func setupCountingAccountServer() (*Server, *countingAccountStore) {
+	st := &countingAccountStore{MemoryStore: storage.NewMemoryStore()}
+	mux := stdhttp.NewServeMux()
+	logger := observability.NewLogger(observability.Config{
+		Level:  "info",
+		Format: "json",
+		Output: io.Discard,
+	})
+	srv := NewServer(mux, st, logger, nil, nil)
+	srv.registerUnprotectedTestRoutes()
+	return srv, st
+}
+
 func doJSON(t *testing.T, mux *stdhttp.ServeMux, method, path, body string, code int) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(method, path, strings.NewReader(body))
@@ -419,6 +442,120 @@ func TestAnalytics_MetadataInBlocks(t *testing.T) {
 		if it.AccountID == nil || *it.AccountID != a1.ID {
 			t.Fatalf("filter mismatch: %+v", it)
 		}
+	}
+}
+
+func TestBlocksListCachesAccountMetadataPerRequest(t *testing.T) {
+	srv, st := setupCountingAccountServer()
+
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:111111111111","name":"Prod","platform":"aws","environment":"prd","regions":["us-east-1"]}`, stdhttp.StatusCreated)
+	var account struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &account); err != nil {
+		t.Fatalf("unmarshal account: %v", err)
+	}
+
+	rr = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.60.0.0/16"}`, stdhttp.StatusCreated)
+	var root poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil {
+		t.Fatalf("unmarshal root: %v", err)
+	}
+	doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"prod-a","cidr":"10.60.1.0/24","parent_id":`+strconv.FormatInt(root.ID, 10)+`,"account_id":`+strconv.FormatInt(account.ID, 10)+`}`, stdhttp.StatusCreated)
+	doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"prod-b","cidr":"10.60.2.0/24","parent_id":`+strconv.FormatInt(root.ID, 10)+`,"account_id":`+strconv.FormatInt(account.ID, 10)+`}`, stdhttp.StatusCreated)
+
+	st.listAccountsCalls = 0
+	rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/blocks?page_size=all", "", stdhttp.StatusOK)
+	var env struct {
+		Items []struct {
+			AccountID          *int64   `json:"account_id"`
+			AccountName        string   `json:"account_name"`
+			AccountPlatform    string   `json:"account_platform"`
+			AccountEnvironment string   `json:"account_environment"`
+			AccountRegions     []string `json:"account_regions"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal blocks: %v", err)
+	}
+	if st.listAccountsCalls != 1 {
+		t.Fatalf("ListAccounts calls = %d, want 1", st.listAccountsCalls)
+	}
+
+	var matchingRows int
+	for _, item := range env.Items {
+		if item.AccountID == nil || *item.AccountID != account.ID {
+			continue
+		}
+		matchingRows++
+		if item.AccountName != "Prod" || item.AccountPlatform != "aws" || item.AccountEnvironment != "prd" || len(item.AccountRegions) != 1 || item.AccountRegions[0] != "us-east-1" {
+			t.Fatalf("account metadata mismatch: %+v", item)
+		}
+	}
+	if matchingRows != 2 {
+		t.Fatalf("matching account rows = %d, want 2", matchingRows)
+	}
+
+	doJSON(t, srv.mux, stdhttp.MethodPatch, "/api/v1/accounts/"+strconv.FormatInt(account.ID, 10), `{"name":"Prod Renamed","platform":"aws","environment":"prd","regions":["us-west-2"]}`, stdhttp.StatusOK)
+	rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/blocks?page_size=all", "", stdhttp.StatusOK)
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal blocks after account update: %v", err)
+	}
+	if st.listAccountsCalls != 2 {
+		t.Fatalf("ListAccounts calls after second request = %d, want 2", st.listAccountsCalls)
+	}
+	for _, item := range env.Items {
+		if item.AccountID != nil && *item.AccountID == account.ID && (item.AccountName != "Prod Renamed" || len(item.AccountRegions) != 1 || item.AccountRegions[0] != "us-west-2") {
+			t.Fatalf("stale account metadata after update: %+v", item)
+		}
+	}
+}
+
+func TestPoolBlocksCachesAccountMetadataPerRequest(t *testing.T) {
+	srv, st := setupCountingAccountServer()
+
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:222222222222","name":"Shared"}`, stdhttp.StatusCreated)
+	var account struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &account); err != nil {
+		t.Fatalf("unmarshal account: %v", err)
+	}
+	rr = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"root","cidr":"10.61.0.0/22"}`, stdhttp.StatusCreated)
+	var root poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &root); err != nil {
+		t.Fatalf("unmarshal root: %v", err)
+	}
+	doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"shared-a","cidr":"10.61.0.0/24","parent_id":`+strconv.FormatInt(root.ID, 10)+`,"account_id":`+strconv.FormatInt(account.ID, 10)+`}`, stdhttp.StatusCreated)
+	doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools", `{"name":"shared-b","cidr":"10.61.1.0/24","parent_id":`+strconv.FormatInt(root.ID, 10)+`,"account_id":`+strconv.FormatInt(account.ID, 10)+`}`, stdhttp.StatusCreated)
+
+	st.listAccountsCalls = 0
+	rr = doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/pools/"+strconv.FormatInt(root.ID, 10)+"/blocks?new_prefix_len=24&page_size=all", "", stdhttp.StatusOK)
+	var env struct {
+		Items []struct {
+			Used                bool   `json:"used"`
+			AssignedAccountID   int64  `json:"assigned_account_id"`
+			AssignedAccountName string `json:"assigned_account_name"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal pool blocks: %v", err)
+	}
+	if st.listAccountsCalls != 1 {
+		t.Fatalf("ListAccounts calls = %d, want 1", st.listAccountsCalls)
+	}
+	var usedRows int
+	for _, item := range env.Items {
+		if !item.Used {
+			continue
+		}
+		usedRows++
+		if item.AssignedAccountID != account.ID || item.AssignedAccountName != "Shared" {
+			t.Fatalf("assigned account metadata mismatch: %+v", item)
+		}
+	}
+	if usedRows != 2 {
+		t.Fatalf("used rows = %d, want 2", usedRows)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a request-local account metadata resolver for blocks endpoints.
- Reuses a single account metadata load for repeated account references in `/api/v1/blocks` and `/api/v1/pools/{id}/blocks`.
- Documents cache invalidation in code: the resolver is discarded after each request, so account updates are visible on the next request.
- Adds call-count regression tests and a `0.21.1` changelog note.

Closes #31.

## Tests

- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./internal/api -run 'TestBlocks|TestPoolBlocks|TestAnalytics_MetadataInBlocks'`
- `env XDG_CACHE_HOME=/tmp/nix-cache nix develop --command go test ./internal/api`

## Review

- Pipeline reviewer verdict: approve.

## Residual Risks

- Full repository tests were not run.
- SQLite/PostgreSQL-specific tests were not run because the change is confined to API handler request-local account metadata resolution.
