### PR TITLE
UI: guard against stale responses and duplicate submits

### DIFF
--- a/ui/src/__tests__/AIPlannerPage.test.tsx
+++ b/ui/src/__tests__/AIPlannerPage.test.tsx
@@ -1,0 +1,130 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AIPlannerPage from '../pages/AIPlannerPage'
+import type { ApplyPlanResponse } from '../api/types'
+
+const mockUseAIPlanner = vi.fn()
+const mockUseToast = vi.fn()
+
+vi.mock('../hooks/useAIPlanner', () => ({
+  useAIPlanner: () => mockUseAIPlanner(),
+}))
+
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => mockUseToast(),
+}))
+
+const planMessage = `Here is a plan:
+
+\`\`\`json
+{
+  "name": "Production VPC",
+  "description": "Production network layout",
+  "pools": [
+    {"ref": "root", "name": "prod-vpc", "cidr": "10.0.0.0/16", "type": "supernet"}
+  ]
+}
+\`\`\`
+`
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('AIPlannerPage', () => {
+  const showToast = vi.fn()
+  const applyPlan = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // jsdom does not implement scrollIntoView
+    Element.prototype.scrollIntoView = vi.fn()
+
+    mockUseToast.mockReturnValue({ showToast })
+    mockUseAIPlanner.mockReturnValue({
+      sessions: [{ id: 'a', title: 'Session A', created_at: '', updated_at: '' }],
+      activeSession: {
+        id: 'a',
+        title: 'Session A',
+        created_at: '',
+        updated_at: '',
+        messages: [
+          { id: 'm1', conversation_id: 'a', role: 'assistant', content: planMessage, created_at: '' },
+        ],
+      },
+      streaming: false,
+      streamingText: '',
+      loading: false,
+      applying: false,
+      error: null,
+      fetchSessions: vi.fn(),
+      createSession: vi.fn(),
+      selectSession: vi.fn(),
+      deleteSession: vi.fn(),
+      sendMessage: vi.fn(),
+      applyPlan,
+      setError: vi.fn(),
+    })
+  })
+
+  it('applies a generated plan once and reports the result', async () => {
+    applyPlan.mockResolvedValue({ created: 1, skipped: 0, errors: [], root_pool_id: 1, pool_map: {} })
+
+    render(<AIPlannerPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply Plan/i }))
+
+    await waitFor(() => {
+      expect(applyPlan).toHaveBeenCalledTimes(1)
+      expect(showToast).toHaveBeenCalledWith('Created 1 pools', 'success')
+    })
+  })
+
+  it('does not submit a duplicate apply while the first one is in flight', async () => {
+    const pending = deferred<ApplyPlanResponse>()
+    applyPlan.mockReturnValue(pending.promise)
+
+    render(<AIPlannerPage />)
+
+    const button = screen.getByRole('button', { name: /Apply Plan/i })
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    expect(applyPlan).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Applying/i })).toHaveProperty('disabled', true)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Applying/i }))
+    expect(applyPlan).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      pending.resolve({ created: 1, skipped: 0, errors: [], root_pool_id: 1, pool_map: {} })
+      await pending.promise
+    })
+
+    // The button re-enables once the request settles
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Apply Plan/i })).toHaveProperty('disabled', false)
+    })
+  })
+
+  it('re-enables the apply button after a failed apply', async () => {
+    applyPlan.mockRejectedValue(new Error('boom'))
+
+    render(<AIPlannerPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply Plan/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Apply Plan/i })).toHaveProperty('disabled', false)
+    })
+    expect(applyPlan).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/__tests__/UpdatesPageUpgradeGating.test.tsx
+++ b/ui/src/__tests__/UpdatesPageUpgradeGating.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import UpdatesPage from '../pages/UpdatesPage'
+import type { UpdateStatusResponse } from '../api/types'
+
+const mockUseAuth = vi.fn()
+const mockUseToast = vi.fn()
+const mockUseUpdates = vi.fn()
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => mockUseToast(),
+}))
+
+vi.mock('../hooks/useUpdates', () => ({
+  useUpdates: () => mockUseUpdates(),
+}))
+
+vi.mock('../utils/upgradeReload', () => ({
+  scheduleFrontendResetAfterUpgrade: vi.fn(),
+}))
+
+describe('UpdatesPage upgrade gating', () => {
+  const showToast = vi.fn()
+  const triggerUpgrade = vi.fn()
+
+  function setup(status: UpdateStatusResponse) {
+    mockUseAuth.mockReturnValue({ role: 'admin' })
+    mockUseToast.mockReturnValue({ showToast })
+    mockUseUpdates.mockReturnValue({
+      summary: {
+        current_version: '0.8.0',
+        latest_version: '0.9.0',
+        update_available: true,
+      },
+      status,
+      loadingSummary: false,
+      loadingStatus: false,
+      actionLoading: false,
+      summaryError: null,
+      statusError: null,
+      actionError: null,
+      refreshSummary: vi.fn().mockResolvedValue(undefined),
+      refreshStatus: vi.fn().mockResolvedValue(undefined),
+      triggerUpgrade,
+      acknowledgeUpgradeStatus: vi.fn().mockResolvedValue({}),
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('submits only one upgrade request when the button is clicked twice', async () => {
+    setup({ status: 'idle' })
+    let resolveTrigger: (value: { status: string; target_version: string }) => void = () => {}
+    triggerUpgrade.mockReturnValue(
+      new Promise(res => {
+        resolveTrigger = res
+      }),
+    )
+
+    render(<UpdatesPage />)
+
+    const button = screen.getByRole('button', { name: 'Upgrade to v0.9.0' })
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    expect(triggerUpgrade).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Upgrade to v0.9.0' })).toHaveProperty('disabled', true)
+    })
+
+    resolveTrigger({ status: 'upgrade_requested', target_version: '0.9.0' })
+
+    // Still gated afterwards, because an upgrade is now pending
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Upgrade to v0.9.0' })).toHaveProperty('disabled', true)
+    })
+    expect(triggerUpgrade).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the upgrade button while a host upgrade is already running', () => {
+    setup({ status: 'running', target_version: '0.9.0' })
+
+    render(<UpdatesPage />)
+
+    expect(screen.getByRole('button', { name: 'Upgrade to v0.9.0' })).toHaveProperty('disabled', true)
+  })
+})

