### PR TITLE
UI: fix API client contract for empty responses and raw CSV import

### DIFF
--- a/ui/src/__tests__/ImportExportModal.test.tsx
+++ b/ui/src/__tests__/ImportExportModal.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ImportExportModal from '../components/ImportExportModal'
+import { post, postRaw } from '../api/client'
+
+vi.mock('../api/client', () => ({
+  post: vi.fn(),
+  postRaw: vi.fn(),
+}))
+
+const showToast = vi.fn()
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ showToast }),
+}))
+
+const mockPost = vi.mocked(post)
+const mockPostRaw = vi.mocked(postRaw)
+
+const csv = 'key,name\nacct-a,Account A\nacct-b,Account B\n'
+
+function selectCSVFile() {
+  const file = new File([csv], 'accounts.csv', { type: 'text/csv' })
+  // jsdom's Blob implementation has no text(); browsers do.
+  Object.defineProperty(file, 'text', { value: () => Promise.resolve(csv) })
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement
+  fireEvent.change(input, { target: { files: [file] } })
+}
+
+describe('ImportExportModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('posts the CSV file contents as a raw body, not JSON', async () => {
+    mockPostRaw.mockResolvedValue({ created: 2, skipped: 0, errors: [] })
+    render(<ImportExportModal open onClose={() => {}} />)
+
+    selectCSVFile()
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+
+    await waitFor(() => {
+      expect(mockPostRaw).toHaveBeenCalledWith('/api/v1/import/accounts', csv)
+    })
+    expect(mockPost).not.toHaveBeenCalled()
+
+    const [, body] = mockPostRaw.mock.calls[0]
+    expect(body).not.toContain('\\n')
+    expect(body).toBe(csv)
+  })
+
+  it('targets the selected import type', async () => {
+    mockPostRaw.mockResolvedValue({ created: 0, skipped: 0, errors: [] })
+    render(<ImportExportModal open onClose={() => {}} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'pools' } })
+    selectCSVFile()
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+
+    await waitFor(() => {
+      expect(mockPostRaw).toHaveBeenCalledWith('/api/v1/import/pools', csv)
+    })
+  })
+})

--- a/ui/src/__tests__/client.test.ts
+++ b/ui/src/__tests__/client.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiRequestError, del, get, post, postRaw } from '../api/client'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function noContentResponse() {
+  return new Response(null, { status: 204 })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('request empty-body handling', () => {
+  it('resolves DELETE requests that return 204 No Content', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(noContentResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(del('/api/v1/accounts/1')).resolves.toBeUndefined()
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/accounts/1',
+      expect.objectContaining({ method: 'DELETE', credentials: 'same-origin' }),
+    )
+  })
+
+  it('resolves successful responses with an empty body and no content type', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(del('/api/v1/auth/keys/abc')).resolves.toBeUndefined()
+  })
+
+  it('resolves successful responses declaring content-length: 0', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('', { status: 200, headers: { 'Content-Length': '0' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(del('/api/v1/discovery/resources/r1/link')).resolves.toBeUndefined()
+  })
+
+  it('still throws for non-JSON error responses such as an HTML 500 page', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<html><body>boom</body></html>', {
+        status: 500,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(del('/api/v1/accounts/1')).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      status: 500,
+    })
+  })
+
+  it('still throws the API error payload for JSON error responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ error: 'pool has children' }, 409))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(del('/api/v1/pools/3')).rejects.toBeInstanceOf(ApiRequestError)
+  })
+
+  it('still returns parsed JSON bodies for successful responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ keys: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(get('/api/v1/auth/keys')).resolves.toEqual({ keys: [] })
+  })
+})
+
+describe('postRaw', () => {
+  it('sends the body verbatim with a text/csv content type', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ created: 2, skipped: 0, errors: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const csv = 'key,name\nacct-a,Account A\nacct-b,Account B\n'
+    await expect(postRaw('/api/v1/import/accounts', csv)).resolves.toEqual({
+      created: 2,
+      skipped: 0,
+      errors: [],
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('same-origin')
+    expect(init.headers['Content-Type']).toBe('text/csv')
+    expect(init.body).toBe(csv)
+  })
+
+  it('includes the CSRF token header like other state-changing requests', async () => {
+    document.cookie = 'csrf_token=raw-token-123'
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ created: 0, skipped: 0, errors: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await postRaw('/api/v1/import/pools', 'name,cidr\n')
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers['X-CSRF-Token']).toBe('raw-token-123')
+    document.cookie = 'csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT'
+  })
+
+  it('differs from post(), which JSON-encodes the body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const csv = 'key,name\nacct-a,Account A\n'
+    await post('/api/v1/import/accounts', csv)
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers['Content-Type']).toBe('application/json')
+    expect(init.body).toBe(JSON.stringify(csv))
+  })
+})

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -16,8 +16,26 @@ function getCSRFToken(): string | null {
   return match ? match[1] : null
 }
 
