### PR TITLE
API: close backend security and data-loss findings

### DIFF
--- a/internal/api/export_handlers.go
+++ b/internal/api/export_handlers.go
@@ -5,18 +5,95 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"cloudpam/internal/auth"
 	"cloudpam/internal/domain"
 	"cloudpam/internal/storage"
 )
 
+// parseExportDatasets returns the set of known datasets named by the datasets
+// query parameter. Unknown names are ignored.
+func parseExportDatasets(datasetsQ string) map[string]bool {
+	want := map[string]bool{}
+	for _, d := range strings.Split(datasetsQ, ",") {
+		d = strings.TrimSpace(strings.ToLower(d))
+		if d == "accounts" || d == "pools" || d == "blocks" {
+			want[d] = true
+		}
+	}
+	return want
+}
+
+// exportRequiredResources returns the RBAC resources the caller must be able to
+// read for the requested datasets. It mirrors the data handleExport loads: the
+// accounts dataset emits account records, the pools dataset emits pool records,
+// and the blocks dataset emits pool records enriched with account metadata, so
+// it requires both.
+func exportRequiredResources(want map[string]bool) []string {
+	var resources []string
+	if want["accounts"] || want["blocks"] {
+		resources = append(resources, auth.ResourceAccounts)
+	}
+	if want["pools"] || want["blocks"] {
+		resources = append(resources, auth.ResourcePools)
+	}
+	return resources
+}
+
+// RequireExportPermissionsMiddleware enforces per-dataset read permissions for
+// the export endpoint. A caller holding only pools:read must not be able to
+// export account data, so each requested dataset is checked against the
+// resource that actually backs it. Must be used after an auth middleware.
+func RequireExportPermissionsMiddleware(logger *slog.Logger) Middleware {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			if auth.GetEffectiveRole(ctx) == auth.RoleNone {
+				writeJSON(w, http.StatusUnauthorized, apiError{Error: "unauthorized"})
+				return
+			}
+
+			want := parseExportDatasets(r.URL.Query().Get("datasets"))
+			for _, resource := range exportRequiredResources(want) {
+				if err := auth.RequirePermission(ctx, resource, auth.ActionRead); err == nil {
+					continue
+				}
+
+				attrs := appendRequestID(ctx, []any{
+					"method", r.Method,
+					"path", r.URL.Path,
+					"required_resource", resource,
+					"required_action", auth.ActionRead,
+				})
+				if key := auth.APIKeyFromContext(ctx); key != nil {
+					attrs = append(attrs, "api_key_id", key.ID)
+					attrs = append(attrs, "api_key_prefix", key.Prefix)
+				}
+				logger.WarnContext(ctx, "authorization denied", attrs...)
+
+				writeJSON(w, http.StatusForbidden, apiError{Error: "forbidden"})
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // GET /api/v1/export?datasets=accounts,pools,blocks&accounts_fields=...&pools_fields=...&blocks_fields=...&accounts=1,2&pools=3,4
 // Returns a ZIP archive containing separate CSV files per selected dataset.
+// Per-dataset RBAC is enforced by RequireExportPermissionsMiddleware.
 func (s *Server) handleExport(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		s.writeErr(r.Context(), w, http.StatusMethodNotAllowed, "method not allowed", "")
@@ -29,13 +106,7 @@ func (s *Server) handleExport(w http.ResponseWriter, r *http.Request) {
 		s.writeErr(r.Context(), w, http.StatusBadRequest, "datasets is required", "")
 		return
 	}
-	want := map[string]bool{}
-	for _, d := range strings.Split(datasetsQ, ",") {
-		d = strings.TrimSpace(strings.ToLower(d))
-		if d == "accounts" || d == "pools" || d == "blocks" {
-			want[d] = true
-		}
-	}
+	want := parseExportDatasets(datasetsQ)
 	if len(want) == 0 {
 		s.writeErr(r.Context(), w, http.StatusBadRequest, "no valid datasets requested", "")
 		return

--- a/internal/api/export_permissions_test.go
+++ b/internal/api/export_permissions_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"cloudpam/internal/auth"
+)
+
+// exportPermTestHandler reports whether the wrapped handler was reached.
+func exportPermTestHandler(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		*called = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestRequireExportPermissionsMiddleware(t *testing.T) {
+	poolsOnly := &auth.APIKey{ID: "pools-only", Scopes: []string{"pools:read"}}
+	accountsOnly := &auth.APIKey{ID: "accounts-only", Scopes: []string{"accounts:read"}}
+	both := &auth.APIKey{ID: "both", Scopes: []string{"pools:read", "accounts:read"}}
+
+	tests := []struct {
+		name        string
+		key         *auth.APIKey
+		datasets    string
+		wantStatus  int
+		wantHandler bool
+	}{
+		{"pools key exports pools", poolsOnly, "pools", http.StatusOK, true},
+		{"pools key cannot export accounts", poolsOnly, "accounts", http.StatusForbidden, false},
+		{"pools key cannot export blocks", poolsOnly, "blocks", http.StatusForbidden, false},
+		{"pools key cannot export accounts alongside pools", poolsOnly, "pools,accounts", http.StatusForbidden, false},
+		{"accounts key exports accounts", accountsOnly, "accounts", http.StatusOK, true},
+		{"accounts key cannot export pools", accountsOnly, "pools", http.StatusForbidden, false},
+		{"key with both scopes exports everything", both, "accounts,pools,blocks", http.StatusOK, true},
+		{"unknown datasets reach the handler for a 400", poolsOnly, "bogus", http.StatusOK, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called bool
+			wrapped := RequireExportPermissionsMiddleware(newTestLogger())(exportPermTestHandler(&called))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/export?datasets="+tt.datasets, nil)
+			req = req.WithContext(auth.ContextWithAPIKey(req.Context(), tt.key))
+
+			rr := httptest.NewRecorder()
+			wrapped.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rr.Code, tt.wantStatus)
+			}
+			if called != tt.wantHandler {
+				t.Errorf("handler called = %v, want %v", called, tt.wantHandler)
+			}
+		})
+	}
+}
+
+func TestRequireExportPermissionsMiddlewareAllowsAdminRole(t *testing.T) {
+	var called bool
+	wrapped := RequireExportPermissionsMiddleware(newTestLogger())(exportPermTestHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/export?datasets=accounts,pools,blocks", nil)
+	req = req.WithContext(auth.ContextWithRole(req.Context(), auth.RoleAdmin))
+
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if !called {
+		t.Error("handler should have been called")
+	}
+}
+
+func TestRequireExportPermissionsMiddlewareDeniesUnauthenticated(t *testing.T) {
+	var called bool
+	wrapped := RequireExportPermissionsMiddleware(newTestLogger())(exportPermTestHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/export?datasets=pools", nil)
+
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+	if called {
+		t.Error("handler should not have been called")
+	}
+}
+
+func TestExportRequiredResources(t *testing.T) {
+	tests := []struct {
+		datasets string
+		want     []string
+	}{
+		{"", nil},
+		{"pools", []string{auth.ResourcePools}},
+		{"accounts", []string{auth.ResourceAccounts}},
+		{"blocks", []string{auth.ResourceAccounts, auth.ResourcePools}},
+		{"accounts,pools", []string{auth.ResourceAccounts, auth.ResourcePools}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.datasets, func(t *testing.T) {
+			got := exportRequiredResources(parseExportDatasets(tt.datasets))
+			if len(got) != len(tt.want) {
+				t.Fatalf("resources = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("resources = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -217,10 +217,9 @@ func (s *Server) RegisterProtectedRoutes(keyStore auth.KeyStore, sessionStore au
 	poolsReadMW := RequirePermissionMiddleware(auth.ResourcePools, auth.ActionRead, slogger)
 	s.handleOpenAPIRoute("/api/v1/blocks", dualMW(poolsReadMW(http.HandlerFunc(s.handleBlocksList))))
 
-	// Export endpoint - requires pools:read and accounts:read
-	exportPermMW := RequireAnyPermissionMiddleware([]auth.Permission{
-		{Resource: auth.ResourcePools, Action: auth.ActionRead},
-	}, slogger)
+	// Export endpoint - permissions depend on the requested datasets:
+	// accounts data requires accounts:read, pool data requires pools:read.
+	exportPermMW := RequireExportPermissionsMiddleware(slogger)
 	s.handleOpenAPIRoute("/api/v1/export", dualMW(exportPermMW(http.HandlerFunc(s.handleExport))))
 
 	// Schema planner endpoints - require pools:create

--- a/internal/audit/sqlite.go
+++ b/internal/audit/sqlite.go
@@ -15,6 +15,9 @@ import (
 // SQLiteAuditLogger is a SQLite-backed implementation of AuditLogger.
 type SQLiteAuditLogger struct {
 	db *sql.DB
+	// ownDB is true when this logger opened db itself and is therefore
+	// responsible for closing it.
+	ownDB bool
 }
 
 // NewSQLiteAuditLogger creates a new SQLite-backed audit logger.
@@ -28,16 +31,21 @@ func NewSQLiteAuditLogger(dsn string) (*SQLiteAuditLogger, error) {
 		_ = db.Close()
 		return nil, err
 	}
-	return &SQLiteAuditLogger{db: db}, nil
+	return &SQLiteAuditLogger{db: db, ownDB: true}, nil
 }
 
 // NewSQLiteAuditLoggerFromDB creates a new SQLite-backed audit logger using an existing DB connection.
+// The handle stays owned by the caller: Close is a no-op for this logger.
 func NewSQLiteAuditLoggerFromDB(db *sql.DB) *SQLiteAuditLogger {
 	return &SQLiteAuditLogger{db: db}
 }
 
-// Close closes the database connection.
+// Close closes the database connection when this logger opened it.
+// Loggers built from a caller-owned handle leave it open.
 func (s *SQLiteAuditLogger) Close() error {
+	if !s.ownDB {
+		return nil
+	}
 	return s.db.Close()
 }
 

--- a/internal/audit/sqlite_test.go
+++ b/internal/audit/sqlite_test.go
@@ -1,0 +1,80 @@
+//go:build sqlite
+
+package audit
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite" // CGO-less SQLite driver
+)
+
+func newAuditTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := "file:" + filepath.Join(t.TempDir(), "audit.db") + "?_fk=1"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec(`CREATE TABLE audit_logs (
+		id TEXT PRIMARY KEY,
+		timestamp TEXT NOT NULL,
+		actor TEXT,
+		actor_type TEXT,
+		action TEXT,
+		resource_type TEXT,
+		resource_id TEXT,
+		resource_name TEXT,
+		changes TEXT,
+		request_id TEXT,
+		ip_address TEXT,
+		status_code INTEGER
+	)`); err != nil {
+		t.Fatalf("create audit_logs: %v", err)
+	}
+	return db
+}
+
+func TestSQLiteAuditLoggerCloseLeavesBorrowedDBOpen(t *testing.T) {
+	ctx := context.Background()
+	db := newAuditTestDB(t)
+
+	logger := NewSQLiteAuditLoggerFromDB(db)
+	if err := logger.Log(ctx, &AuditEvent{Actor: "tester", Action: "create"}); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+
+	if err := logger.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// The caller still owns the handle, so it must remain usable.
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatalf("borrowed db was closed by the audit logger: %v", err)
+	}
+	if err := logger.Log(ctx, &AuditEvent{Actor: "tester", Action: "update"}); err != nil {
+		t.Fatalf("Log after Close on borrowed handle: %v", err)
+	}
+}
+
+func TestSQLiteAuditLoggerCloseClosesOwnedDB(t *testing.T) {
+	ctx := context.Background()
+	dsn := "file:" + filepath.Join(t.TempDir(), "owned.db") + "?_fk=1"
+
+	logger, err := NewSQLiteAuditLogger(dsn)
+	if err != nil {
+		t.Fatalf("NewSQLiteAuditLogger: %v", err)
+	}
+	if err := logger.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := logger.db.PingContext(ctx); err == nil {
+		t.Fatal("expected the self-opened handle to be closed")
+	}
+}

--- a/internal/discovery/aws/collector.go
+++ b/internal/discovery/aws/collector.go
@@ -144,78 +144,112 @@ func displayRegion(region string) string {
 	return region
 }
 
-func (c *Collector) discoverVPCs(ctx context.Context, client ec2API, account domain.Account, region string, now time.Time) ([]domain.DiscoveredResource, error) {
-	out, err := client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{})
-	if err != nil {
-		return nil, err
+// nextPageToken returns the token for the next page, or "" when the listing is
+// exhausted. A token identical to the current one is treated as exhausted so a
+// misbehaving endpoint cannot spin the caller forever.
+func nextPageToken(current, next *string) string {
+	token := aws.ToString(next)
+	if token == "" || token == aws.ToString(current) {
+		return ""
 	}
+	return token
+}
 
+func (c *Collector) discoverVPCs(ctx context.Context, client ec2API, account domain.Account, region string, now time.Time) ([]domain.DiscoveredResource, error) {
 	var resources []domain.DiscoveredResource
-	for _, vpc := range out.Vpcs {
-		name := extractTagName(vpc.Tags)
-		meta := map[string]string{
-			"state": string(vpc.State),
-		}
-		if vpc.IsDefault != nil && *vpc.IsDefault {
-			meta["is_default"] = "true"
+
+	var token *string
+	for {
+		out, err := client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{NextToken: token})
+		if err != nil {
+			return nil, err
 		}
 
-		resources = append(resources, domain.DiscoveredResource{
-			ID:           uuid.New(),
-			AccountID:    account.ID,
-			Provider:     "aws",
-			Region:       region,
-			ResourceType: domain.ResourceTypeVPC,
-			ResourceID:   aws.ToString(vpc.VpcId),
-			Name:         name,
-			CIDR:         aws.ToString(vpc.CidrBlock),
-			Status:       domain.DiscoveryStatusActive,
-			Metadata:     meta,
-			DiscoveredAt: now,
-			LastSeenAt:   now,
-		})
+		for _, vpc := range out.Vpcs {
+			name := extractTagName(vpc.Tags)
+			meta := map[string]string{
+				"state": string(vpc.State),
+			}
+			if vpc.IsDefault != nil && *vpc.IsDefault {
+				meta["is_default"] = "true"
+			}
+
+			resources = append(resources, domain.DiscoveredResource{
+				ID:           uuid.New(),
+				AccountID:    account.ID,
+				Provider:     "aws",
+				Region:       region,
+				ResourceType: domain.ResourceTypeVPC,
+				ResourceID:   aws.ToString(vpc.VpcId),
+				Name:         name,
+				CIDR:         aws.ToString(vpc.CidrBlock),
+				Status:       domain.DiscoveryStatusActive,
+				Metadata:     meta,
+				DiscoveredAt: now,
+				LastSeenAt:   now,
+			})
+		}
+
+		next := nextPageToken(token, out.NextToken)
+		if next == "" {
+			break
+		}
+		token = aws.String(next)
 	}
 	return resources, nil
 }
 
 func (c *Collector) discoverSubnets(ctx context.Context, client ec2API, account domain.Account, region string, now time.Time) ([]domain.DiscoveredResource, error) {
-	out, err := client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{})
-	if err != nil {
-		return nil, err
-	}
-
 	var resources []domain.DiscoveredResource
-	for _, subnet := range out.Subnets {
-		name := extractTagName(subnet.Tags)
-		vpcID := aws.ToString(subnet.VpcId)
-		az := aws.ToString(subnet.AvailabilityZone)
-		meta := map[string]string{
-			"availability_zone": az,
-			"state":             string(subnet.State),
-		}
-		if subnet.AvailableIpAddressCount != nil {
-			meta["available_ips"] = fmt.Sprintf("%d", *subnet.AvailableIpAddressCount)
+
+	var token *string
+	for {
+		out, err := client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{NextToken: token})
+		if err != nil {
+			return nil, err
 		}
 
-		resources = append(resources, domain.DiscoveredResource{
-			ID:               uuid.New(),
-			AccountID:        account.ID,
-			Provider:         "aws",
-			Region:           region,
-			ResourceType:     domain.ResourceTypeSubnet,
-			ResourceID:       aws.ToString(subnet.SubnetId),
-			Name:             name,
-			CIDR:             aws.ToString(subnet.CidrBlock),
-			ParentResourceID: &vpcID,
-			Status:           domain.DiscoveryStatusActive,
-			Metadata:         meta,
-			DiscoveredAt:     now,
-			LastSeenAt:       now,
-		})
+		for _, subnet := range out.Subnets {
+			name := extractTagName(subnet.Tags)
+			vpcID := aws.ToString(subnet.VpcId)
+			az := aws.ToString(subnet.AvailabilityZone)
+			meta := map[string]string{
+				"availability_zone": az,
+				"state":             string(subnet.State),
+			}
+			if subnet.AvailableIpAddressCount != nil {
+				meta["available_ips"] = fmt.Sprintf("%d", *subnet.AvailableIpAddressCount)
+			}
+
+			resources = append(resources, domain.DiscoveredResource{
+				ID:               uuid.New(),
+				AccountID:        account.ID,
+				Provider:         "aws",
+				Region:           region,
+				ResourceType:     domain.ResourceTypeSubnet,
+				ResourceID:       aws.ToString(subnet.SubnetId),
+				Name:             name,
+				CIDR:             aws.ToString(subnet.CidrBlock),
+				ParentResourceID: &vpcID,
+				Status:           domain.DiscoveryStatusActive,
+				Metadata:         meta,
+				DiscoveredAt:     now,
+				LastSeenAt:       now,
+			})
+		}
+
+		next := nextPageToken(token, out.NextToken)
+		if next == "" {
+			break
+		}
+		token = aws.String(next)
 	}
 	return resources, nil
 }
 
+// discoverElasticIPs issues a single DescribeAddresses call: unlike
+// DescribeVpcs and DescribeSubnets, the EC2 DescribeAddresses response carries
+// no NextToken and is not paginated.
 func (c *Collector) discoverElasticIPs(ctx context.Context, client ec2API, account domain.Account, region string, now time.Time) ([]domain.DiscoveredResource, error) {
 	out, err := client.DescribeAddresses(ctx, &ec2.DescribeAddressesInput{})
 	if err != nil {

--- a/internal/discovery/aws/pagination_test.go
+++ b/internal/discovery/aws/pagination_test.go
@@ -1,0 +1,160 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"cloudpam/internal/domain"
+)
+
+// pagedEC2 serves DescribeVpcs and DescribeSubnets one page at a time, keyed by
+// the NextToken the collector echoes back. An unknown token is an error so a
+// collector that drops pagination is caught rather than silently truncating.
+type pagedEC2 struct {
+	vpcPages    [][]ec2types.Vpc
+	subnetPages [][]ec2types.Subnet
+	addresses   []ec2types.Address
+
+	vpcCalls    int
+	subnetCalls int
+	addrCalls   int
+}
+
+func pageIndex(token *string) (int, error) {
+	if token == nil {
+		return 0, nil
+	}
+	var idx int
+	if _, err := fmt.Sscanf(*token, "page-%d", &idx); err != nil {
+		return 0, fmt.Errorf("unexpected page token %q", *token)
+	}
+	return idx, nil
+}
+
+func nextTokenFor(idx, total int) *string {
+	if idx+1 >= total {
+		return nil
+	}
+	return awssdk.String(fmt.Sprintf("page-%d", idx+1))
+}
+
+func (f *pagedEC2) DescribeVpcs(_ context.Context, in *ec2.DescribeVpcsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	f.vpcCalls++
+	idx, err := pageIndex(in.NextToken)
+	if err != nil {
+		return nil, err
+	}
+	if idx >= len(f.vpcPages) {
+		return nil, fmt.Errorf("vpc page %d out of range", idx)
+	}
+	return &ec2.DescribeVpcsOutput{Vpcs: f.vpcPages[idx], NextToken: nextTokenFor(idx, len(f.vpcPages))}, nil
+}
+
+func (f *pagedEC2) DescribeSubnets(_ context.Context, in *ec2.DescribeSubnetsInput, _ ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	f.subnetCalls++
+	idx, err := pageIndex(in.NextToken)
+	if err != nil {
+		return nil, err
+	}
+	if idx >= len(f.subnetPages) {
+		return nil, fmt.Errorf("subnet page %d out of range", idx)
+	}
+	return &ec2.DescribeSubnetsOutput{Subnets: f.subnetPages[idx], NextToken: nextTokenFor(idx, len(f.subnetPages))}, nil
+}
+
+func (f *pagedEC2) DescribeAddresses(_ context.Context, _ *ec2.DescribeAddressesInput, _ ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error) {
+	f.addrCalls++
+	return &ec2.DescribeAddressesOutput{Addresses: f.addresses}, nil
+}
+
+func TestDiscoverFollowsPaginationAcrossAllPages(t *testing.T) {
+	client := &pagedEC2{
+		vpcPages: [][]ec2types.Vpc{
+			{{VpcId: awssdk.String("vpc-1"), CidrBlock: awssdk.String("10.0.0.0/16"), State: ec2types.VpcStateAvailable}},
+			{{VpcId: awssdk.String("vpc-2"), CidrBlock: awssdk.String("10.1.0.0/16"), State: ec2types.VpcStateAvailable}},
+			{{VpcId: awssdk.String("vpc-3"), CidrBlock: awssdk.String("10.2.0.0/16"), State: ec2types.VpcStateAvailable}},
+		},
+		subnetPages: [][]ec2types.Subnet{
+			{{SubnetId: awssdk.String("subnet-1"), VpcId: awssdk.String("vpc-1"), CidrBlock: awssdk.String("10.0.1.0/24")}},
+			{{SubnetId: awssdk.String("subnet-2"), VpcId: awssdk.String("vpc-2"), CidrBlock: awssdk.String("10.1.1.0/24")}},
+		},
+		addresses: []ec2types.Address{{AllocationId: awssdk.String("eipalloc-1"), PublicIp: awssdk.String("203.0.113.10")}},
+	}
+	collector := newTestCollector(map[string]ec2API{"us-east-1": client})
+
+	resources, err := collector.Discover(context.Background(), domain.Account{ID: 7, Regions: []string{"us-east-1"}})
+	if err != nil {
+		t.Fatalf("Discover() unexpected error: %v", err)
+	}
+
+	byType := map[domain.CloudResourceType][]string{}
+	for _, res := range resources {
+		byType[res.ResourceType] = append(byType[res.ResourceType], res.ResourceID)
+	}
+
+	if got, want := len(byType[domain.ResourceTypeVPC]), 3; got != want {
+		t.Errorf("VPCs = %v, want %d entries", byType[domain.ResourceTypeVPC], want)
+	}
+	if got, want := len(byType[domain.ResourceTypeSubnet]), 2; got != want {
+		t.Errorf("subnets = %v, want %d entries", byType[domain.ResourceTypeSubnet], want)
+	}
+	if got, want := len(byType[domain.ResourceTypeElasticIP]), 1; got != want {
+		t.Errorf("elastic IPs = %v, want %d entries", byType[domain.ResourceTypeElasticIP], want)
+	}
+
+	if client.vpcCalls != 3 {
+		t.Errorf("DescribeVpcs calls = %d, want 3", client.vpcCalls)
+	}
+	if client.subnetCalls != 2 {
+		t.Errorf("DescribeSubnets calls = %d, want 2", client.subnetCalls)
+	}
+	// DescribeAddresses is not paginated by EC2, so it must be called once.
+	if client.addrCalls != 1 {
+		t.Errorf("DescribeAddresses calls = %d, want 1", client.addrCalls)
+	}
+}
+
+// repeatTokenEC2 always returns the same NextToken, mimicking a broken endpoint.
+type repeatTokenEC2 struct {
+	vpcCalls int
+}
+
+func (f *repeatTokenEC2) DescribeVpcs(_ context.Context, _ *ec2.DescribeVpcsInput, _ ...func(*ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	f.vpcCalls++
+	if f.vpcCalls > 10 {
+		return nil, fmt.Errorf("pagination did not terminate")
+	}
+	return &ec2.DescribeVpcsOutput{
+		Vpcs:      []ec2types.Vpc{{VpcId: awssdk.String("vpc-loop"), CidrBlock: awssdk.String("10.0.0.0/16")}},
+		NextToken: awssdk.String("stuck"),
+	}, nil
+}
+
+func (f *repeatTokenEC2) DescribeSubnets(context.Context, *ec2.DescribeSubnetsInput, ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	return &ec2.DescribeSubnetsOutput{}, nil
+}
+
+func (f *repeatTokenEC2) DescribeAddresses(context.Context, *ec2.DescribeAddressesInput, ...func(*ec2.Options)) (*ec2.DescribeAddressesOutput, error) {
+	return &ec2.DescribeAddressesOutput{}, nil
+}
+
+func TestDiscoverStopsOnRepeatedPageToken(t *testing.T) {
+	client := &repeatTokenEC2{}
+	collector := newTestCollector(map[string]ec2API{"us-east-1": client})
+
+	resources, err := collector.Discover(context.Background(), domain.Account{ID: 7, Regions: []string{"us-east-1"}})
+	if err != nil {
+		t.Fatalf("Discover() unexpected error: %v", err)
+	}
+	if got, want := len(resources), 2; got != want {
+		t.Fatalf("len(resources) = %d, want %d", got, want)
+	}
+	if client.vpcCalls != 2 {
+		t.Errorf("DescribeVpcs calls = %d, want 2 (first page plus one repeat)", client.vpcCalls)
+	}
+}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -153,7 +153,12 @@ func NewMetrics(cfg MetricsConfig) *Metrics {
 }
 
 // RecordHTTPRequest records an HTTP request with its method, path, status code, and duration.
+// A nil receiver means metrics are disabled and the call is a no-op.
 func (m *Metrics) RecordHTTPRequest(method, path string, statusCode int, duration time.Duration) {
+	if m == nil {
+		return
+	}
+
 	// Normalize path to avoid high cardinality
 	normalizedPath := normalizePath(path)
 
@@ -181,22 +186,38 @@ func (m *Metrics) RecordHTTPRequest(method, path string, statusCode int, duratio
 }
 
 // RecordRateLimitAllowed increments the count of allowed requests.
+// A nil receiver means metrics are disabled and the call is a no-op.
 func (m *Metrics) RecordRateLimitAllowed() {
+	if m == nil {
+		return
+	}
 	m.rateLimitAllowed.Add(1)
 }
 
 // RecordRateLimitRejected increments the count of rejected requests.
+// A nil receiver means metrics are disabled and the call is a no-op.
 func (m *Metrics) RecordRateLimitRejected() {
+	if m == nil {
+		return
+	}
 	m.rateLimitRejected.Add(1)
 }
 
 // IncrementActiveConnections increments the active connection gauge.
+// A nil receiver means metrics are disabled and the call is a no-op.
 func (m *Metrics) IncrementActiveConnections() {
+	if m == nil {
+		return
+	}
 	m.activeConnections.Add(1)
 }
 
 // DecrementActiveConnections decrements the active connection gauge.
+// A nil receiver means metrics are disabled and the call is a no-op.
 func (m *Metrics) DecrementActiveConnections() {
+	if m == nil {
+		return
+	}
 	m.activeConnections.Add(-1)
 }
 
@@ -218,7 +239,14 @@ func normalizePath(path string) string {
 }
 
 // Handler returns an http.Handler that serves Prometheus-format metrics.
+// A nil receiver means metrics are disabled and the handler reports 404.
 func (m *Metrics) Handler() http.Handler {
+	if m == nil {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "metrics disabled", http.StatusNotFound)
+		})
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -372,7 +400,8 @@ func RateLimitMetricsMiddleware(m *Metrics, rateLimitEnabled bool) func(http.Han
 }
 
 // NoopMetrics returns a Metrics instance that doesn't collect anything.
-// Useful for testing or when metrics are disabled.
+// Useful for testing or when MetricsConfig.Enabled is false. All Metrics
+// methods are nil-safe, so the result can be used like any other collector.
 func NoopMetrics() *Metrics {
 	return nil
 }

--- a/internal/observability/metrics_disabled_test.go
+++ b/internal/observability/metrics_disabled_test.go
@@ -1,0 +1,82 @@
+package observability
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildMetrics mirrors how cmd/cloudpam wires metrics: a disabled config yields
+// no collector at all.
+func buildMetrics(cfg MetricsConfig) *Metrics {
+	if !cfg.Enabled {
+		return nil
+	}
+	return NewMetrics(cfg)
+}
+
+func TestDisabledMetricsConfigCollectsNothing(t *testing.T) {
+	orig, had := os.LookupEnv("CLOUDPAM_METRICS_ENABLED")
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("CLOUDPAM_METRICS_ENABLED", orig)
+			return
+		}
+		_ = os.Unsetenv("CLOUDPAM_METRICS_ENABLED")
+	})
+	_ = os.Setenv("CLOUDPAM_METRICS_ENABLED", "false")
+
+	cfg := MetricsConfigFromEnv()
+	if cfg.Enabled {
+		t.Fatal("expected Enabled=false from env")
+	}
+
+	m := buildMetrics(cfg)
+	if m != nil {
+		t.Fatal("expected no collector when metrics are disabled")
+	}
+
+	// Every recording path must be inert rather than panicking.
+	m.RecordHTTPRequest(http.MethodGet, "/api/v1/pools", 200, time.Second)
+	m.RecordRateLimitAllowed()
+	m.RecordRateLimitRejected()
+	m.IncrementActiveConnections()
+	m.DecrementActiveConnections()
+
+	// The middleware stack must pass requests through untouched.
+	var handlerCalled bool
+	handler := MetricsMiddleware(m)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/pools", nil))
+	if !handlerCalled || rr.Code != http.StatusOK {
+		t.Errorf("handler called = %v, status = %d; want true, 200", handlerCalled, rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	RateLimitMetricsMiddleware(m, true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/v1/pools", nil))
+	if rr.Code != http.StatusOK {
+		t.Errorf("rate limit middleware status = %d, want 200", rr.Code)
+	}
+}
+
+func TestDisabledMetricsHandlerDoesNotServe(t *testing.T) {
+	m := NoopMetrics()
+
+	rr := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
+	}
+	if strings.Contains(rr.Body.String(), "http_requests_total") {
+		t.Errorf("disabled handler exposed metrics: %q", rr.Body.String())
+	}
+}

--- a/internal/planning/compliance.go
+++ b/internal/planning/compliance.go
@@ -166,24 +166,31 @@ func (s *AnalysisService) resolvePools(ctx context.Context, poolIDs []int64, inc
 	}
 
 	if includeChildren {
+		// Breadth-first descent so grandchildren and deeper levels are
+		// included, not just the immediate children. seen doubles as cycle
+		// protection for malformed hierarchies.
 		seen := map[int64]bool{}
+		queue := make([]int64, 0, len(pools))
 		for _, p := range pools {
 			seen[p.ID] = true
+			queue = append(queue, p.ID)
 		}
-		var extra []domain.Pool
-		for _, p := range pools {
-			children, err := s.store.GetPoolChildren(ctx, p.ID)
+		for len(queue) > 0 {
+			id := queue[0]
+			queue = queue[1:]
+			children, err := s.store.GetPoolChildren(ctx, id)
 			if err != nil {
 				continue
 			}
 			for _, c := range children {
-				if !seen[c.ID] {
-					seen[c.ID] = true
-					extra = append(extra, c)
+				if seen[c.ID] {
+					continue
 				}
+				seen[c.ID] = true
+				pools = append(pools, c)
+				queue = append(queue, c.ID)
 			}
 		}
-		pools = append(pools, extra...)
 	}
 
 	return pools, nil

--- a/internal/planning/resolve_pools_test.go
+++ b/internal/planning/resolve_pools_test.go
@@ -1,0 +1,135 @@
+package planning
+
+import (
+	"context"
+	"testing"
+
+	"cloudpam/internal/domain"
+	"cloudpam/internal/storage"
+)
+
+// newDeepHierarchy builds root -> level1 -> level2 -> level3 and returns the
+// pools in depth order.
+func newDeepHierarchy(t *testing.T, ctx context.Context, store storage.Store) []domain.Pool {
+	t.Helper()
+
+	root, err := store.CreatePool(ctx, domain.CreatePool{
+		Name: "Root", CIDR: "10.0.0.0/16", Type: domain.PoolTypeSupernet,
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+
+	pools := []domain.Pool{root}
+	specs := []struct {
+		name string
+		cidr string
+	}{
+		{"Level 1", "10.0.0.0/20"},
+		{"Level 2", "10.0.0.0/24"},
+		{"Level 3", "10.0.0.0/26"},
+	}
+	for _, spec := range specs {
+		parentID := pools[len(pools)-1].ID
+		p, err := store.CreatePool(ctx, domain.CreatePool{
+			Name: spec.name, CIDR: spec.cidr, ParentID: &parentID, Type: domain.PoolTypeSubnet,
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", spec.name, err)
+		}
+		pools = append(pools, p)
+	}
+	return pools
+}
+
+func TestResolvePoolsIncludesDescendantsAtEveryLevel(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemoryStore()
+	pools := newDeepHierarchy(t, ctx, store)
+
+	svc := NewAnalysisService(store)
+	resolved, err := svc.resolvePools(ctx, []int64{pools[0].ID}, true)
+	if err != nil {
+		t.Fatalf("resolvePools: %v", err)
+	}
+
+	got := map[int64]bool{}
+	for _, p := range resolved {
+		got[p.ID] = true
+	}
+	for _, want := range pools {
+		if !got[want.ID] {
+			t.Errorf("pool %q (id %d) missing from resolved set", want.Name, want.ID)
+		}
+	}
+	if len(resolved) != len(pools) {
+		t.Errorf("len(resolved) = %d, want %d", len(resolved), len(pools))
+	}
+}
+
+func TestResolvePoolsDeduplicatesOverlappingRequests(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemoryStore()
+	pools := newDeepHierarchy(t, ctx, store)
+
+	svc := NewAnalysisService(store)
+	// Ask for a pool and one of its own descendants at the same time.
+	resolved, err := svc.resolvePools(ctx, []int64{pools[0].ID, pools[2].ID}, true)
+	if err != nil {
+		t.Fatalf("resolvePools: %v", err)
+	}
+
+	seen := map[int64]int{}
+	for _, p := range resolved {
+		seen[p.ID]++
+	}
+	for id, count := range seen {
+		if count != 1 {
+			t.Errorf("pool %d appears %d times, want 1", id, count)
+		}
+	}
+	if len(seen) != len(pools) {
+		t.Errorf("distinct pools = %d, want %d", len(seen), len(pools))
+	}
+}
+
+func TestResolvePoolsWithoutChildrenReturnsOnlyRequested(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemoryStore()
+	pools := newDeepHierarchy(t, ctx, store)
+
+	svc := NewAnalysisService(store)
+	resolved, err := svc.resolvePools(ctx, []int64{pools[0].ID}, false)
+	if err != nil {
+		t.Fatalf("resolvePools: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0].ID != pools[0].ID {
+		t.Fatalf("resolved = %v, want only root pool %d", resolved, pools[0].ID)
+	}
+}
+
+func TestCheckComplianceCoversGrandchildren(t *testing.T) {
+	ctx := context.Background()
+	store := storage.NewMemoryStore()
+	pools := newDeepHierarchy(t, ctx, store)
+
+	svc := NewAnalysisService(store)
+	shallow, err := svc.CheckCompliance(ctx, []int64{pools[0].ID}, false)
+	if err != nil {
+		t.Fatalf("CheckCompliance without children: %v", err)
+	}
+	deep, err := svc.CheckCompliance(ctx, []int64{pools[0].ID}, true)
+	if err != nil {
+		t.Fatalf("CheckCompliance with children: %v", err)
+	}
+
+	// Every pool contributes the same fixed number of checks, so the deep run
+	// must scale with the full descendant count, not just the direct children.
+	perPool := shallow.TotalChecks
+	if perPool == 0 {
+		t.Fatal("expected the shallow run to record checks")
+	}
+	if want := perPool * len(pools); deep.TotalChecks != want {
+		t.Errorf("TotalChecks = %d, want %d (%d pools)", deep.TotalChecks, want, len(pools))
+	}
+}

--- a/internal/storage/settings_memory.go
+++ b/internal/storage/settings_memory.go
@@ -14,24 +14,46 @@ type MemorySettingsStore struct {
 	networkSchemaPolicy *domain.NetworkSchemaPolicy
 }
 
+// cloneSecuritySettings deep-copies security settings so store-owned state and
+// caller-owned state never share the nested slice and map fields.
+func cloneSecuritySettings(in *domain.SecuritySettings) *domain.SecuritySettings {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.TrustedProxies != nil {
+		out.TrustedProxies = append([]string(nil), in.TrustedProxies...)
+	}
+	if in.APIKeyAllowedScopesByRole != nil {
+		out.APIKeyAllowedScopesByRole = make(map[string][]string, len(in.APIKeyAllowedScopesByRole))
+		for role, scopes := range in.APIKeyAllowedScopesByRole {
+			if scopes == nil {
+				out.APIKeyAllowedScopesByRole[role] = nil
+				continue
+			}
+			out.APIKeyAllowedScopesByRole[role] = append([]string(nil), scopes...)
+		}
+	}
+	return &out
+}
+
 // NewMemorySettingsStore creates a new in-memory settings store with defaults.
 func NewMemorySettingsStore() *MemorySettingsStore {
 	defaults := domain.DefaultSecuritySettings()
 	policy := domain.DefaultNetworkSchemaPolicy()
-	return &MemorySettingsStore{security: &defaults, networkSchemaPolicy: &policy}
+	return &MemorySettingsStore{security: cloneSecuritySettings(&defaults), networkSchemaPolicy: &policy}
 }
 
 func (s *MemorySettingsStore) GetSecuritySettings(_ context.Context) (*domain.SecuritySettings, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	copy := *s.security
-	return domain.NormalizeSecuritySettings(&copy), nil
+	return domain.NormalizeSecuritySettings(cloneSecuritySettings(s.security)), nil
 }
 
 func (s *MemorySettingsStore) UpdateSecuritySettings(_ context.Context, settings *domain.SecuritySettings) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.security = domain.NormalizeSecuritySettings(settings)
+	s.security = domain.NormalizeSecuritySettings(cloneSecuritySettings(settings))
 	return nil
 }
 

--- a/internal/storage/settings_memory_test.go
+++ b/internal/storage/settings_memory_test.go
@@ -1,0 +1,94 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"cloudpam/internal/domain"
+)
+
+func TestMemorySettingsStoreGetReturnsIsolatedCopy(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemorySettingsStore()
+
+	got, err := store.GetSecuritySettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSecuritySettings: %v", err)
+	}
+
+	// Mutate every nested reference type the caller can reach.
+	got.TrustedProxies = append(got.TrustedProxies, "10.0.0.0/8")
+	got.APIKeyAllowedScopesByRole["admin"] = []string{"*"}
+	got.APIKeyAllowedScopesByRole["intruder"] = []string{"*"}
+	got.SessionDurationHours = 999
+
+	after, err := store.GetSecuritySettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSecuritySettings: %v", err)
+	}
+
+	if len(after.TrustedProxies) != 0 {
+		t.Errorf("TrustedProxies = %v, want empty", after.TrustedProxies)
+	}
+	if _, ok := after.APIKeyAllowedScopesByRole["intruder"]; ok {
+		t.Error("caller mutation added a role to store-owned scope policy")
+	}
+	if got, want := len(after.APIKeyAllowedScopesByRole["admin"]), len(domain.DefaultAPIKeyAllowedScopesByRole()["admin"]); got != want {
+		t.Errorf("admin scopes = %d entries, want %d", got, want)
+	}
+	if after.SessionDurationHours != domain.DefaultSecuritySettings().SessionDurationHours {
+		t.Errorf("SessionDurationHours = %d, want default", after.SessionDurationHours)
+	}
+}
+
+func TestMemorySettingsStoreUpdateCopiesCallerState(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemorySettingsStore()
+
+	input := domain.DefaultSecuritySettings()
+	input.TrustedProxies = []string{"192.168.0.0/16"}
+	input.APIKeyAllowedScopesByRole = map[string][]string{"viewer": {"pools:read"}}
+
+	if err := store.UpdateSecuritySettings(ctx, &input); err != nil {
+		t.Fatalf("UpdateSecuritySettings: %v", err)
+	}
+
+	// Mutating the caller's struct after the write must not reach the store.
+	input.TrustedProxies[0] = "0.0.0.0/0"
+	input.APIKeyAllowedScopesByRole["viewer"] = []string{"*"}
+	input.APIKeyAllowedScopesByRole["admin"] = []string{"*"}
+
+	after, err := store.GetSecuritySettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSecuritySettings: %v", err)
+	}
+	if len(after.TrustedProxies) != 1 || after.TrustedProxies[0] != "192.168.0.0/16" {
+		t.Errorf("TrustedProxies = %v, want [192.168.0.0/16]", after.TrustedProxies)
+	}
+	if scopes := after.APIKeyAllowedScopesByRole["viewer"]; len(scopes) != 1 || scopes[0] != "pools:read" {
+		t.Errorf("viewer scopes = %v, want [pools:read]", scopes)
+	}
+}
+
+func TestMemorySettingsStoreDefaultsAreNotShared(t *testing.T) {
+	ctx := context.Background()
+	a := NewMemorySettingsStore()
+	b := NewMemorySettingsStore()
+
+	settings, err := a.GetSecuritySettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSecuritySettings: %v", err)
+	}
+	settings.APIKeyAllowedScopesByRole["viewer"] = []string{"*"}
+	if err := a.UpdateSecuritySettings(ctx, settings); err != nil {
+		t.Fatalf("UpdateSecuritySettings: %v", err)
+	}
+
+	other, err := b.GetSecuritySettings(ctx)
+	if err != nil {
+		t.Fatalf("GetSecuritySettings: %v", err)
+	}
+	if scopes := other.APIKeyAllowedScopesByRole["viewer"]; len(scopes) == 1 && scopes[0] == "*" {
+		t.Error("second store shares the default scope policy map with the first")
+	}
+}


### PR DESCRIPTION
Six backend findings from #223. Each fix ships with a regression test that fails against the unfixed code.

## Security

**`/api/v1/export` exposed account data to `pools:read`-only callers.** The route was gated on `pools:read` alone (`server.go:220`) while `handleExport` can emit accounts — the comment claimed both permissions were required, the code required one. Adds `RequireExportPermissionsMiddleware`, deriving required permissions from the requested datasets:

| dataset | requires |
|---|---|
| `accounts` | `accounts:read` |
| `pools` | `pools:read` |
| `blocks` | **both** — the blocks CSV emits `account_name`, `platform`, `tier`, `environment`, `regions` |

Implemented as route middleware rather than in-handler because `RequireAllPermissionsMiddleware` doesn't exist, gating the whole route on both would break legitimate `pools:read`-only pool exports, and an in-handler `RequirePermission` would 403 the existing unprotected-route handler tests.

**Built-in roles are unaffected** — viewer/operator/admin all hold both scopes. Only a hand-scoped `pools:read`-only API key loses blocks export, which is the intended tightening.

## Data loss

**AWS discovery dropped everything after the first EC2 page.** `DescribeVpcs`/`DescribeSubnets` ignored `NextToken` entirely, so multi-page accounts silently lost resources — and because the sync service stales unseen resources, it could also wrongly stale valid ones. Both now page to exhaustion with a repeated-token guard.

`DescribeAddresses` deliberately left as a single call: `DescribeAddressesOutput` has no `NextToken` in the vendored SDK, unlike the other two. Comment records why.

**`includeChildren` only descended one level.** `resolvePools` did a single non-recursive pass, so analysis and compliance under-reported on any hierarchy deeper than two levels. Now breadth-first over descendants, keeping cycle protection.

## Correctness

- **`MemorySettingsStore` leaked mutable state** — shared its `TrustedProxies` slice and `APIKeyAllowedScopesByRole` map with callers, and `Update` stored the caller's pointer outright. Adds `cloneSecuritySettings` at all three boundaries.
- **`SQLiteAuditLogger.Close` killed caller-owned handles** — closed the `*sql.DB` unconditionally, so closing the audit logger could take down a shared database. Adds `ownDB`, matching the `ownPool` pattern already used by the postgres store.
- **Metrics recording is now nil-receiver-safe** — see the note below.

## Two findings that turned out to be inaccurate as filed

**`MetricsConfig.Enabled` is already enforced.** The finding says the flag is parsed and never used. That's true *within `metrics.go`*, but the shipped binary gates on it at the wiring layer: `main.go:101` only constructs `Metrics` when enabled, `MetricsMiddleware(nil)` is a passthrough, and `server.go:194` skips the `/metrics` route when nil. So `CLOUDPAM_METRICS_ENABLED=false` genuinely stops collection today.

Enforcing it a second time inside `NewMetrics` would break 5 existing tests that construct `MetricsConfig{Namespace: "test"}` with `Enabled` at its `false` zero value and then assert collection works — a plain bool can't distinguish "zero value" from "explicitly disabled". Rather than rewrite those tests, this PR hardens the path production actually uses: recording methods and `Handler()` are nil-receiver-safe, so the disabled representation is inert instead of a panic trap, and `Handler()` on nil returns 404.

**`utilization_memory.go` already returns a copy.** `LatestSnapshot` value-copies and `UtilizationSnapshot` has no reference fields; `utilization_memory_test.go:11` already asserts this and passes. No change made, no duplicate test added.

## Out of scope, worth a follow-up

`/api/v1/blocks` is gated on `pools:read` alone but returns the same account fields — the same class of leak as the export fix, on a different endpoint.

## Tests

Six new test files, no existing test modified. Each was confirmed to fail against the unfixed code (e.g. `VPCs = [vpc-1], want 3 entries`; `pool "Level 2" missing`; `borrowed db was closed by the audit logger`).

## Verification

```
go build ./... && go vet ./...                      pass
go test -race ./...                                 pass
go test -tags sqlite ./...                          pass
go build -tags postgres ./...                       pass
golangci-lint run --timeout=5m                      0 issues
```

Refs #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)