--- a/ui/src/__tests__/UsersAdminPanel.test.tsx
+++ b/ui/src/__tests__/UsersAdminPanel.test.tsx
@@ -1,0 +1,110 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import UsersAdminPanel from '../components/UsersAdminPanel'
+import type { UserInfo } from '../api/types'
+
+const mockUseUsers = vi.fn()
+const mockUseRoles = vi.fn()
+
+vi.mock('../hooks/useUsers', () => ({
+  useUsers: () => mockUseUsers(),
+}))
+
+vi.mock('../hooks/useRoles', () => ({
+  useRoles: () => mockUseRoles(),
+}))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const createdUser = {
+  id: 'u1',
+  username: 'jdoe',
+  role: 'viewer',
+  is_active: true,
+} as UserInfo
+
+function fillForm() {
+  fireEvent.change(screen.getByPlaceholderText('jdoe'), { target: { value: 'jdoe' } })
+  fireEvent.change(screen.getByPlaceholderText('Minimum 8 characters'), {
+    target: { value: 'correct horse battery' },
+  })
+}
+
+describe('UsersAdminPanel', () => {
+  const create = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockUseRoles.mockReturnValue({ roles: [] })
+    mockUseUsers.mockReturnValue({
+      users: [],
+      loading: false,
+      error: null,
+      create,
+      update: vi.fn(),
+      deactivate: vi.fn(),
+      unlock: vi.fn(),
+    })
+  })
+
+  it('does not create a duplicate user when the button is clicked twice', async () => {
+    const pending = deferred<UserInfo>()
+    create.mockReturnValue(pending.promise)
+
+    render(<UsersAdminPanel />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create User' }))
+    fillForm()
+
+    const submit = screen.getByRole('button', { name: 'Create' })
+    fireEvent.click(submit)
+    fireEvent.click(submit)
+
+    expect(create).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Creating...' })).toHaveProperty('disabled', true)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Creating...' }))
+    expect(create).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      pending.resolve(createdUser)
+      await pending.promise
+    })
+
+    // The form closes on success
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Creat(e|ing)/ })).toHaveProperty(
+        'textContent',
+        'Create User',
+      )
+    })
+  })
+
+  it('re-enables the create button after a failed create', async () => {
+    create.mockRejectedValue(new Error('username already exists'))
+
+    render(<UsersAdminPanel />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create User' }))
+    fillForm()
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('username already exists')).toBeTruthy()
+      expect(screen.getByRole('button', { name: 'Create' })).toHaveProperty('disabled', false)
+    })
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/__tests__/useAIPlanner.test.ts
+++ b/ui/src/__tests__/useAIPlanner.test.ts
@@ -1,0 +1,150 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAIPlanner } from '../hooks/useAIPlanner'
+import { get, post, streamPost, type SSECallbacks } from '../api/client'
+import type { ApplyPlanResponse, ConversationWithMessages, GeneratedPlan } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  del: vi.fn(),
+  streamPost: vi.fn(),
+}))
+
+const mockGet = vi.mocked(get)
+const mockPost = vi.mocked(post)
+const mockStreamPost = vi.mocked(streamPost)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function conversation(id: string): ConversationWithMessages {
+  return {
+    id,
+    title: `Session ${id}`,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    messages: [],
+  }
+}
+
+const plan: GeneratedPlan = { name: 'Plan', description: '', pools: [] }
+
+describe('useAIPlanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('drops stream output for a session the user has switched away from', async () => {
+    mockGet
+      .mockResolvedValueOnce(conversation('a') as never)
+      .mockResolvedValueOnce(conversation('b') as never)
+
+    let streamCallbacks: SSECallbacks | undefined
+    mockStreamPost.mockImplementation((_path, _data, callbacks) => {
+      streamCallbacks = callbacks
+      return new Promise<void>(() => {
+        // stays pending for the duration of the test
+      })
+    })
+
+    const { result } = renderHook(() => useAIPlanner())
+
+    await act(async () => {
+      await result.current.selectSession('a')
+    })
+    expect(result.current.activeSession?.id).toBe('a')
+
+    act(() => {
+      void result.current.sendMessage('plan a /16')
+    })
+    await waitFor(() => expect(mockStreamPost).toHaveBeenCalledTimes(1))
+
+    // User switches to another session while the answer is still streaming
+    await act(async () => {
+      await result.current.selectSession('b')
+    })
+    expect(result.current.activeSession?.id).toBe('b')
+
+    act(() => {
+      streamCallbacks?.onDelta('half an answer')
+    })
+    expect(result.current.streamingText).toBe('')
+
+    act(() => {
+      streamCallbacks?.onDone()
+    })
+
+    expect(result.current.activeSession?.id).toBe('b')
+    expect(result.current.activeSession?.messages).toHaveLength(0)
+    expect(result.current.streamingText).toBe('')
+    expect(result.current.streaming).toBe(false)
+  })
+
+  it('still appends the answer when the session has not changed', async () => {
+    mockGet.mockResolvedValueOnce(conversation('a') as never)
+
+    let streamCallbacks: SSECallbacks | undefined
+    mockStreamPost.mockImplementation((_path, _data, callbacks) => {
+      streamCallbacks = callbacks
+      return new Promise<void>(() => {})
+    })
+
+    const { result } = renderHook(() => useAIPlanner())
+
+    await act(async () => {
+      await result.current.selectSession('a')
+    })
+
+    act(() => {
+      void result.current.sendMessage('plan a /16')
+    })
+    await waitFor(() => expect(mockStreamPost).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      streamCallbacks?.onDelta('an answer')
+      streamCallbacks?.onDone()
+    })
+
+    const roles = result.current.activeSession?.messages.map(m => m.role)
+    expect(roles).toEqual(['user', 'assistant'])
+    expect(result.current.activeSession?.messages[1].content).toBe('an answer')
+  })
+
+  it('ignores a second applyPlan while the first is still in flight', async () => {
+    mockGet.mockResolvedValueOnce(conversation('a') as never)
+
+    const apply = deferred<ApplyPlanResponse>()
+    mockPost.mockReturnValueOnce(apply.promise as Promise<never>)
+
+    const { result } = renderHook(() => useAIPlanner())
+
+    await act(async () => {
+      await result.current.selectSession('a')
+    })
+
+    let secondResult: ApplyPlanResponse | null = null
+    act(() => {
+      void result.current.applyPlan(plan)
+      void result.current.applyPlan(plan).then(res => {
+        secondResult = res
+      })
+    })
+
+    expect(mockPost).toHaveBeenCalledTimes(1)
+    expect(result.current.applying).toBe(true)
+
+    await act(async () => {
+      apply.resolve({ created: 2, skipped: 0, errors: [], root_pool_id: 1, pool_map: {} })
+      await apply.promise
+    })
+
+    expect(secondResult).toBeNull()
+    expect(result.current.applying).toBe(false)
+  })
+})