-async function request<T>(path: string, options?: RequestInit): Promise<T> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+interface RequestOptions extends Omit<RequestInit, 'headers'> {
+  headers?: Record<string, string>
+}
+
+// Successful responses are allowed to carry no payload (e.g. 204 No Content from
+// DELETE endpoints), and those statuses never have a readable body.
+function isNoContent(res: Response): boolean {
+  return res.status === 204 || res.status === 205 || res.headers.get('content-length') === '0'
+}
+
+async function readBody(res: Response): Promise<string> {
+  try {
+    return await res.text()
+  } catch {
+    return ''
+  }
+}
+
+async function request<T>(path: string, options?: RequestOptions): Promise<T> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json', ...options?.headers }
 
   // Add CSRF token for state-changing requests
   if (options?.method && options.method !== 'GET' && options.method !== 'HEAD') {
@@ -29,8 +47,8 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
   const res = await fetch(path, {
     credentials: 'same-origin',
-    headers,
     ...options,
+    headers,
   })
 
   // On 401, dispatch logout event so the auth context can clear state
@@ -38,14 +56,33 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     window.dispatchEvent(new CustomEvent('auth:logout'))
   }
 
+  // A successful response with no content is not an error; callers of these
+  // endpoints (e.g. del()) expect void.
+  if (res.ok && isNoContent(res)) {
+    return undefined as T
+  }
+
   const contentType = res.headers.get('content-type') || ''
+  const text = await readBody(res)
+
+  if (res.ok && text.trim() === '') {
+    return undefined as T
+  }
+
   if (!contentType.includes('application/json')) {
     throw new ApiRequestError(res.status, {
       error: `Unexpected response (${res.status}): server returned ${contentType || 'non-JSON'}`,
     })
   }
 
-  const body = await res.json()
+  let body: unknown
+  try {
+    body = JSON.parse(text)
+  } catch {
+    throw new ApiRequestError(res.status, {
+      error: `Unexpected response (${res.status}): server returned malformed JSON`,
+    })
+  }
 
   if (!res.ok) {
     throw new ApiRequestError(res.status, body as ApiError)
@@ -58,6 +95,16 @@ export function post<T>(path: string, data: unknown): Promise<T> {
   return request<T>(path, {
     method: 'POST',
     body: JSON.stringify(data),
+  })
+}
+
+// postRaw sends the body verbatim (no JSON encoding) for endpoints that parse the
+// raw request body, such as the CSV import handlers.
+export function postRaw<T>(path: string, body: string, contentType = 'text/csv'): Promise<T> {
+  return request<T>(path, {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body,
   })
 }
 

--- a/ui/src/components/ImportExportModal.tsx
+++ b/ui/src/components/ImportExportModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react'
 import { Download, Upload, X, FileText } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
-import { post } from '../api/client'
+import { postRaw } from '../api/client'
 import type { ImportResult } from '../api/types'
 
 interface ImportExportModalProps {
@@ -76,7 +76,8 @@ export default function ImportExportModal({ open, onClose }: ImportExportModalPr
     setImportResult(null)
     try {
       const text = await importFile.text()
-      const result = await post<ImportResult>(`/api/v1/import/${importType}`, text)
+      // The server parses the request body as raw CSV, not JSON.
+      const result = await postRaw<ImportResult>(`/api/v1/import/${importType}`, text)
       setImportResult(result)
       showToast(`Imported ${result.created} ${importType}`, 'success')
     } catch (err) {


### PR DESCRIPTION
Fixes two distinct, user-visible bugs in the shared API client. Both were reported as findings in #223 (six of the 58 entries there describe these two bugs).

## Bug 1 — successful 204 responses reported as errors

`request()` in `ui/src/api/client.ts` checked the response content type *before* checking `res.ok`, and threw `ApiRequestError` for anything non-JSON. Endpoints returning `204 No Content` send neither a body nor a JSON content type, so every successful DELETE surfaced to the user as a failure.

Affected endpoints include `DELETE /api/v1/accounts/{id}` (`account_handlers.go:220`) and `DELETE /api/v1/auth/keys/{id}` (`auth_handlers.go:524`), reached from `useApiKeys`, `useAccounts`, `usePools`, `useUsers`, `useRoles`, `useDiscovery`, `useAIPlanner`, `useOIDCAdmin`, and `BlocksPage`.

Successful empty responses (204/205, `content-length: 0`, or an empty body on a chunked response) now resolve. Genuine non-JSON *error* responses — an HTML 500 page, say — still throw with the same message as before.

## Bug 2 — CSV import posted as a JSON string

`ImportExportModal.handleImport()` read the file with `.text()` and passed the string to `post()`, which `JSON.stringify`s the body and sets `Content-Type: application/json`. The server handlers do `csv.NewReader(r.Body)` directly (`export_handlers.go:348` and `:446`) and never inspect the content type, so they received a JSON-quoted string with escaped newlines. **UI-driven CSV import did not work.**

Adds `postRaw()`, which sends the body verbatim as `text/csv` while preserving the CSRF token and `same-origin` credentials. No server change was needed — the UI was the broken side.

## Tests

Two new test files, 11 cases. No existing test was modified.

- `client.test.ts` — `del()` resolving on 204 / empty 200 / `content-length: 0`; still throwing on HTML 500 and JSON 409; JSON success still parsed; `postRaw` sending the body verbatim with the CSRF header; contrast case showing `post()` JSON-encodes the same input.
- `ImportExportModal.test.tsx` — selecting a CSV file and importing calls `postRaw` with the exact raw CSV and never calls `post`.

## Verification

```
npx tsc --noEmit          clean
npx vitest run            15 files, 94 tests passed
go build ./... && go test ./...   pass
```

Refs #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)