### PR TITLE
UI: capture discovery import and merged network screenshots

### DIFF
--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -1,0 +1,150 @@
+# Regenerating Screenshots
+
+`scripts/capture_screenshots.js` drives a **live** CloudPAM instance with Playwright and
+writes PNGs to `photos/`. It is not a test — it needs a running server, an admin login and
+realistic data, because empty-state screenshots are worthless for review.
+
+> **Point this at a throwaway dev server only.** The script logs in, runs first-boot setup
+> and writes accounts, pools and discovered resources into whatever instance `APP_URL`
+> names.
+
+## Quick start
+
+All commands run from the repo root inside the Nix dev shell
+(`nix develop`, or prefix each command with `nix develop --command bash -c '...'`).
+
+```bash
+# 1. Build the UI (embedded into the binary via go:embed)
+cd ui && npm install && npm run build && cd ..
+
+# 2. Build the server (in-memory store is the easiest target)
+go build -o /tmp/cloudpam-shots ./cmd/cloudpam
+
+# 3. Run it on a scratch port. DEV_MODE=1 is required to opt into the in-memory store;
+#    RATE_LIMIT_RPS=0 keeps the default 10 rps limiter from throttling the capture run.
+DEV_MODE=1 RATE_LIMIT_RPS=0 CLOUDPAM_LOG_LEVEL=warn /tmp/cloudpam-shots -addr :8195 &
+
+# 4. Install the browser (first run only)
+npm install && npx playwright install chromium
+
+# 5. Capture
+APP_URL=http://localhost:8195 \
+  SCREENSHOT_USERNAME=screenshot-admin \
+  SCREENSHOT_PASSWORD='ScreenshotDev12345!' \
+  npm run screenshots
+```
+
+`npm run screenshots:discovery` captures only the discovery set, which is what you want
+when iterating on the Discovery page.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `APP_URL` | `http://localhost:8080` | Base URL of the running instance |
+| `SCREENSHOT_USERNAME` | `CLOUDPAM_ADMIN_USERNAME` | Admin username used for setup + login |
+| `SCREENSHOT_PASSWORD` | `CLOUDPAM_ADMIN_PASSWORD` | Admin password (min 12 chars, NIST 800-63B policy) |
+| `SCREENSHOT_SEED` | seed enabled | Set to `0` to skip seeding and capture existing data |
+| `SCREENSHOT_ONLY` | all groups | `legacy` and/or `discovery`, comma-separated |
+
+## Auth
+
+The app defaults to auth-always, so the script authenticates before it navigates anywhere.
+
+It deliberately does **not** rely on `CLOUDPAM_ADMIN_USERNAME` / `CLOUDPAM_ADMIN_PASSWORD`
+for the server. `cmd/cloudpam/main.go` sets the `needs_setup` flag *before* bootstrapping
+the env-var admin and never clears it, so a server started that way still reports
+`needs_setup: true` and the SPA's `ProtectedRoute` bounces every page to `/setup`. Instead:
+
+1. `GET /healthz` — if `needs_setup` is true,
+2. `POST /api/v1/auth/setup` with the screenshot credentials (this is what actually clears
+   the flag), then
+3. `POST /api/v1/auth/login`.
+
+The session cookie lands in the Playwright browser context, so page navigations and the
+seeding requests below share one authenticated jar. State-changing seed requests read the
+`csrf_token` cookie and echo it in the `X-CSRF-Token` header to satisfy the double-submit
+CSRF middleware.
+
+## Seeding
+
+Seeding is idempotent and runs once per capture run:
+
+1. **Managed pools** via `POST /api/v1/pools` — `Corp Supernet` (10.0.0.0/8) with children
+   `Prod East VPC` (10.20.0.0/16) and `Edge Transit` (10.40.0.0/17). Pools already present
+   by name are left alone.
+2. **Discovered cloud resources** via `POST /api/v1/discovery/ingest/org`, which also
+   auto-creates the `prod-platform` and `sandbox` cloud accounts. Org ingest upserts by
+   `(account, resource_id)`, so re-running is safe.
+
+The resource set is designed so every conflict class in the merged network view actually
+fires:
+
+| Seeded resource | Produces |
+|-----------------|----------|
+| `vpc-0a1prod` 10.20.0.0/16, `vpc-0c1edge` 10.40.64.0/17 | `unlinked_exact_pool` — exact match against a managed pool |
+| `subnet-0b9` parented to `vpc-deleted-999` | `missing_parent` |
+| `subnet-0b8` 172.16.5.0/24 inside `vpc-0b1prod` 10.21.0.0/16 | `invalid_nesting` |
+| `vpc-0d1shared` / `vpc-0d2shared`, both 192.168.10.0/24 | `duplicate_cidr` under the default account policy |
+| `vpc-0b1prod` + subnets | clean importable rows for the import preview |
+
+One detail worth knowing if you edit the payload: `last_seen_at` is set slightly in the
+**future**. `SyncService.ProcessResources` marks anything last seen before the ingest
+timestamp as stale, and stale resources are neither selectable nor importable, so a
+"now" timestamp from the client would race the server clock and produce an all-stale table.
+
+## Captures
+
+| File | View |
+|------|------|
+| `discovery-import-selection.png` | Resources tab with four rows checkbox-selected, selection toolbar and bulk link controls active |
+| `discovery-import-preview.png` | Import preview modal — per-resource action, status (importable / blocked) and evidence |
+| `discovery-network-hierarchy.png` | Merged Network → Hierarchy: managed pools with discovered children and conflict badges |
+| `discovery-network-flat.png` | Merged Network → Flat: all merged rows with state, issues and relationships |
+| `discovery-network-conflicts.png` | Merged Network → Conflicts: conflict list plus the populated review panel (evidence, review decisions, actions) |
+
+Two implementation notes:
+
+- The Discovery page renders inside a `flex-1 overflow-auto` container, so the document
+  never scrolls and Playwright's `fullPage` option returns exactly one viewport. The script
+  temporarily grows the viewport (`withViewportHeight`) so each view fits in one capture.
+- The release-update banner is dismissed first. It depends on an external version check and
+  would otherwise shift layout nondeterministically between runs.
+
+## Viewports
+
+`VIEWPORTS` at the top of the script is the single place viewports are declared. Adding one
+is a one-line change: append an entry and every capture re-runs against it, with `suffix`
+appended to each filename.
+
+**Only desktop (1280 wide) is captured today.** This is deliberate. The app has no
+responsive layout yet — `ui/src/components/Layout.tsx` and `Header.tsx` carry no breakpoint
+classes and there is no mobile navigation — so a narrow capture would document a broken
+layout rather than a reviewable one. Responsive work is tracked in issue #83; uncomment the
+mobile entry once that lands.
+
+## Known rot: the legacy captures
+
+`pools.png`, `blocks.png`, `accounts.png`, `analytics.png`, `visualization.png` and
+`bulk-actions-pools.png` predate the Sprint 9 React SPA. Their selectors (`Top-level
+Pools`, `button:has-text("Pools")`, the `⋮` bulk menu) belong to the old Alpine.js UI and
+no longer match anything, so the `legacy` group silently falls back to capturing the
+dashboard for each name and skips two files entirely. The committed PNGs are still the
+older, correct ones — do not regenerate the legacy group until those captures are rewritten
+against the current SPA routes.
+
+Use `SCREENSHOT_ONLY=discovery` (or `npm run screenshots:discovery`) to avoid overwriting
+them in the meantime.
+
+## Git LFS
+
+`.gitattributes` declares `photos/**/*.png` as LFS-tracked, but the PNGs currently in
+history were committed as plain git blobs and never migrated (`git lfs ls-files` returns
+nothing). Two consequences:
+
+- Every file under `photos/` shows as modified in a clean checkout, because git runs the
+  LFS clean filter over the working file and compares a pointer against a raw blob.
+- Newly added PNGs *are* stored as LFS pointers, so `photos/` ends up half-LFS.
+
+Migrating the existing files (`git lfs migrate import --include='photos/**/*.png'`) or
+dropping the LFS rules would fix this; it is out of scope for screenshot changes.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "screenshots": "node scripts/capture_screenshots.js"
+    "screenshots": "node scripts/capture_screenshots.js",
+    "screenshots:discovery": "SCREENSHOT_ONLY=discovery node scripts/capture_screenshots.js"
   },
   "devDependencies": {
     "playwright": "^1.55.1"

--- a/photos/discovery-import-preview.png
+++ b/photos/discovery-import-preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9f297896f4bca13cbcd558bce351fb3ff5d43dcb9b1fa66ea1f9aeb2256651e
+size 162750

--- a/photos/discovery-import-selection.png
+++ b/photos/discovery-import-selection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8b5038356fcb38426af4e3b4a227e04fd91d025b9619ef449368868fcdf90cd
+size 540611

--- a/photos/discovery-network-conflicts.png
+++ b/photos/discovery-network-conflicts.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7123b5273bdfc74b670f57c6506846f640605ae4cc211263c1cca3a994378df2
+size 965101

--- a/photos/discovery-network-flat.png
+++ b/photos/discovery-network-flat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce1974af47270f8baf4be4c53744de64613e78452660bf14523f6f827e0406a9
+size 856671

--- a/photos/discovery-network-hierarchy.png
+++ b/photos/discovery-network-hierarchy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cf07f3f88ccf957563b86449ee19e83e4d64fa62c36a56d41605425b92db2ce
+size 701596

--- a/scripts/capture_screenshots.js
+++ b/scripts/capture_screenshots.js
@@ -1,39 +1,248 @@
 // Capture app screenshots with Playwright.
+//
 // Usage:
 //   cd code/cloudpam
 //   npm install
 //   npx playwright install chromium
 //   APP_URL=http://localhost:8080 npm run screenshots
+//
+// See docs/SCREENSHOTS.md for the full runbook (server setup, auth, seeding).
+//
+// Environment:
+//   APP_URL              base URL of a running CloudPAM instance (default http://localhost:8080)
+//   SCREENSHOT_USERNAME  login username (falls back to CLOUDPAM_ADMIN_USERNAME)
+//   SCREENSHOT_PASSWORD  login password (falls back to CLOUDPAM_ADMIN_PASSWORD)
+//   SCREENSHOT_SEED      "0" disables demo-data seeding (default: seed enabled)
+//   SCREENSHOT_ONLY      comma-separated capture group filter: "legacy,discovery"
+//
+// WARNING: seeding writes accounts, pools and discovered resources into the target
+// instance. Only point this script at a throwaway dev server.
 
 const { chromium } = require('playwright');
 const path = require('path');
 const fs = require('fs');
 
-(async () => {
-  const baseURL = process.env.APP_URL || 'http://localhost:8080';
-  const outDir = path.join(process.cwd(), 'photos');
-  fs.mkdirSync(outDir, { recursive: true });
+const baseURL = process.env.APP_URL || 'http://localhost:8080';
+const outDir = path.join(process.cwd(), 'photos');
 
-  const browser = await chromium.launch();
-  const context = await browser.newContext({ viewport: { width: 1280, height: 900 }, deviceScaleFactor: 2 });
-  const page = await context.newPage();
+const username = process.env.SCREENSHOT_USERNAME || process.env.CLOUDPAM_ADMIN_USERNAME || '';
+const password = process.env.SCREENSHOT_PASSWORD || process.env.CLOUDPAM_ADMIN_PASSWORD || '';
+const seedEnabled = process.env.SCREENSHOT_SEED !== '0';
 
-  const safeShot = async (name, locatorOrPage) => {
-    const file = path.join(outDir, name);
+const onlyGroups = (process.env.SCREENSHOT_ONLY || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+// Viewports to capture. Adding a viewport is a one-line change: append an entry and
+// every capture below is re-run against it, with `suffix` appended to each filename.
+//
+// Only desktop is captured today. The app has no responsive layout yet (Layout.tsx and
+// Header.tsx carry no breakpoint classes and there is no mobile nav), so a narrow capture
+// would document a broken layout rather than a reviewable one. Responsive work is tracked
+// in issue #83; add the mobile entry below once that lands.
+const VIEWPORTS = [
+  { name: 'desktop', width: 1280, height: 900, suffix: '' },
+  // { name: 'mobile', width: 390, height: 844, suffix: '-mobile' },  // blocked on #83
+];
+
+// Taller viewport used for the discovery views (see withViewportHeight below).
+const RESOURCE_VIEW_HEIGHT = 1200;
+const NETWORK_VIEW_HEIGHT = 1700;
+// The conflict review panel is the tallest view: list + full evidence/review sidebar.
+const CONFLICT_VIEW_HEIGHT = 2300;
+
+function wants(group) {
+  return onlyGroups.length === 0 || onlyGroups.includes(group);
+}
+
+/**
+ * Screenshot helper. Accepts a Page (captures full page) or a Locator (captures the
+ * element). Never throws: a failed capture logs and lets the rest of the run continue.
+ */
+function makeShot(page, viewport) {
+  return async function shot(name, locatorOrPage) {
+    const ext = path.extname(name) || '.png';
+    const stem = name.slice(0, name.length - ext.length);
+    const file = path.join(outDir, `${stem}${viewport.suffix}${ext}`);
+    const target = locatorOrPage || page;
     try {
-      if (locatorOrPage?.screenshot) {
-        await locatorOrPage.screenshot({ path: file, fullPage: locatorOrPage === page });
-      } else {
+      if (target === page) {
         await page.screenshot({ path: file, fullPage: true });
+      } else {
+        await target.screenshot({ path: file });
       }
       console.log('Saved', file);
-    } catch (e) { console.warn('Failed to save', file, e.message); }
+    } catch (e) {
+      console.warn('Failed to save', file, e.message);
+    }
   };
+}
 
+// ---------------------------------------------------------------------------
+// Auth + seeding
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs first-boot setup when the server reports `needs_setup`. A fresh dev server
+ * always does: bootstrapping an admin via CLOUDPAM_ADMIN_USERNAME creates the user
+ * but leaves `needs_setup` true, so the SPA keeps redirecting to /setup. Creating the
+ * admin through this endpoint is what actually clears the flag.
+ */
+async function setupIfNeeded(context) {
+  const res = await context.request.get(`${baseURL}/healthz`);
+  if (!res.ok()) return;
+  const health = await res.json();
+  if (health.needs_setup !== true) return;
+
+  const created = await context.request.post(`${baseURL}/api/v1/auth/setup`, {
+    data: { username, password, email: `${username}@localhost` },
+  });
+  if (created.ok()) {
+    console.log(`Created first-boot admin ${username}`);
+  } else {
+    console.warn(`Setup failed (${created.status()}): ${await created.text()}`);
+  }
+}
+
+async function login(context) {
+  if (!username || !password) {
+    console.warn('No SCREENSHOT_USERNAME/SCREENSHOT_PASSWORD set; continuing unauthenticated.');
+    return false;
+  }
+  await setupIfNeeded(context);
+  const res = await context.request.post(`${baseURL}/api/v1/auth/login`, {
+    data: { username, password },
+  });
+  if (!res.ok()) {
+    console.warn(`Login failed (${res.status()}); continuing unauthenticated.`);
+    return false;
+  }
+  console.log(`Logged in as ${username}`);
+  return true;
+}
+
+/** Reads the double-submit CSRF cookie the server sets on any safe request. */
+async function csrfToken(context) {
+  await context.request.get(`${baseURL}/api/v1/pools`);
+  const cookies = await context.cookies(baseURL);
+  const cookie = cookies.find((c) => c.name === 'csrf_token');
+  return cookie ? cookie.value : '';
+}
+
+const SEED_POOLS = [
+  { name: 'Corp Supernet', cidr: '10.0.0.0/8' },
+  { name: 'Prod East VPC', cidr: '10.20.0.0/16', parent: 'Corp Supernet' },
+  { name: 'Edge Transit', cidr: '10.40.0.0/17', parent: 'Corp Supernet' },
+];
+
+const SEED_ACCOUNT_NAME = 'prod-platform';
+
+/**
+ * Builds the org-ingest payload. `last_seen_at` is deliberately in the future: the
+ * server marks anything last seen before the ingest timestamp as stale, and stale
+ * resources are not selectable for import.
+ */
+function seedIngestPayload() {
+  const now = new Date().toISOString();
+  const fresh = new Date(Date.now() + 60_000).toISOString();
+  const res = (o) => ({ provider: 'aws', status: 'active', discovered_at: now, last_seen_at: fresh, ...o });
+
+  return {
+    accounts: [
+      {
+        aws_account_id: '111111111111',
+        account_name: SEED_ACCOUNT_NAME,
+        provider: 'aws',
+        regions: ['us-east-1', 'us-west-2'],
+        resources: [
+          // Exactly matches the "Prod East VPC" pool -> unlinked_exact_pool conflict.
+          res({ region: 'us-east-1', resource_type: 'vpc', resource_id: 'vpc-0a1prod', name: 'prod-east-vpc', cidr: '10.20.0.0/16' }),
+          res({ region: 'us-east-1', resource_type: 'subnet', resource_id: 'subnet-0a1', name: 'prod-east-app-a', cidr: '10.20.1.0/24', parent_resource_id: 'vpc-0a1prod' }),
+          res({ region: 'us-east-1', resource_type: 'subnet', resource_id: 'subnet-0a2', name: 'prod-east-app-b', cidr: '10.20.2.0/24', parent_resource_id: 'vpc-0a1prod' }),
+          // Clean importable VPC + subnet.
+          res({ region: 'us-west-2', resource_type: 'vpc', resource_id: 'vpc-0b1prod', name: 'prod-west-vpc', cidr: '10.21.0.0/16' }),
+          res({ region: 'us-west-2', resource_type: 'subnet', resource_id: 'subnet-0b1', name: 'prod-west-app-a', cidr: '10.21.1.0/24', parent_resource_id: 'vpc-0b1prod' }),
+          // Parent was never discovered -> missing_parent conflict.
+          res({ region: 'us-west-2', resource_type: 'subnet', resource_id: 'subnet-0b9', name: 'orphan-analytics', cidr: '10.99.5.0/24', parent_resource_id: 'vpc-deleted-999' }),
+          // Not contained by its parent VPC -> invalid_nesting conflict.
+          res({ region: 'us-west-2', resource_type: 'subnet', resource_id: 'subnet-0b8', name: 'misnested-dmz', cidr: '172.16.5.0/24', parent_resource_id: 'vpc-0b1prod' }),
+          // Exactly matches the "Edge Transit" pool -> unlinked_exact_pool conflict.
+          res({ region: 'us-east-1', resource_type: 'vpc', resource_id: 'vpc-0c1edge', name: 'edge-transit-vpc', cidr: '10.40.64.0/17' }),
+          // Same CIDR twice in one account -> duplicate_cidr conflict under account policy.
+          res({ region: 'us-east-1', resource_type: 'vpc', resource_id: 'vpc-0d1shared', name: 'shared-services-a', cidr: '192.168.10.0/24' }),
+          res({ region: 'us-west-2', resource_type: 'vpc', resource_id: 'vpc-0d2shared', name: 'shared-services-b', cidr: '192.168.10.0/24' }),
+        ],
+      },
+      {
+        aws_account_id: '222222222222',
+        account_name: 'sandbox',
+        provider: 'aws',
+        regions: ['eu-west-1'],
+        resources: [
+          res({ region: 'eu-west-1', resource_type: 'vpc', resource_id: 'vpc-0e1sbx', name: 'sandbox-vpc', cidr: '10.60.0.0/16' }),
+          res({ region: 'eu-west-1', resource_type: 'subnet', resource_id: 'subnet-0e1', name: 'sandbox-app', cidr: '10.60.1.0/24', parent_resource_id: 'vpc-0e1sbx' }),
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Seeds managed pools and discovered cloud resources so the discovery views have
+ * something real to show. Idempotent: pools already present by name are left alone,
+ * and org ingest upserts discovered resources by (account, resource_id).
+ */
+async function seed(context) {
+  const token = await csrfToken(context);
+  const headers = { 'X-CSRF-Token': token, 'Content-Type': 'application/json' };
+
+  const poolsRes = await context.request.get(`${baseURL}/api/v1/pools`);
+  if (!poolsRes.ok()) {
+    console.warn(`Seed skipped: cannot list pools (${poolsRes.status()}).`);
+    return false;
+  }
+  const body = await poolsRes.json();
+  const existing = Array.isArray(body) ? body : body.items || [];
+  const byName = new Map(existing.map((p) => [p.name, p]));
+
+  for (const spec of SEED_POOLS) {
+    if (byName.has(spec.name)) continue;
+    const parent = spec.parent ? byName.get(spec.parent) : null;
+    const payload = { name: spec.name, cidr: spec.cidr };
+    if (parent) payload.parent_id = parent.id;
+    const res = await context.request.post(`${baseURL}/api/v1/pools`, { headers, data: payload });
+    if (!res.ok()) {
+      console.warn(`Seed pool ${spec.name} failed (${res.status()}): ${await res.text()}`);
+      continue;
+    }
+    byName.set(spec.name, await res.json());
+  }
+
+  const ingest = await context.request.post(`${baseURL}/api/v1/discovery/ingest/org`, {
+    headers,
+    data: seedIngestPayload(),
+  });
+  if (!ingest.ok()) {
+    console.warn(`Seed ingest failed (${ingest.status()}): ${await ingest.text()}`);
+    return false;
+  }
+  const summary = await ingest.json();
+  console.log(
+    `Seeded ${summary.accounts_processed} accounts / ${summary.total_resources} discovered resources`,
+  );
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Captures
+// ---------------------------------------------------------------------------
+
+async function captureLegacy(page, shot) {
   // Pools overview
   await page.goto(baseURL, { waitUntil: 'domcontentloaded' });
   await page.waitForSelector('text=Top-level Pools', { timeout: 5000 }).catch(() => {});
-  await safeShot('pools.png', page);
+  await shot('pools.png', page);
 
   // Blocks view (select first pool row if available)
   const viewBtn = page.locator('table >> text=View').first();
@@ -45,12 +254,12 @@ const fs = require('fs');
       await page.waitForSelector('table thead >> text=Prefix', { timeout: 4000 }).catch(() => {});
     }
   }
-  await safeShot('blocks.png', page);
+  await shot('blocks.png', page);
 
   // IP Space visualization (capture the card if present)
   const vizCard = page.locator('xpath=//strong[text()="IP Space Visualization"]/ancestor::*[contains(@class,"card")]').first();
   if (await vizCard.count()) {
-    await safeShot('visualization.png', vizCard);
+    await shot('visualization.png', vizCard);
   }
 
   // Bulk actions in Pools (select a couple and open the menu)
@@ -63,20 +272,154 @@ const fs = require('fs');
     const bulkBtn = page.locator('section:has-text("Top-level Pools") button:has-text("⋮")').first();
     if (await bulkBtn.count()) {
       await bulkBtn.click().catch(() => {});
-      await safeShot('bulk-actions-pools.png', page);
+      await shot('bulk-actions-pools.png', page);
     }
   }
 
   // Accounts page
   await page.locator('button:has-text("Accounts")').click().catch(() => {});
   await page.waitForSelector('text=Accounts', { timeout: 4000 }).catch(() => {});
-  await safeShot('accounts.png', page);
+  await shot('accounts.png', page);
 
   // Analytics page
   await page.locator('button:has-text("Analytics")').click().catch(() => {});
   await page.waitForSelector('text=All Assigned Blocks', { timeout: 4000 }).catch(() => {});
-  await safeShot('analytics.png', page);
+  await shot('analytics.png', page);
+}
 
-  await browser.close();
-})();
+/**
+ * The Discovery page renders inside a `flex-1 overflow-auto` container, so the document
+ * itself never scrolls and Playwright's fullPage option yields exactly one viewport.
+ * Growing the viewport is the only way to fit the whole view into one capture.
+ */
+async function withViewportHeight(page, height, fn) {
+  const original = page.viewportSize();
+  await page.setViewportSize({ width: original.width, height });
+  try {
+    await fn();
+  } finally {
+    await page.setViewportSize(original);
+  }
+}
 
+/** Hides the release-update banner, which depends on an external version check. */
+async function dismissUpdateBanner(page) {
+  const dismiss = page.locator('button:has-text("Dismiss")').first();
+  if (await dismiss.count()) {
+    await dismiss.click().catch(() => {});
+    await page.waitForTimeout(200);
+  }
+}
+
+/** Opens /discovery and pins the account selector to the seeded account. */
+async function openDiscovery(page) {
+  await page.goto(`${baseURL}/discovery`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('h1:has-text("Cloud Discovery")', { timeout: 15000 });
+  await dismissUpdateBanner(page);
+
+  const accountSelect = page.locator('select').first();
+  const options = await accountSelect.locator('option').allTextContents();
+  const match = options.find((label) => label.startsWith(SEED_ACCOUNT_NAME));
+  if (match) {
+    await accountSelect.selectOption({ label: match });
+  }
+  await page.waitForTimeout(700);
+}
+
+async function captureDiscovery(page, shot) {
+  await openDiscovery(page);
+
+  // --- Checkbox multi-select + import preview -------------------------------
+  const rowCheckboxes = page.locator('table tbody tr input[type="checkbox"]:not([disabled])');
+  const rowCount = await rowCheckboxes.count();
+  if (rowCount === 0) {
+    console.warn('Discovery: no selectable resource rows; skipping import captures.');
+  } else {
+    for (let i = 0; i < Math.min(4, rowCount); i++) {
+      await rowCheckboxes.nth(i).check().catch(() => {});
+    }
+    await page.waitForTimeout(200);
+    await withViewportHeight(page, RESOURCE_VIEW_HEIGHT, async () => {
+      await shot('discovery-import-selection.png', page);
+    });
+
+    await page.locator('button:has-text("Preview Import")').click();
+    // The modal panel is the scrollable child of the fixed overlay.
+    const modal = page
+      .locator('h2:text-is("Import preview")')
+      .locator('xpath=ancestor::div[contains(@class,"overflow-auto")][1]');
+    await modal.waitFor({ state: 'visible', timeout: 15000 });
+    await page.waitForTimeout(400);
+    await withViewportHeight(page, RESOURCE_VIEW_HEIGHT, async () => {
+      await shot('discovery-import-preview.png', modal);
+    });
+
+    await page.locator('button:has-text("Cancel")').last().click().catch(() => {});
+    await page.waitForTimeout(200);
+  }
+
+  // --- Merged network: hierarchy, flat, conflicts ---------------------------
+  await page.locator('button:has-text("Merged Network")').click();
+  await page.waitForSelector('button:has-text("Hierarchy")', { timeout: 10000 });
+
+  await withViewportHeight(page, NETWORK_VIEW_HEIGHT, async () => {
+    await page.locator('button:has-text("Hierarchy")').click();
+    await page.waitForTimeout(900);
+    await shot('discovery-network-hierarchy.png', page);
+
+    await page.locator('button:has-text("Flat")').click();
+    await page.waitForTimeout(900);
+    await shot('discovery-network-flat.png', page);
+  });
+
+  await withViewportHeight(page, CONFLICT_VIEW_HEIGHT, async () => {
+    await page.locator('button:has-text("Conflicts")').first().click();
+    await page.waitForTimeout(900);
+
+    // Select the first conflict so the right-hand review panel is populated.
+    const conflictRow = page.locator('button:has-text("Discovered CIDR matches managed pool")').first();
+    if (await conflictRow.count()) {
+      await conflictRow.click().catch(() => {});
+      await page.waitForTimeout(600);
+    } else {
+      console.warn('Discovery: no conflicts listed; capturing empty conflict list.');
+    }
+    await shot('discovery-network-conflicts.png', page);
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+async function main() {
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const browser = await chromium.launch();
+  try {
+    let seeded = false;
+    for (const viewport of VIEWPORTS) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+        deviceScaleFactor: 2,
+      });
+      try {
+        await login(context);
+        if (seedEnabled && !seeded) {
+          seeded = await seed(context);
+        }
+        const page = await context.newPage();
+        const shot = makeShot(page, viewport);
+        if (wants('legacy')) await captureLegacy(page, shot);
+        if (wants('discovery')) await captureDiscovery(page, shot);
+      } finally {
+        await context.close();
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/capture_screenshots.js
+++ b/scripts/capture_screenshots.js
@@ -99,7 +99,7 @@ async function setupIfNeeded(context) {
     data: { username, password, email: `${username}@localhost` },
   });
   if (created.ok()) {
-    console.log(`Created first-boot admin ${username}`);
+    console.log('Created first-boot admin account');
   } else {
     console.warn(`Setup failed (${created.status()}): ${await created.text()}`);
   }
@@ -118,7 +118,7 @@ async function login(context) {
     console.warn(`Login failed (${res.status()}); continuing unauthenticated.`);
     return false;
   }
-  console.log(`Logged in as ${username}`);
+  console.log('Logged in for screenshot capture');
   return true;
 }
 


### PR DESCRIPTION
Closes #195. Adds all four captures the issue asked for, plus one extra.

| Screenshot | Shows |
|---|---|
| `discovery-import-selection` | checkbox multi-select import |
| `discovery-import-preview` | import preview |
| `discovery-network-hierarchy` | merged hierarchy view |
| `discovery-network-flat` | flat network view |
| `discovery-network-conflicts` | conflict review panel |

## These are real, populated views

The hard part wasn't the captures — it was making them worth having. The Discovery page is empty on a fresh instance, so naive screenshots would show empty states. The script now:

- **bootstraps an admin and logs in**, since the app defaults to auth-always and `/discovery` is unreachable otherwise
- **seeds discovered resources and pools** so the merged views contain genuine conflicts

The hierarchy capture shows 13 rows / 5 issues with duplicate CIDRs (`192.168.10.0/24` twice), invalid nesting (`misnested-dmz` under a `/16`), a missing parent, and link candidates — i.e. the actual states the conflict workflow exists to resolve.

## Browser lifecycle fix

The script had no `try/finally` after `chromium.launch()`, so any uncaught step failure leaked the browser process. Now wrapped properly. That was filed separately as a low finding in #224 — fixed here since this PR rewrites the file substantially.

## Viewport scope — deliberate deferral

The issue asks for "at least one narrow/mobile viewport where practical". **Desktop only for now.** When this was written the app had no responsive layout at all (`Layout.tsx`/`Header.tsx` had zero breakpoint classes, no mobile nav), so a narrow capture would have documented a broken layout rather than a reviewable one.

The script takes a viewport list, so adding one is a small change once #83 (open PR #238) lands. This is stated explicitly in the doc.

## Docs

`docs/SCREENSHOTS.md` covers regeneration end to end — build, server startup, admin bootstrap, seeding, and how to add a capture. That satisfies the issue's "PR documentation explains how to regenerate" criterion.

## Note

The five PNGs are committed as Git LFS pointers, consistent with `.gitattributes`. Pre-existing `photos/*.png` show as modified in fresh worktrees due to an unrelated LFS checkout quirk in this repo; those are untouched here.

Refs #195, #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)