--- a/ui/src/__tests__/useAccounts.test.ts
+++ b/ui/src/__tests__/useAccounts.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAccounts } from '../hooks/useAccounts'
+import { get, post } from '../api/client'
+import type { Account } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  del: vi.fn(),
+}))
+
+const mockGet = vi.mocked(get)
+const mockPost = vi.mocked(post)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function account(id: number, name: string): Account {
+  return { id, key: `key-${id}`, name, created_at: '2026-01-01T00:00:00Z' }
+}
+
+describe('useAccounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not let a slow initial fetch drop a newly created account', async () => {
+    const list = deferred<Account[]>()
+    mockGet.mockReturnValueOnce(list.promise as Promise<never>)
+    mockPost.mockResolvedValue(account(2, 'New Account'))
+
+    const { result } = renderHook(() => useAccounts())
+
+    act(() => {
+      void result.current.fetchAccounts()
+    })
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      await result.current.createAccount({ key: 'key-2', name: 'New Account' })
+    })
+
+    // The initial list request finally lands, without the new account in it
+    await act(async () => {
+      list.resolve([account(1, 'Existing')])
+      await list.promise
+    })
+
+    expect(result.current.accounts.map(a => a.name)).toEqual(['New Account'])
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/ui/src/__tests__/useConflictChecker.test.ts
+++ b/ui/src/__tests__/useConflictChecker.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useConflictChecker } from '../wizard/hooks/useConflictChecker'
+import type { SchemaNode } from '../wizard/utils/cidr'
+import type { SchemaCheckResponse } from '../api/types'
+import { post } from '../api/client'
+
+vi.mock('../api/client', () => ({
+  post: vi.fn(),
+}))
+
+const mockPost = vi.mocked(post)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function schemaNode(cidr: string): SchemaNode {
+  return { id: 'root', name: 'Root', cidr, type: 'supernet', children: [] }
+}
+
+function response(cidr: string): SchemaCheckResponse {
+  return {
+    conflicts: [
+      {
+        planned_cidr: cidr,
+        planned_name: 'Root',
+        existing_pool_id: 1,
+        existing_pool_name: 'Existing',
+        existing_cidr: cidr,
+        overlap_type: 'overlap',
+      },
+    ],
+    total_pools: 1,
+    conflict_count: 1,
+  }
+}
+
+describe('useConflictChecker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps conflicts for the latest schema when an older check resolves last', async () => {
+    const first = deferred<SchemaCheckResponse>()
+    const second = deferred<SchemaCheckResponse>()
+    mockPost
+      .mockReturnValueOnce(first.promise as Promise<never>)
+      .mockReturnValueOnce(second.promise as Promise<never>)
+
+    const { result, rerender } = renderHook(
+      ({ schema }: { schema: SchemaNode }) => useConflictChecker(schema, true),
+      { initialProps: { schema: schemaNode('10.0.0.0/8') } },
+    )
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1))
+
+    rerender({ schema: schemaNode('192.168.0.0/16') })
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(2))
+
+    // The newer check answers first, then the stale one lands
+    await act(async () => {
+      second.resolve(response('192.168.0.0/16'))
+      await second.promise
+    })
+    await act(async () => {
+      first.resolve(response('10.0.0.0/8'))
+      await first.promise
+    })
+
+    expect(result.current.conflicts).toHaveLength(1)
+    expect(result.current.conflicts[0].planned_cidr).toBe('192.168.0.0/16')
+  })
+})

--- a/ui/src/__tests__/useDiscovery.test.ts
+++ b/ui/src/__tests__/useDiscovery.test.ts
@@ -1,0 +1,59 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDiscoveryResources } from '../hooks/useDiscovery'
+import { get } from '../api/client'
+import type { DiscoveryResourcesResponse } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  del: vi.fn(),
+}))
+
+const mockGet = vi.mocked(get)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function response(total: number): DiscoveryResourcesResponse {
+  return { items: [], total, page: 1, page_size: 25 }
+}
+
+describe('useDiscoveryResources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not let a previous account load overwrite the current one', async () => {
+    const first = deferred<DiscoveryResourcesResponse>()
+    const second = deferred<DiscoveryResourcesResponse>()
+    mockGet
+      .mockReturnValueOnce(first.promise as Promise<never>)
+      .mockReturnValueOnce(second.promise as Promise<never>)
+
+    const { result } = renderHook(() => useDiscoveryResources())
+
+    act(() => {
+      void result.current.fetch(1)
+      void result.current.fetch(2)
+    })
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      second.resolve(response(5))
+      await second.promise
+    })
+    await act(async () => {
+      first.resolve(response(999))
+      await first.promise
+    })
+
+    expect(result.current.data?.total).toBe(5)
+  })
+})

--- a/ui/src/__tests__/useDrift.test.ts
+++ b/ui/src/__tests__/useDrift.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDrift } from '../hooks/useDrift'
+import { get } from '../api/client'
+import type { DriftListResponse } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}))
+
+const mockGet = vi.mocked(get)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function response(total: number): DriftListResponse {
+  return {
+    items: [],
+    total,
+    page: 1,
+    page_size: 50,
+    summary: {
+      total_drifts: total,
+      by_severity: {},
+      by_type: {},
+      accounts_scanned: 0,
+      resources_scanned: 0,
+      pools_scanned: 0,
+    },
+  }
+}
+
+describe('useDrift', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps the newest filter results when an older request resolves last', async () => {
+    const first = deferred<DriftListResponse>()
+    const second = deferred<DriftListResponse>()
+    mockGet
+      .mockReturnValueOnce(first.promise as Promise<never>)
+      .mockReturnValueOnce(second.promise as Promise<never>)
+
+    const { result } = renderHook(() => useDrift())
+
+    act(() => {
+      void result.current.fetch({ severity: 'low' })
+      void result.current.fetch({ severity: 'critical' })
+    })
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      second.resolve(response(2))
+      await second.promise
+    })
+    await act(async () => {
+      first.resolve(response(99))
+      await first.promise
+    })
+
+    expect(result.current.data?.total).toBe(2)
+  })
+})

--- a/ui/src/__tests__/useRecommendations.test.ts
+++ b/ui/src/__tests__/useRecommendations.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useRecommendations } from '../hooks/useRecommendations'
+import { get } from '../api/client'
+import type { RecommendationsListResponse } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}))
+
+const mockGet = vi.mocked(get)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function response(total: number): RecommendationsListResponse {
+  return { items: [], total, page: 1, page_size: 50 }
+}
+
+describe('useRecommendations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps the newest filter results when an older request resolves last', async () => {
+    const first = deferred<RecommendationsListResponse>()
+    const second = deferred<RecommendationsListResponse>()
+    mockGet
+      .mockReturnValueOnce(first.promise as Promise<never>)
+      .mockReturnValueOnce(second.promise as Promise<never>)
+
+    const { result } = renderHook(() => useRecommendations())
+
+    act(() => {
+      void result.current.fetch({ status: 'pending' })
+      void result.current.fetch({ status: 'applied' })
+    })
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      second.resolve(response(3))
+      await second.promise
+    })
+    await act(async () => {
+      first.resolve(response(77))
+      await first.promise
+    })
+
+    expect(result.current.data?.total).toBe(3)
+  })
+})

--- a/ui/src/__tests__/useSearch.test.ts
+++ b/ui/src/__tests__/useSearch.test.ts
@@ -1,0 +1,104 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSearch } from '../hooks/useSearch'
+import { get } from '../api/client'
+import type { SearchResponse } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  get: vi.fn(),
+}))
+
+const mockGet = vi.mocked(get)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function response(name: string): SearchResponse {
+  return {
+    items: [{ type: 'pool', id: 1, name }],
+    total: 1,
+    page: 1,
+    page_size: 20,
+  }
+}
+
+describe('useSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the newest results when an older request resolves last', async () => {
+    const first = deferred<SearchResponse>()
+    const second = deferred<SearchResponse>()
+    mockGet
+      .mockReturnValueOnce(first.promise as Promise<never>)
+      .mockReturnValueOnce(second.promise as Promise<never>)
+
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.setQuery('alpha')
+    })
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      result.current.setQuery('beta')
+    })
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+
+    // The newer request answers first, then the stale one lands
+    await act(async () => {
+      second.resolve(response('beta'))
+      await second.promise
+    })
+    await act(async () => {
+      first.resolve(response('alpha'))
+      await first.promise
+    })
+
+    expect(result.current.results?.items[0].name).toBe('beta')
+  })
+
+  it('ignores an error from a superseded request', async () => {
+    const first = deferred<SearchResponse>()
+    const second = deferred<SearchResponse>()
+    mockGet
+      .mockReturnValueOnce(first.promise as Promise<never>)
+      .mockReturnValueOnce(second.promise as Promise<never>)
+
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.setQuery('alpha')
+    })
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      result.current.setQuery('beta')
+    })
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      second.resolve(response('beta'))
+      await second.promise
+    })
+    await act(async () => {
+      first.reject(new Error('stale failure'))
+      await first.promise.catch(() => undefined)
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.results?.items[0].name).toBe('beta')
+  })
+})

--- a/ui/src/components/UsersAdminPanel.tsx
+++ b/ui/src/components/UsersAdminPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Users, Plus, AlertCircle, UserCheck, UserX, LockOpen } from 'lucide-react'
 import { useUsers } from '../hooks/useUsers'
 import { useRoles } from '../hooks/useRoles'
+import { usePendingAction } from '../hooks/usePendingAction'
 import type { CreateUserRequest, UserInfo } from '../api/types'
 
 interface UsersAdminPanelProps {
@@ -24,7 +25,7 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editRole, setEditRole] = useState('')
 
-  async function handleCreate() {
+  async function createUser() {
     if (!form.username.trim() || !form.password) return
     setCreateError('')
     try {
@@ -35,6 +36,9 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
       setCreateError(err instanceof Error ? err.message : 'Failed to create user')
     }
   }
+
+  // Gated so a second click before the request settles cannot create a duplicate user
+  const { pending: creating, run: handleCreate } = usePendingAction(createUser)
 
   async function handleRoleSave(id: string) {
     try {
@@ -176,11 +180,11 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
 
           <div className="flex gap-2 pt-3">
             <button
-              onClick={handleCreate}
-              disabled={!form.username.trim() || !form.password}
+              onClick={() => void handleCreate()}
+              disabled={creating || !form.username.trim() || !form.password}
               className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
             >
-              Create
+              {creating ? 'Creating...' : 'Create'}
             </button>
             <button
               onClick={() => setShowCreate(false)}

--- a/ui/src/hooks/useAIPlanner.ts
+++ b/ui/src/hooks/useAIPlanner.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react'
 import { get, post, del, streamPost } from '../api/client'
+import { useLatestRequest } from './useLatestRequest'
 import type {
   Conversation,
   ConversationWithMessages,
@@ -14,8 +15,23 @@ export function useAIPlanner() {
   const [streaming, setStreaming] = useState(false)
   const [streamingText, setStreamingText] = useState('')
   const [loading, setLoading] = useState(false)
+  const [applying, setApplying] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const streamingTextRef = useRef('')
+  const applyingRef = useRef(false)
+  // Guards the active session against out-of-order session loads
+  const { begin: beginActive, isCurrent: isCurrentActive } = useLatestRequest()
+  // Session currently shown; a stream started for another session is dropped
+  const activeSessionIdRef = useRef<string | null>(null)
+
+  const focusSession = useCallback((id: string | null) => {
+    if (activeSessionIdRef.current === id) return
+    activeSessionIdRef.current = id
+    // Whatever was streaming belonged to the previous session
+    setStreaming(false)
+    setStreamingText('')
+    streamingTextRef.current = ''
+  }, [])
 
   const fetchSessions = useCallback(async () => {
     try {
@@ -30,52 +46,68 @@ export function useAIPlanner() {
     try {
       const conv = await post<Conversation>('/api/v1/ai/sessions', { title: title || 'New Planning Session' })
       setSessions(prev => [conv, ...prev])
+      beginActive()
+      focusSession(conv.id)
       setActiveSession({ ...conv, messages: [] })
       return conv
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create session')
       return null
     }
-  }, [])
+  }, [beginActive, focusSession])
 
   const selectSession = useCallback(async (id: string) => {
+    const token = beginActive()
     setLoading(true)
     try {
       const conv = await get<ConversationWithMessages>(`/api/v1/ai/sessions/${id}`)
+      if (!isCurrentActive(token)) return
+      focusSession(conv.id)
       setActiveSession(conv)
       setError(null)
     } catch (err) {
+      if (!isCurrentActive(token)) return
       setError(err instanceof Error ? err.message : 'Failed to load session')
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [beginActive, isCurrentActive, focusSession])
 
   const deleteSession = useCallback(async (id: string) => {
     try {
       await del(`/api/v1/ai/sessions/${id}`)
       setSessions(prev => prev.filter(s => s.id !== id))
       if (activeSession?.id === id) {
+        beginActive()
+        focusSession(null)
         setActiveSession(null)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete session')
     }
-  }, [activeSession])
+  }, [activeSession, beginActive, focusSession])
 
   const sendMessage = useCallback(async (message: string) => {
     if (!activeSession || streaming) return
 
+    // The session this stream belongs to; if the user switches sessions
+    // mid-stream, the remaining chunks must not land on the new session.
+    const sessionId = activeSession.id
+    activeSessionIdRef.current = sessionId
+    const isStreamSessionActive = () => activeSessionIdRef.current === sessionId
+
     // Add user message to the UI immediately
     const userMsg = {
       id: crypto.randomUUID(),
-      conversation_id: activeSession.id,
+      conversation_id: sessionId,
       role: 'user' as const,
       content: message,
       created_at: new Date().toISOString(),
     }
     setActiveSession(prev =>
-      prev ? { ...prev, messages: [...prev.messages, userMsg] } : null
+      prev && prev.id === sessionId
+        ? { ...prev, messages: [...prev.messages, userMsg] }
+        : prev
     )
 
     setStreaming(true)
@@ -84,30 +116,35 @@ export function useAIPlanner() {
     setError(null)
 
     await streamPost('/api/v1/ai/chat', {
-      session_id: activeSession.id,
+      session_id: sessionId,
       message,
     }, {
       onDelta: (text) => {
+        if (!isStreamSessionActive()) return
         streamingTextRef.current += text
         setStreamingText(streamingTextRef.current)
       },
       onDone: () => {
+        if (!isStreamSessionActive()) return
         // Add the assistant message
         const assistantMsg = {
           id: crypto.randomUUID(),
-          conversation_id: activeSession.id,
+          conversation_id: sessionId,
           role: 'assistant' as const,
           content: streamingTextRef.current,
           created_at: new Date().toISOString(),
         }
         setActiveSession(prev =>
-          prev ? { ...prev, messages: [...prev.messages, assistantMsg] } : null
+          prev && prev.id === sessionId
+            ? { ...prev, messages: [...prev.messages, assistantMsg] }
+            : prev
         )
         setStreamingText('')
         streamingTextRef.current = ''
         setStreaming(false)
       },
       onError: (err) => {
+        if (!isStreamSessionActive()) return
         setError(err.message)
         setStreaming(false)
         setStreamingText('')
@@ -117,7 +154,11 @@ export function useAIPlanner() {
   }, [activeSession, streaming])
 
   const applyPlan = useCallback(async (plan: GeneratedPlan) => {
-    if (!activeSession) return null
+    if (!activeSession || applyingRef.current) return null
+    // A duplicate apply would create duplicate pools, so gate it on a ref that
+    // updates synchronously rather than on the re-rendered `applying` state.
+    applyingRef.current = true
+    setApplying(true)
     try {
       const res = await post<ApplyPlanResponse>(
         `/api/v1/ai/sessions/${activeSession.id}/apply-plan`,
@@ -127,6 +168,9 @@ export function useAIPlanner() {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to apply plan')
       return null
+    } finally {
+      applyingRef.current = false
+      setApplying(false)
     }
   }, [activeSession])
 
@@ -136,6 +180,7 @@ export function useAIPlanner() {
     streaming,
     streamingText,
     loading,
+    applying,
     error,
     fetchSessions,
     createSession,

--- a/ui/src/hooks/useAccounts.ts
+++ b/ui/src/hooks/useAccounts.ts
@@ -1,35 +1,43 @@
 import { useState, useCallback } from 'react'
 import { get, post, del } from '../api/client'
+import { useLatestRequest } from './useLatestRequest'
 import type { Account, CreateAccountRequest } from '../api/types'
 
 export function useAccounts() {
   const [accounts, setAccounts] = useState<Account[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { begin, isCurrent } = useLatestRequest()
 
   const fetchAccounts = useCallback(async () => {
+    const token = begin()
     setLoading(true)
     setError(null)
     try {
       const data = await get<Account[]>('/api/v1/accounts')
+      if (!isCurrent(token)) return
       setAccounts(data ?? [])
     } catch (e) {
+      if (!isCurrent(token)) return
       setError(e instanceof Error ? e.message : 'Failed to fetch accounts')
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [begin, isCurrent])
 
   const createAccount = useCallback(async (data: CreateAccountRequest) => {
     const account = await post<Account>('/api/v1/accounts', data)
+    // This write is newer than any list load still in flight
+    begin()
     setAccounts(prev => [...prev, account])
     return account
-  }, [])
+  }, [begin])
 
   const deleteAccount = useCallback(async (id: number) => {
     await del(`/api/v1/accounts/${id}`)
+    begin()
     setAccounts(prev => prev.filter(a => a.id !== id))
-  }, [])
+  }, [begin])
 
   return { accounts, loading, error, fetchAccounts, createAccount, deleteAccount }
 }

--- a/ui/src/hooks/useDiscovery.ts
+++ b/ui/src/hooks/useDiscovery.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import { get, post, del } from '../api/client'
+import { useLatestRequest } from './useLatestRequest'
 import type {
   DiscoveryResourcesResponse,
   DiscoveryAgent,
@@ -17,6 +18,7 @@ export function useDiscoveryResources() {
   const [data, setData] = useState<DiscoveryResourcesResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { begin, isCurrent } = useLatestRequest()
 
   const fetch = useCallback(
     async (
@@ -32,6 +34,7 @@ export function useDiscoveryResources() {
         page_size?: number
       },
     ) => {
+      const token = begin()
       setLoading(true)
       setError(null)
       try {
@@ -50,14 +53,16 @@ export function useDiscoveryResources() {
         const resp = await get<DiscoveryResourcesResponse>(
           `/api/v1/discovery/resources?${params}`,
         )
+        if (!isCurrent(token)) return
         setData(resp)
       } catch (err) {
+        if (!isCurrent(token)) return
         setError(err instanceof Error ? err.message : 'Failed to load resources')
       } finally {
         setLoading(false)
       }
     },
-    [],
+    [begin, isCurrent],
   )
 
   const linkToPool = useCallback(
@@ -80,21 +85,25 @@ export function useSyncJobs() {
   const [jobs, setJobs] = useState<SyncJob[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { begin, isCurrent } = useLatestRequest()
 
   const fetch = useCallback(async (accountId: number) => {
+    const token = begin()
     setLoading(true)
     setError(null)
     try {
       const resp = await get<SyncJobsResponse>(
         `/api/v1/discovery/sync?account_id=${accountId}`,
       )
+      if (!isCurrent(token)) return
       setJobs(resp.items)
     } catch (err) {
+      if (!isCurrent(token)) return
       setError(err instanceof Error ? err.message : 'Failed to load sync jobs')
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [begin, isCurrent])
 
   const triggerSync = useCallback(async (options: {
     accountId?: number
@@ -191,8 +200,10 @@ export function useDiscoveryAgents() {
   const [agents, setAgents] = useState<DiscoveryAgent[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { begin, isCurrent } = useLatestRequest()
 
   const fetch = useCallback(async (accountId?: number) => {
+    const token = begin()
     setLoading(true)
     setError(null)
     try {
@@ -202,13 +213,15 @@ export function useDiscoveryAgents() {
       const resp = await get<DiscoveryAgentsResponse>(
         `/api/v1/discovery/agents${params ? '?' + params : ''}`,
       )
+      if (!isCurrent(token)) return
       setAgents(resp.items)
     } catch (err) {
+      if (!isCurrent(token)) return
       setError(err instanceof Error ? err.message : 'Failed to load agents')
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [begin, isCurrent])
 
   const deleteAgent = useCallback(async (agentId: string) => {
     await del(`/api/v1/discovery/agents/${agentId}`)

--- a/ui/src/hooks/useDrift.ts
+++ b/ui/src/hooks/useDrift.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import { get, post } from '../api/client'
+import { useLatestRequest } from './useLatestRequest'
 import type {
   DriftListResponse,
   RunDriftDetectionResponse,
@@ -10,6 +11,7 @@ export function useDrift() {
   const [data, setData] = useState<DriftListResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { begin, isCurrent } = useLatestRequest()
 
   const fetch = useCallback(
     async (filters?: {
@@ -20,6 +22,7 @@ export function useDrift() {
       page?: number
       page_size?: number
     }) => {
+      const token = begin()
       setLoading(true)
       setError(null)
       try {
@@ -35,8 +38,10 @@ export function useDrift() {
         const resp = await get<DriftListResponse>(
           `/api/v1/drift${qs ? '?' + qs : ''}`,
         )
+        if (!isCurrent(token)) return
         setData(resp)
       } catch (err) {
+        if (!isCurrent(token)) return
         setError(
           err instanceof Error ? err.message : 'Failed to load drift items',
         )
@@ -44,7 +49,7 @@ export function useDrift() {
         setLoading(false)
       }
     },
-    [],
+    [begin, isCurrent],
   )
 
   const detect = useCallback(

--- a/ui/src/hooks/useLatestRequest.ts
+++ b/ui/src/hooks/useLatestRequest.ts
@@ -1,0 +1,35 @@
+import { useCallback, useRef } from 'react'
+
+/**
+ * Guards state updates against out-of-order async responses.
+ *
+ * Overlapping requests (fast typing, quick filter changes, context switches)
+ * can resolve in any order, so a slower earlier response may land last and
+ * clobber the newer result. Call `begin()` when a request starts and check
+ * `isCurrent(token)` before committing its result:
+ *
+ *   const token = begin()
+ *   const resp = await get(...)
+ *   if (!isCurrent(token)) return
+ *   setData(resp)
+ *
+ * Mutations that write the same state should also call `begin()` right before
+ * committing, so an in-flight load cannot overwrite the newer local value.
+ *
+ * Use one instance per piece of state; sharing an instance across unrelated
+ * state would invalidate requests that never competed with each other.
+ */
+export function useLatestRequest() {
+  const seqRef = useRef(0)
+
+  /** Starts a new request and invalidates every earlier one. */
+  const begin = useCallback(() => {
+    seqRef.current += 1
+    return seqRef.current
+  }, [])
+
+  /** Reports whether `token` still belongs to the most recent request. */
+  const isCurrent = useCallback((token: number) => seqRef.current === token, [])
+
+  return { begin, isCurrent }
+}

--- a/ui/src/hooks/usePendingAction.ts
+++ b/ui/src/hooks/usePendingAction.ts
@@ -1,0 +1,33 @@
+import { useCallback, useRef, useState } from 'react'
+
+/**
+ * Gates an async action so it cannot be fired again while it is still running.
+ *
+ * `pending` drives the button's disabled state; the ref guard additionally
+ * blocks a second click that lands before React re-renders with the new state.
+ * The flag is always cleared in a `finally`, so a failed action re-enables the
+ * control instead of leaving it stuck.
+ */
+export function usePendingAction<A extends unknown[], R>(
+  action: (...args: A) => Promise<R>,
+): { pending: boolean; run: (...args: A) => Promise<R | undefined> } {
+  const [pending, setPending] = useState(false)
+  const inFlightRef = useRef(false)
+
+  const run = useCallback(
+    async (...args: A): Promise<R | undefined> => {
+      if (inFlightRef.current) return undefined
+      inFlightRef.current = true
+      setPending(true)
+      try {
+        return await action(...args)
+      } finally {
+        inFlightRef.current = false
+        setPending(false)
+      }
+    },
+    [action],
+  )
+
+  return { pending, run }
+}

--- a/ui/src/hooks/useRecommendations.ts
+++ b/ui/src/hooks/useRecommendations.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import { get, post } from '../api/client'
+import { useLatestRequest } from './useLatestRequest'
 import type {
   RecommendationsListResponse,
   GenerateRecommendationsResponse,
@@ -10,6 +11,7 @@ export function useRecommendations() {
   const [data, setData] = useState<RecommendationsListResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { begin, isCurrent } = useLatestRequest()
 
   const fetch = useCallback(
     async (filters?: {
@@ -20,6 +22,7 @@ export function useRecommendations() {
       page?: number
       page_size?: number
     }) => {
+      const token = begin()
       setLoading(true)
       setError(null)
       try {
@@ -36,8 +39,10 @@ export function useRecommendations() {
         const resp = await get<RecommendationsListResponse>(
           `/api/v1/recommendations${qs ? '?' + qs : ''}`,
         )
+        if (!isCurrent(token)) return
         setData(resp)
       } catch (err) {
+        if (!isCurrent(token)) return
         setError(
           err instanceof Error ? err.message : 'Failed to load recommendations',
         )
@@ -45,7 +50,7 @@ export function useRecommendations() {
         setLoading(false)
       }
     },
-    [],
+    [begin, isCurrent],
   )
 
   const generate = useCallback(

--- a/ui/src/hooks/useSearch.ts
+++ b/ui/src/hooks/useSearch.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { get } from '../api/client'
+import { useLatestRequest } from './useLatestRequest'
 import type { SearchResponse } from '../api/types'
 
 const DEBOUNCE_MS = 300
@@ -15,18 +16,18 @@ export function useSearch() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const abortRef = useRef<AbortController | null>(null)
+  const { begin, isCurrent } = useLatestRequest()
 
   const search = useCallback(async (q: string) => {
     if (!q.trim()) {
+      begin()
       setResults(null)
       setLoading(false)
       return
     }
 
-    // Cancel any in-flight request
-    abortRef.current?.abort()
-    abortRef.current = new AbortController()
+    // Supersede any in-flight request so its response cannot land last
+    const token = begin()
 
     setLoading(true)
     setError(null)
@@ -43,20 +44,22 @@ export function useSearch() {
       params.set('page_size', '20')
 
       const resp = await get<SearchResponse>(`/api/v1/search?${params}`)
+      if (!isCurrent(token)) return
       setResults(resp)
     } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') return
+      if (!isCurrent(token)) return
       setError(err instanceof Error ? err.message : 'Search failed')
       setResults(null)
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [begin, isCurrent])
 
   useEffect(() => {
     if (timerRef.current) clearTimeout(timerRef.current)
 
     if (!query.trim()) {
+      begin()
       setResults(null)
       setLoading(false)
       return
@@ -68,7 +71,7 @@ export function useSearch() {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
     }
-  }, [query, search])
+  }, [query, search, begin])
 
   return { query, setQuery, results, loading, error }
 }

--- a/ui/src/pages/AIPlannerPage.tsx
+++ b/ui/src/pages/AIPlannerPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from 'react'
 import { Bot, Plus, Trash2, Send, Loader2, AlertCircle, CheckCircle } from 'lucide-react'
 import { useAIPlanner } from '../hooks/useAIPlanner'
+import { usePendingAction } from '../hooks/usePendingAction'
 import { extractPlan } from '../utils/planParser'
 import type { GeneratedPlan } from '../api/types'
 import { useToast } from '../hooks/useToast'
@@ -12,6 +13,7 @@ export default function AIPlannerPage() {
     streaming,
     streamingText,
     loading,
+    applying,
     error,
     fetchSessions,
     createSession,
@@ -48,7 +50,7 @@ export default function AIPlannerPage() {
     }
   }
 
-  async function handleApplyPlan(plan: GeneratedPlan) {
+  async function handleApplyPlan(plan: GeneratedPlan): Promise<void> {
     const res = await applyPlan(plan)
     if (res) {
       showToast(`Created ${res.created} pools`, 'success')
@@ -128,6 +130,7 @@ export default function AIPlannerPage() {
                   key={msg.id}
                   role={msg.role}
                   content={msg.content}
+                  applyPending={applying}
                   onApplyPlan={handleApplyPlan}
                 />
               ))}
@@ -137,6 +140,7 @@ export default function AIPlannerPage() {
                   role="assistant"
                   content={streamingText}
                   isStreaming
+                  applyPending={applying}
                   onApplyPlan={handleApplyPlan}
                 />
               )}
@@ -191,21 +195,24 @@ interface MessageBubbleProps {
   role: string
   content: string
   isStreaming?: boolean
-  onApplyPlan: (plan: GeneratedPlan) => void
+  /** True while any plan on the page is being applied */
+  applyPending?: boolean
+  onApplyPlan: (plan: GeneratedPlan) => Promise<void>
 }
 
-function MessageBubble({ role, content, isStreaming, onApplyPlan }: MessageBubbleProps) {
-  const [applying, setApplying] = useState(false)
-
+function MessageBubble({ role, content, isStreaming, applyPending, onApplyPlan }: MessageBubbleProps) {
   const isUser = role === 'user'
   const plan = !isStreaming ? extractPlan(content) : null
 
-  async function handleApply() {
-    if (!plan || applying) return
-    setApplying(true)
-    onApplyPlan(plan)
-    // The parent will handle the result; we just show "applying" state
-    setApplying(false)
+  // Applying twice would create duplicate pools, so the button stays disabled
+  // until the request settles (including on failure).
+  const { pending: applying, run: runApply } = usePendingAction(onApplyPlan)
+
+  function handleApply() {
+    if (!plan) return
+    void runApply(plan).catch(() => {
+      // Failures are surfaced by the planner hook; the button re-enables either way
+    })
   }
 
   return (
@@ -236,7 +243,7 @@ function MessageBubble({ role, content, isStreaming, onApplyPlan }: MessageBubbl
             </div>
             <button
               onClick={handleApply}
-              disabled={applying}
+              disabled={applying || applyPending}
               className="w-full flex items-center justify-center gap-2 px-3 py-1.5 bg-green-600 text-white rounded text-sm hover:bg-green-700 disabled:opacity-50"
             >
               {applying ? (

--- a/ui/src/pages/ApiKeysPage.tsx
+++ b/ui/src/pages/ApiKeysPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Key, Plus, Ban, Copy, Check, AlertCircle } from 'lucide-react'
 import { useApiKeys } from '../hooks/useApiKeys'
 import { useSecuritySettings } from '../hooks/useSettings'
+import { usePendingAction } from '../hooks/usePendingAction'
 import type { ApiKeyCreateResponse } from '../api/types'
 
 // Must match backend validScopes in auth_handlers.go createAPIKey
@@ -38,7 +39,7 @@ export default function ApiKeysPage() {
   const [copied, setCopied] = useState(false)
   const [createError, setCreateError] = useState('')
 
-  async function handleCreate() {
+  async function createKey() {
     if (!newKeyName.trim()) return
     setCreateError('')
     try {
@@ -55,6 +56,9 @@ export default function ApiKeysPage() {
       setCreateError(err instanceof Error ? err.message : 'Failed to create key')
     }
   }
+
+  // Gated so a second click before the request settles cannot mint a duplicate key
+  const { pending: creating, run: handleCreate } = usePendingAction(createKey)
 
   function toggleScope(scope: string) {
     if (scope === '*') {
@@ -207,11 +211,11 @@ export default function ApiKeysPage() {
 
             <div className="flex gap-2 pt-1">
               <button
-                onClick={handleCreate}
-                disabled={!newKeyName.trim()}
+                onClick={() => void handleCreate()}
+                disabled={creating || !newKeyName.trim()}
                 className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
               >
-                Create
+                {creating ? 'Creating...' : 'Create'}
               </button>
               <button
                 onClick={() => setShowCreate(false)}

--- a/ui/src/pages/DiscoveryPage.tsx
+++ b/ui/src/pages/DiscoveryPage.tsx
@@ -183,6 +183,17 @@ export default function DiscoveryPage() {
     loadResources()
   }, [loadResources])
 
+  // The scan poller outlives the render that started it, so it reads the
+  // current account/loader through refs instead of a stale closure.
+  const loadResourcesRef = useRef(loadResources)
+  const selectedAccountIdRef = useRef(selectedAccountId)
+  useEffect(() => {
+    loadResourcesRef.current = loadResources
+  }, [loadResources])
+  useEffect(() => {
+    selectedAccountIdRef.current = selectedAccountId
+  }, [selectedAccountId])
+
   useEffect(() => {
     setResourcePage(1)
   }, [selectedAccountId, statusFilter, typeFilter, linkedFilter, searchQuery, resourcePageSize])
@@ -251,8 +262,8 @@ export default function DiscoveryPage() {
       if (updatedJobs.length > 0) {
         setTrackedScanJobs((current) => mergeJobs(current, updatedJobs))
       }
-      if (selectedAccountId) {
-        fetchJobs(selectedAccountId)
+      if (selectedAccountIdRef.current) {
+        fetchJobs(selectedAccountIdRef.current)
       }
       if (pending.size === 0 || attempts >= 40) {
         if (scanPollRef.current) {
@@ -260,9 +271,9 @@ export default function DiscoveryPage() {
           scanPollRef.current = null
         }
         fetchAccounts()
-        loadResources()
-        if (selectedAccountId) {
-          fetchJobs(selectedAccountId)
+        loadResourcesRef.current()
+        if (selectedAccountIdRef.current) {
+          fetchJobs(selectedAccountIdRef.current)
         }
       }
     }, 3000)

--- a/ui/src/pages/UpdatesPage.tsx
+++ b/ui/src/pages/UpdatesPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useAuth } from '../hooks/useAuth'
 import { useToast } from '../hooks/useToast'
 import { useUpdates } from '../hooks/useUpdates'
+import { usePendingAction } from '../hooks/usePendingAction'
 import type { UpdateStatusResponse } from '../api/types'
 import { scheduleFrontendResetAfterUpgrade } from '../utils/upgradeReload'
 
@@ -206,7 +207,7 @@ export default function UpdatesPage() {
     showToast('Update metadata refreshed', 'success')
   }
 
-  async function handleUpgrade() {
+  async function requestUpgrade() {
     try {
       const response = await triggerUpgrade()
       setPendingTargetVersion(response.target_version)
@@ -215,6 +216,9 @@ export default function UpdatesPage() {
       showToast(err instanceof Error ? err.message : 'Failed to request upgrade', 'error')
     }
   }
+
+  // Gated so a second click cannot submit a duplicate upgrade request
+  const { pending: submittingUpgrade, run: handleUpgrade } = usePendingAction(requestUpgrade)
 
   if (role !== 'admin') {
     return (
@@ -239,7 +243,13 @@ export default function UpdatesPage() {
       ? status
       : { status: pendingTargetVersion ? 'upgrade_requested' : 'idle', target_version: pendingTargetVersion ?? undefined }
   const waitingForHost = pendingTargetVersion !== null && normalizeStatus(status?.status) === 'idle'
-  const canTriggerUpgrade = summary?.update_available === true && !actionLoading
+  // An upgrade that is already requested, queued, or rolling out must not be re-submitted
+  const upgradeInFlight =
+    submittingUpgrade ||
+    actionLoading ||
+    pendingTargetVersion !== null ||
+    isActiveUpgradeStatus(status?.status)
+  const canTriggerUpgrade = summary?.update_available === true && !upgradeInFlight
 
   return (
     <div className="p-6 space-y-6">
@@ -264,7 +274,7 @@ export default function UpdatesPage() {
             disabled={!canTriggerUpgrade}
             className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-400"
           >
-            {actionLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowUpCircle className="w-4 h-4" />}
+            {upgradeInFlight ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowUpCircle className="w-4 h-4" />}
             {summary?.update_available ? `Upgrade to ${formatVersion(summary.latest_version)}` : 'No update available'}
           </button>
         </div>

--- a/ui/src/wizard/hooks/useConflictChecker.ts
+++ b/ui/src/wizard/hooks/useConflictChecker.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { post } from '../../api/client'
+import { useLatestRequest } from '../../hooks/useLatestRequest'
 import type { SchemaPoolEntry, SchemaCheckRequest, SchemaCheckResponse, SchemaConflict } from '../../api/types'
 import type { SchemaNode } from '../utils/cidr'
 
@@ -22,10 +23,12 @@ export function useConflictChecker(schema: SchemaNode | null, enabled: boolean) 
   const [conflicts, setConflicts] = useState<SchemaConflict[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { begin, isCurrent } = useLatestRequest()
 
   const check = useCallback(async () => {
     if (!schema || !enabled) return
 
+    const token = begin()
     setLoading(true)
     setError(null)
 
@@ -33,14 +36,16 @@ export function useConflictChecker(schema: SchemaNode | null, enabled: boolean) 
       const pools = flattenSchema(schema)
       const req: SchemaCheckRequest = { pools }
       const res = await post<SchemaCheckResponse>('/api/v1/schema/check', req)
+      if (!isCurrent(token)) return
       setConflicts(res.conflicts ?? [])
     } catch (err) {
+      if (!isCurrent(token)) return
       setError(err instanceof Error ? err.message : 'Failed to check conflicts')
       setConflicts([])
     } finally {
       setLoading(false)
     }
-  }, [schema, enabled])
+  }, [schema, enabled, begin, isCurrent])
 
   useEffect(() => {
     check()


### PR DESCRIPTION
Eleven concurrency findings from #223 and #224, in two classes. Fixed with two shared conventions rather than a different trick per hook.

## The conventions

**`useLatestRequest`** — issues a monotonic token per request and reports whether it's still the newest, so a superseded response skips its state commit. Mutations that write the same state also call `begin()` before committing, so an in-flight load can't overwrite a newer local value. One instance per piece of state; sharing one across unrelated state would invalidate requests that never competed.

`setLoading(false)` deliberately stays unconditional in `finally` — a superseded request that skipped it could otherwise leave a spinner stuck forever when a *mutation* rather than another load superseded it.

**`usePendingAction`** — wraps an async action, exposing a `pending` flag plus a ref guard that blocks a second click landing before React re-renders. Cleared in `finally`, so a failure re-enables the control.

## Class 1 — stale responses

| Hook | Fix |
|---|---|
| `useSearch` | Had a **dead `AbortController`** — it was never passed to `get()`, so the abort branch could never fire. That's why the "cancellation" and "stale results" findings were one bug. Replaced with the sequence guard; clearing the query also calls `begin()` so an in-flight search can't repopulate a cleared box. |
| `useDrift`, `useRecommendations` | Sequence guard around fetch; drives filter changes. |
| `useAccounts` | Guard on fetch; create/delete call `begin()` before their local list write, so a slow initial GET can't drop the new row. |
| `useConflictChecker` | Guard around the `/schema/check` POST — newest schema's conflicts win. |
| `useAIPlanner` | Session id captured at send time; deltas/done/error dropped unless the session is still active, appends use a functional updater keyed on session id. |
| `useDiscovery` + `DiscoveryPage` | Guards on all three loaders. `pollScanJobs` now reads current refs instead of the closure captured when the scan started — a completed scan reloads the account selected **now**, not the one selected when it began. |

## Class 2 — duplicate submits

`UsersAdminPanel` and `ApiKeysPage` create buttons gated on `usePendingAction`.

**AI planner Apply Plan needed two layers**, since a duplicate apply creates duplicate pools: the bubble previously set `applying` true and false in the *same tick*, so it never actually disabled. It now awaits via `usePendingAction`, and the hook holds an `applyingRef` so two different bubbles can't both fire.

**`UpdatesPage`** gating now also excludes a pending target version and an active upgrade status — previously only `actionLoading`, so the button re-enabled the moment the request returned while the host rollout was still running.

## Tests

10 new test files, 17 new tests (13 files/83 tests → 23 files/100 tests). **No existing test modified** — the UpdatesPage gating test went into a new `UpdatesPageUpgradeGating.test.tsx` rather than editing the existing file.

The new tests were confirmed to actually fail against unguarded code by temporarily neutering each guard: forcing `isCurrent` to always return true failed all 7 stale-response tests; removing `applyingRef` failed the duplicate-apply test; removing the stream session check failed the session-switch test (`expected 'half an answer' to be ''`).

## Note on scope

No `AbortSignal` plumbing was needed — every guard lives in a hook or component, so `client.ts` is untouched. That was deliberate: it kept this branch from colliding with the client-layer changes in #230, and merges cleanly with them.

## Verification

```
npx tsc --noEmit     clean
npx vitest run       23 files, 100 tests passed
```

Refs #223, #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)