### PR TITLE
UI/API: align permission gating and fix discovery correctness

### DIFF
--- a/cmd/openapi-validate/main.go
+++ b/cmd/openapi-validate/main.go
@@ -65,13 +65,13 @@ func validateSpec(data []byte) (int, int, error) {
 	if !ok || len(paths) == 0 {
 		return 0, 0, errors.New("paths must be a non-empty mapping")
 	}
-	components, ok := spec["components"].(map[string]any)
-	if !ok {
-		return 0, 0, errors.New("components must be a mapping")
-	}
-	schemas, ok := components["schemas"].(map[string]any)
-	if !ok || len(schemas) == 0 {
-		return 0, 0, errors.New("components.schemas must be a non-empty mapping")
+	// components is optional: a spec may define every schema inline.
+	components := map[string]any{}
+	if raw, present := spec["components"]; present {
+		components, ok = raw.(map[string]any)
+		if !ok {
+			return 0, 0, errors.New("components must be a mapping")
+		}
 	}
 
 	for path, rawPathItem := range paths {
@@ -97,21 +97,45 @@ func validateSpec(data []byte) (int, int, error) {
 				return 0, 0, fmt.Errorf("%s %s missing responses", method, path)
 			}
 			for _, ref := range collectRefs(operation) {
-				name, ok := strings.CutPrefix(ref, "#/components/schemas/")
-				if ok {
-					if _, exists := schemas[name]; !exists {
-						return 0, 0, fmt.Errorf("%s %s references missing schema %q", method, path, name)
-					}
-					continue
+				if err := checkComponentRef(components, method, path, ref); err != nil {
+					return 0, 0, err
 				}
-				if _, ok := strings.CutPrefix(ref, "#/components/responses/"); ok {
-					continue
-				}
-				return 0, 0, fmt.Errorf("%s %s has unsupported ref %q", method, path, ref)
 			}
 		}
 	}
 	return len(paths), len(components), nil
+}
+
+// componentNamespaces maps each supported components subsection to the noun used
+// when reporting a reference to something it does not define.
+var componentNamespaces = []struct {
+	name string
+	noun string
+}{
+	{name: "schemas", noun: "schema"},
+	{name: "responses", noun: "response"},
+	{name: "parameters", noun: "parameter"},
+	{name: "requestBodies", noun: "request body"},
+	{name: "headers", noun: "header"},
+	{name: "securitySchemes", noun: "security scheme"},
+}
+
+// checkComponentRef resolves a local component reference against the spec's own
+// components section. External and unknown-namespace refs are rejected, since
+// this validator only reasons about a single self-contained document.
+func checkComponentRef(components map[string]any, method, path, ref string) error {
+	for _, ns := range componentNamespaces {
+		name, ok := strings.CutPrefix(ref, "#/components/"+ns.name+"/")
+		if !ok {
+			continue
+		}
+		defined, _ := components[ns.name].(map[string]any)
+		if _, exists := defined[name]; !exists {
+			return fmt.Errorf("%s %s references missing %s %q", method, path, ns.noun, name)
+		}
+		return nil
+	}
+	return fmt.Errorf("%s %s has unsupported ref %q", method, path, ref)
 }
 
 func collectRefs(raw any) []string {

--- a/cmd/openapi-validate/main_test.go
+++ b/cmd/openapi-validate/main_test.go
@@ -63,3 +63,163 @@ components:
 		t.Fatalf("expected missing responses error for options operation, got %v", err)
 	}
 }
+
+func TestValidateSpecAcceptsSpecWithoutComponents(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+paths:
+  /widgets:
+    get:
+      summary: List widgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+`
+	paths, groups, err := validateSpec([]byte(spec))
+	if err != nil {
+		t.Fatalf("expected inline-schema spec to validate, got %v", err)
+	}
+	if paths != 1 {
+		t.Errorf("paths = %d, want 1", paths)
+	}
+	if groups != 0 {
+		t.Errorf("component groups = %d, want 0", groups)
+	}
+}
+
+func TestValidateSpecAcceptsSupportedComponentNamespaces(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+paths:
+  /widgets/{id}:
+    get:
+      summary: Get widget
+      parameters:
+        - $ref: "#/components/parameters/WidgetID"
+      responses:
+        "200":
+          description: ok
+          headers:
+            X-Rate-Limit:
+              $ref: "#/components/headers/RateLimit"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Widget"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    put:
+      summary: Replace widget
+      security:
+        - $ref: "#/components/securitySchemes/BearerAuth"
+      requestBody:
+        $ref: "#/components/requestBodies/WidgetBody"
+      responses:
+        "200":
+          description: ok
+components:
+  schemas:
+    Widget:
+      type: object
+  responses:
+    NotFound:
+      description: missing
+  parameters:
+    WidgetID:
+      name: id
+      in: path
+      required: true
+  requestBodies:
+    WidgetBody:
+      content:
+        application/json:
+          schema:
+            type: object
+  headers:
+    RateLimit:
+      schema:
+        type: integer
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+`
+	paths, groups, err := validateSpec([]byte(spec))
+	if err != nil {
+		t.Fatalf("expected component references to validate, got %v", err)
+	}
+	if paths != 1 {
+		t.Errorf("paths = %d, want 1", paths)
+	}
+	if groups != 6 {
+		t.Errorf("component groups = %d, want 6", groups)
+	}
+}
+
+func TestValidateSpecRejectsMissingComponents(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		wantErr string
+	}{
+		{name: "schema", ref: "#/components/schemas/Missing", wantErr: `references missing schema "Missing"`},
+		{name: "response", ref: "#/components/responses/Missing", wantErr: `references missing response "Missing"`},
+		{name: "parameter", ref: "#/components/parameters/Missing", wantErr: `references missing parameter "Missing"`},
+		{name: "request body", ref: "#/components/requestBodies/Missing", wantErr: `references missing request body "Missing"`},
+		{name: "header", ref: "#/components/headers/Missing", wantErr: `references missing header "Missing"`},
+		{name: "security scheme", ref: "#/components/securitySchemes/Missing", wantErr: `references missing security scheme "Missing"`},
+		{name: "unknown namespace", ref: "#/components/gadgets/Missing", wantErr: `unsupported ref "#/components/gadgets/Missing"`},
+		{name: "external ref", ref: "other.yaml#/Widget", wantErr: `unsupported ref "other.yaml#/Widget"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := `
+openapi: 3.1.0
+paths:
+  /widgets:
+    get:
+      summary: List widgets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "` + tt.ref + `"
+components:
+  schemas:
+    Widget:
+      type: object
+`
+			_, _, err := validateSpec([]byte(spec))
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateSpecRejectsNonMappingComponents(t *testing.T) {
+	spec := `
+openapi: 3.1.0
+paths:
+  /widgets:
+    get:
+      summary: List widgets
+      responses:
+        "200":
+          description: ok
+components: "nope"
+`
+	_, _, err := validateSpec([]byte(spec))
+	if err == nil || !strings.Contains(err.Error(), "components must be a mapping") {
+		t.Fatalf("expected components mapping error, got %v", err)
+	}
+}

--- a/internal/api/drift_handlers.go
+++ b/internal/api/drift_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -113,18 +114,15 @@ func (ds *DriftServer) handleList(w http.ResponseWriter, r *http.Request) {
 		BySeverity: map[string]int{},
 		ByType:     map[string]int{},
 	}
-	// Get all items for summary (unfiltered by page).
-	allItems, allTotal, _ := ds.driftStore.ListDriftItems(r.Context(), domain.DriftFilters{
-		AccountID: filters.AccountID,
-		Status:    filters.Status,
-		Page:      1,
-		PageSize:  10000,
-	})
-	summary.TotalDrifts = allTotal
-	for _, item := range allItems {
-		summary.BySeverity[string(item.Severity)]++
-		summary.ByType[string(item.Type)]++
+	// Summarise every matching item, not just the first page. A single
+	// oversized page silently drops anything past its limit, so walk the
+	// pages until the reported total is covered.
+	allTotal, err := ds.summarizeDrift(r.Context(), filters, &summary)
+	if err != nil {
+		ds.srv.writeStoreErr(r.Context(), w, err)
+		return
 	}
+	summary.TotalDrifts = allTotal
 
 	writeJSON(w, http.StatusOK, domain.DriftListResponse{
 		Items:    items,
@@ -133,6 +131,36 @@ func (ds *DriftServer) handleList(w http.ResponseWriter, r *http.Request) {
 		PageSize: pageSize,
 		Summary:  summary,
 	})
+}
+
+// summarizeDrift tallies severity and type counts across every drift item
+// matching the account/status filters, paging until the store's reported total
+// is covered. Returns the total number of matching items.
+func (ds *DriftServer) summarizeDrift(ctx context.Context, filters domain.DriftFilters, summary *domain.DriftSummary) (int, error) {
+	const pageSize = 1000
+
+	total := 0
+	seen := 0
+	for page := 1; ; page++ {
+		items, pageTotal, err := ds.driftStore.ListDriftItems(ctx, domain.DriftFilters{
+			AccountID: filters.AccountID,
+			Status:    filters.Status,
+			Page:      page,
+			PageSize:  pageSize,
+		})
+		if err != nil {
+			return 0, err
+		}
+		total = pageTotal
+		for _, item := range items {
+			summary.BySeverity[string(item.Severity)]++
+			summary.ByType[string(item.Type)]++
+		}
+		seen += len(items)
+		if len(items) == 0 || seen >= pageTotal {
+			return total, nil
+		}
+	}
 }
 
 // handleByID routes GET/POST for /api/v1/drift/{id} and sub-paths.

--- a/internal/api/drift_handlers_test.go
+++ b/internal/api/drift_handlers_test.go
@@ -204,3 +204,61 @@ func TestDriftHandlers_GetByID(t *testing.T) {
 		t.Fatalf("expected ID %s, got %s", id, item.ID)
 	}
 }
+
+// TestDriftHandlers_SummaryCoversAllPages verifies that the summary tallies
+// every matching drift item rather than only the first page the store returns.
+func TestDriftHandlers_SummaryCoversAllPages(t *testing.T) {
+	mux, ms, _, driftStore := setupDriftTestServer()
+	ctx := context.Background()
+
+	acct, _ := ms.CreateAccount(ctx, domain.CreateAccount{Key: "aws:summary", Name: "Summary", Provider: "aws"})
+
+	// More items than a single summary page can hold.
+	const itemCount = 2500
+	now := time.Now().UTC()
+	for i := 0; i < itemCount; i++ {
+		severity := domain.DriftSeverityWarning
+		if i%2 == 1 {
+			severity = domain.DriftSeverityInfo
+		}
+		if err := driftStore.CreateDriftItem(ctx, domain.DriftItem{
+			ID:          uuid.New().String(),
+			AccountID:   acct.ID,
+			Type:        domain.DriftTypeUnmanaged,
+			Severity:    severity,
+			Status:      domain.DriftStatusOpen,
+			Title:       "unmanaged resource",
+			DetectedAt:  now.Add(time.Duration(i) * time.Millisecond),
+			UpdatedAt:   now,
+			Description: "synthetic",
+		}); err != nil {
+			t.Fatalf("create drift item %d: %v", i, err)
+		}
+	}
+
+	rr := doDriftJSON(t, mux, stdhttp.MethodGet, "/api/v1/drift?status=open&page_size=10", "", stdhttp.StatusOK)
+	var listResp domain.DriftListResponse
+	if err := json.NewDecoder(rr.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if listResp.Summary.TotalDrifts != itemCount {
+		t.Fatalf("expected total_drifts %d, got %d", itemCount, listResp.Summary.TotalDrifts)
+	}
+
+	tallied := 0
+	for _, count := range listResp.Summary.BySeverity {
+		tallied += count
+	}
+	if tallied != itemCount {
+		t.Fatalf("expected by_severity to tally %d items, got %d", itemCount, tallied)
+	}
+
+	tallied = 0
+	for _, count := range listResp.Summary.ByType {
+		tallied += count
+	}
+	if tallied != itemCount {
+		t.Fatalf("expected by_type to tally %d items, got %d", itemCount, tallied)
+	}
+}

--- a/internal/discovery/gcp/collector.go
+++ b/internal/discovery/gcp/collector.go
@@ -5,9 +5,11 @@ package gcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"strings"
 	"time"
 
@@ -69,12 +71,13 @@ func (c *Collector) Discover(ctx context.Context, account domain.Account) ([]dom
 	}
 
 	var all []domain.DiscoveredResource
+	var errs []error
 	now := time.Now().UTC()
 
 	// Discover VPC networks (global resource)
 	networks, err := discoverNetworks(ctx, client, account, project, now)
 	if err != nil {
-		fmt.Printf("failed to discover GCP networks for project %s: %v\n", project, err)
+		errs = append(errs, fmt.Errorf("discover networks for project %s: %w", project, err))
 	} else {
 		all = append(all, networks...)
 	}
@@ -82,7 +85,7 @@ func (c *Collector) Discover(ctx context.Context, account domain.Account) ([]dom
 	// Discover subnetworks (regional, via aggregated list)
 	subnets, err := discoverSubnetworks(ctx, client, account, project, regionSet, now)
 	if err != nil {
-		fmt.Printf("failed to discover GCP subnetworks for project %s: %v\n", project, err)
+		errs = append(errs, fmt.Errorf("discover subnetworks for project %s: %w", project, err))
 	} else {
 		all = append(all, subnets...)
 	}
@@ -90,9 +93,15 @@ func (c *Collector) Discover(ctx context.Context, account domain.Account) ([]dom
 	// Discover external addresses (regional, via aggregated list)
 	addrs, err := discoverAddresses(ctx, client, account, project, regionSet, now)
 	if err != nil {
-		fmt.Printf("failed to discover GCP addresses for project %s: %v\n", project, err)
+		errs = append(errs, fmt.Errorf("discover addresses for project %s: %w", project, err))
 	} else {
 		all = append(all, addrs...)
+	}
+
+	// Surface endpoint failures so the caller does not treat a partial
+	// discovery as a complete inventory (which would mark resources stale).
+	if len(errs) > 0 {
+		return all, errors.Join(errs...)
 	}
 
 	return all, nil
@@ -164,14 +173,15 @@ type addressesScopedList struct {
 }
 
 type address struct {
-	ID          uint64 `json:"id,string"`
-	Name        string `json:"name"`
-	Address     string `json:"address"`
-	AddressType string `json:"addressType"`
-	Status      string `json:"status"`
-	NetworkTier string `json:"networkTier"`
-	IpVersion   string `json:"ipVersion"`
-	Purpose     string `json:"purpose"`
+	ID           uint64 `json:"id,string"`
+	Name         string `json:"name"`
+	Address      string `json:"address"`
+	PrefixLength int    `json:"prefixLength"`
+	AddressType  string `json:"addressType"`
+	Status       string `json:"status"`
+	NetworkTier  string `json:"networkTier"`
+	IpVersion    string `json:"ipVersion"`
+	Purpose      string `json:"purpose"`
 }
 
 // --- Discovery functions ---
@@ -317,10 +327,7 @@ func discoverAddresses(ctx context.Context, client *http.Client, account domain.
 					continue
 				}
 
-				cidr := ""
-				if addr.Address != "" {
-					cidr = addr.Address + "/32"
-				}
+				cidr := addressCIDR(addr)
 
 				meta := map[string]string{
 					"status":       addr.Status,
@@ -360,6 +367,34 @@ func discoverAddresses(ctx context.Context, client *http.Client, account domain.
 	}
 
 	return resources, nil
+}
+
+// addressCIDR renders a GCP address as a CIDR prefix.
+// GCP reports IPv4 addresses as single hosts and IPv6 addresses either as a
+// bare address or with an explicit prefixLength, so the prefix length must be
+// derived from the address family rather than assumed to be /32.
+func addressCIDR(addr address) string {
+	raw := strings.TrimSpace(addr.Address)
+	if raw == "" {
+		return ""
+	}
+	if strings.Contains(raw, "/") {
+		// Already a prefix — normalize it, or drop it if unparseable.
+		prefix, err := netip.ParsePrefix(raw)
+		if err != nil {
+			return ""
+		}
+		return prefix.String()
+	}
+	ip, err := netip.ParseAddr(raw)
+	if err != nil {
+		return ""
+	}
+	bits := ip.BitLen()
+	if addr.PrefixLength > 0 && addr.PrefixLength <= bits {
+		bits = addr.PrefixLength
+	}
+	return netip.PrefixFrom(ip, bits).String()
 }
 
 // doGet performs a GET request and decodes the JSON response.

--- a/internal/discovery/gcp/collector_test.go
+++ b/internal/discovery/gcp/collector_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"cloudpam/internal/discovery"
@@ -376,4 +377,138 @@ func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		transport = http.DefaultTransport
 	}
 	return transport.RoundTrip(newReq)
+}
+
+func TestAddressCIDR(t *testing.T) {
+	tests := []struct {
+		name string
+		addr address
+		want string
+	}{
+		{name: "empty address", addr: address{}, want: ""},
+		{name: "ipv4 host", addr: address{Address: "35.192.0.1"}, want: "35.192.0.1/32"},
+		{name: "ipv6 host", addr: address{Address: "2600:1900:4000::1"}, want: "2600:1900:4000::1/128"},
+		{
+			name: "ipv6 with explicit prefix length",
+			addr: address{Address: "2600:1900:4000::", PrefixLength: 96},
+			want: "2600:1900:4000::/96",
+		},
+		{
+			name: "ipv4 with explicit prefix length",
+			addr: address{Address: "35.192.0.0", PrefixLength: 29},
+			want: "35.192.0.0/29",
+		},
+		{
+			name: "prefix length wider than family is ignored",
+			addr: address{Address: "35.192.0.1", PrefixLength: 64},
+			want: "35.192.0.1/32",
+		},
+		{name: "already a prefix", addr: address{Address: "2600:1900:4000::/64"}, want: "2600:1900:4000::/64"},
+		{name: "unparseable address", addr: address{Address: "not-an-ip"}, want: ""},
+		{name: "unparseable prefix", addr: address{Address: "not-an-ip/24"}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := addressCIDR(tt.addr); got != tt.want {
+				t.Errorf("addressCIDR(%+v) = %q, want %q", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscover_IPv6ExternalAddress(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/compute/v1/projects/test-project/global/networks", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(networkList{}); err != nil {
+			t.Fatalf("encode network list: %v", err)
+		}
+	})
+	mux.HandleFunc("/compute/v1/projects/test-project/aggregated/subnetworks", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(aggregatedSubnetworkList{}); err != nil {
+			t.Fatalf("encode subnetwork list: %v", err)
+		}
+	})
+	mux.HandleFunc("/compute/v1/projects/test-project/aggregated/addresses", func(w http.ResponseWriter, r *http.Request) {
+		resp := aggregatedAddressList{Items: map[string]addressesScopedList{
+			"regions/us-central1": {Addresses: []address{{
+				ID:          555,
+				Name:        "v6-static-ip",
+				Address:     "2600:1900:4000::1",
+				AddressType: "EXTERNAL",
+				IpVersion:   "IPV6",
+			}}},
+		}}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("encode address list: %v", err)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	collector := NewWithHTTPClient(&http.Client{
+		Transport: &rewriteTransport{base: server.Client().Transport, baseURL: server.URL},
+	})
+
+	resources, err := collector.Discover(context.Background(), domain.Account{ID: 1, ExternalID: "test-project"})
+	if err != nil {
+		t.Fatalf("Discover() error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("got %d resources, want 1", len(resources))
+	}
+	if got := resources[0].CIDR; got != "2600:1900:4000::1/128" {
+		t.Errorf("CIDR = %q, want 2600:1900:4000::1/128", got)
+	}
+}
+
+func TestDiscover_PropagatesEndpointFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		failing string
+		wantIn  string
+	}{
+		{name: "networks fail", failing: "/compute/v1/projects/test-project/global/networks", wantIn: "discover networks"},
+		{name: "subnetworks fail", failing: "/compute/v1/projects/test-project/aggregated/subnetworks", wantIn: "discover subnetworks"},
+		{name: "addresses fail", failing: "/compute/v1/projects/test-project/aggregated/addresses", wantIn: "discover addresses"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			for _, path := range []string{
+				"/compute/v1/projects/test-project/global/networks",
+				"/compute/v1/projects/test-project/aggregated/subnetworks",
+				"/compute/v1/projects/test-project/aggregated/addresses",
+			} {
+				if path == tt.failing {
+					mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+						http.Error(w, "permission denied", http.StatusForbidden)
+					})
+					continue
+				}
+				mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+					if _, err := w.Write([]byte(`{}`)); err != nil {
+						t.Errorf("write response: %v", err)
+					}
+				})
+			}
+
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			collector := NewWithHTTPClient(&http.Client{
+				Transport: &rewriteTransport{base: server.Client().Transport, baseURL: server.URL},
+			})
+
+			_, err := collector.Discover(context.Background(), domain.Account{ID: 1, ExternalID: "test-project"})
+			if err == nil {
+				t.Fatal("expected discovery error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantIn) {
+				t.Errorf("error %q does not mention %q", err.Error(), tt.wantIn)
+			}
+		})
+	}
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -55,6 +55,10 @@ export default function App() {
                 </Route>
                 <Route element={<ProtectedRoute requiredPermission="settings:read" />}>
                   <Route path="config" element={<ConfigurationPage />} />
+                  {/* config/api-keys additionally enforces the apikeys:*
+                      permissions inside ApiKeysPage: settings:read opens the
+                      configuration area, but GET /api/v1/auth/keys is guarded
+                      by apikeys:list or apikeys:read. */}
                   <Route path="config/api-keys" element={<ApiKeysPage />} />
                   <Route path="config/log-destinations" element={<LogDestinationsPage />} />
                   <Route path="config/updates" element={<UpdatesPage />} />

--- a/ui/src/__tests__/UsersAdminPanel.test.tsx
+++ b/ui/src/__tests__/UsersAdminPanel.test.tsx
@@ -14,6 +14,13 @@ vi.mock('../hooks/useRoles', () => ({
   useRoles: () => mockUseRoles(),
 }))
 
+// The panel gates its mutating controls on RBAC permissions. These cases cover
+// duplicate-submit handling, not authorization, so grant everything here;
+// permission gating is covered by permissionGating.test.tsx.
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ hasPermission: () => true }),
+}))
+
 function deferred<T>() {
   let resolve!: (value: T) => void
   let reject!: (reason?: unknown) => void

--- a/ui/src/__tests__/client.test.ts
+++ b/ui/src/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ApiRequestError, del, get, post, postRaw } from '../api/client'
+import { ApiRequestError, del, get, post, postRaw, streamPost } from '../api/client'
 
 function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -115,5 +115,114 @@ describe('postRaw', () => {
     const [, init] = fetchMock.mock.calls[0]
     expect(init.headers['Content-Type']).toBe('application/json')
     expect(init.body).toBe(JSON.stringify(csv))
+  })
+})
+
+function sseResponse(chunks: string[]) {
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk))
+      }
+      controller.close()
+    },
+  })
+  return new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+}
+
+function collect() {
+  const deltas: string[] = []
+  let done = false
+  let error: Error | null = null
+  return {
+    deltas,
+    get done() { return done },
+    get error() { return error },
+    callbacks: {
+      onDelta: (d: string) => { deltas.push(d) },
+      onDone: () => { done = true },
+      onError: (e: Error) => { error = e },
+    },
+  }
+}
+
+describe('streamPost EOF handling', () => {
+  it('parses a final data line that arrives without a trailing newline', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse([
+      'data: {"delta":"hello"}\n',
+      'data: {"delta":" world"}',
+    ])))
+
+    const sink = collect()
+    await streamPost('/api/v1/ai/chat', {}, sink.callbacks)
+
+    expect(sink.deltas).toEqual(['hello', ' world'])
+    expect(sink.done).toBe(true)
+    expect(sink.error).toBeNull()
+  })
+
+  it('honours a terminating done event with no trailing newline', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse([
+      'data: {"delta":"a"}\n',
+      'event: done',
+    ])))
+
+    const sink = collect()
+    await streamPost('/api/v1/ai/chat', {}, sink.callbacks)
+
+    expect(sink.deltas).toEqual(['a'])
+    expect(sink.done).toBe(true)
+  })
+
+  it('reassembles a data line split across chunk boundaries', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse([
+      'data: {"del',
+      'ta":"split"}\n',
+    ])))
+
+    const sink = collect()
+    await streamPost('/api/v1/ai/chat', {}, sink.callbacks)
+
+    expect(sink.deltas).toEqual(['split'])
+    expect(sink.done).toBe(true)
+  })
+
+  it('emits a trailing multi-byte character flushed at EOF', async () => {
+    const encoder = new TextEncoder()
+    const full = encoder.encode('data: {"delta":"café"}')
+    // Split mid multi-byte sequence so the decoder must be flushed at EOF.
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(full.slice(0, full.length - 1))
+        controller.enqueue(full.slice(full.length - 1))
+        controller.close()
+      },
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    })))
+
+    const sink = collect()
+    await streamPost('/api/v1/ai/chat', {}, sink.callbacks)
+
+    expect(sink.deltas).toEqual(['café'])
+    expect(sink.done).toBe(true)
+  })
+
+  it('signals completion exactly once for a stream ending in a blank line', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse([
+      'data: {"delta":"x"}\n\n',
+    ])))
+
+    const sink = collect()
+    await streamPost('/api/v1/ai/chat', {}, sink.callbacks)
+
+    expect(sink.deltas).toEqual(['x'])
+    expect(sink.done).toBe(true)
   })
 })

--- a/ui/src/__tests__/escape.test.ts
+++ b/ui/src/__tests__/escape.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hclHeredocShellQuote,
+  hclIdent,
+  hclQuote,
+  hclTemplateEscape,
+  safeFilename,
+  shellQuote,
+  yamlQuote,
+} from '../utils/escape'
+
+// A value crafted to break out of each output format if interpolated raw.
+const SHELL_BREAKOUT = `us-east-1"; rm -rf /; echo "`
+const HCL_BREAKOUT = 'prod-${var.secret}-%{if true}x%{endif}'
+
+describe('shellQuote', () => {
+  it('wraps plain values in single quotes', () => {
+    expect(shellQuote('us-east-1')).toBe(`'us-east-1'`)
+  })
+
+  it('neutralises command substitution and quote breakouts', () => {
+    const quoted = shellQuote(SHELL_BREAKOUT)
+    expect(quoted.startsWith(`'`)).toBe(true)
+    expect(quoted.endsWith(`'`)).toBe(true)
+    // No bare double quote can terminate anything: the whole value is literal.
+    expect(quoted).toBe(`'us-east-1"; rm -rf /; echo "'`)
+  })
+
+  it('closes, escapes and reopens embedded single quotes', () => {
+    expect(shellQuote("it's")).toBe(`'it'\\''s'`)
+  })
+
+  it('escapes backticks and dollar signs by containment', () => {
+    expect(shellQuote('$(id)`whoami`')).toBe(`'$(id)\`whoami\`'`)
+  })
+
+  it('renders null and undefined as an empty literal', () => {
+    expect(shellQuote(null)).toBe(`''`)
+    expect(shellQuote(undefined)).toBe(`''`)
+  })
+
+  it('strips NUL, which cannot be represented in a shell word', () => {
+    expect(shellQuote('a\0b')).toBe(`'ab'`)
+  })
+})
+
+describe('yamlQuote', () => {
+  it('produces a double-quoted scalar', () => {
+    expect(yamlQuote('us-east-1')).toBe('"us-east-1"')
+  })
+
+  it('escapes embedded quotes so the scalar cannot be closed early', () => {
+    expect(yamlQuote('a"b')).toBe('"a\\"b"')
+  })
+
+  it('escapes newlines rather than emitting a second document line', () => {
+    expect(yamlQuote('a\nrole_name: evil')).toBe('"a\\nrole_name: evil"')
+  })
+
+  it('escapes backslashes', () => {
+    expect(yamlQuote('a\\b')).toBe('"a\\\\b"')
+  })
+
+  it('renders empty for null and undefined', () => {
+    expect(yamlQuote(null)).toBe('""')
+    expect(yamlQuote(undefined)).toBe('""')
+  })
+})
+
+describe('hclTemplateEscape', () => {
+  it('neutralises interpolation and directive markers', () => {
+    expect(hclTemplateEscape('${a}')).toBe('$${a}')
+    expect(hclTemplateEscape('%{if x}')).toBe('%%{if x}')
+  })
+
+  it('leaves lone dollar and percent characters alone', () => {
+    expect(hclTemplateEscape('100% $USD')).toBe('100% $USD')
+  })
+})
+
+describe('hclQuote', () => {
+  it('produces a quoted literal with interpolation disabled', () => {
+    expect(hclQuote(HCL_BREAKOUT)).toBe('"prod-$${var.secret}-%%{if true}x%%{endif}"')
+  })
+
+  it('escapes embedded quotes', () => {
+    expect(hclQuote('a"b')).toBe('"a\\"b"')
+  })
+})
+
+describe('hclHeredocShellQuote', () => {
+  it('shell-quotes first, then neutralises HCL interpolation', () => {
+    expect(hclHeredocShellQuote(HCL_BREAKOUT)).toBe(
+      `'prod-$\${var.secret}-%%{if true}x%%{endif}'`
+    )
+  })
+
+  it('keeps shell breakout attempts inside the literal', () => {
+    expect(hclHeredocShellQuote(SHELL_BREAKOUT)).toBe(`'us-east-1"; rm -rf /; echo "'`)
+  })
+})
+
+describe('hclIdent', () => {
+  it('keeps a valid identifier unchanged', () => {
+    expect(hclIdent('CloudPAMDiscoveryRole')).toBe('CloudPAMDiscoveryRole')
+  })
+
+  it('replaces characters that would terminate the resource label', () => {
+    const ident = hclIdent('role" { evil = "1')
+    expect(ident).toBe('role____evil____1')
+    expect(/^[A-Za-z_][A-Za-z0-9_-]*$/.test(ident)).toBe(true)
+  })
+
+  it('falls back when the result cannot start an identifier', () => {
+    expect(hclIdent('123')).toBe('cloudpam')
+    expect(hclIdent('-abc')).toBe('cloudpam')
+    expect(hclIdent('')).toBe('cloudpam')
+    expect(hclIdent('-', 'fallback_role')).toBe('fallback_role')
+  })
+})
+
+describe('safeFilename', () => {
+  it('keeps a simple name', () => {
+    expect(safeFilename('agent-prod')).toBe('agent-prod')
+  })
+
+  it('strips path separators so a download cannot escape its directory', () => {
+    expect(safeFilename('../../etc/passwd')).toBe('etc-passwd')
+    expect(safeFilename('a/b\\c')).toBe('a-b-c')
+  })
+
+  it('strips leading dots and dashes', () => {
+    expect(safeFilename('...hidden')).toBe('hidden')
+  })
+
+  it('falls back when nothing usable remains', () => {
+    expect(safeFilename('///')).toBe('cloudpam-agent')
+    expect(safeFilename(null)).toBe('cloudpam-agent')
+  })
+})

--- a/ui/src/__tests__/permissionGating.test.tsx
+++ b/ui/src/__tests__/permissionGating.test.tsx
@@ -1,0 +1,210 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ReactElement } from 'react'
+import { AuthContext } from '../hooks/useAuth'
+import type { AuthContextValue } from '../hooks/useAuth'
+import ApiKeysPage from '../pages/ApiKeysPage'
+import IdentityPage from '../pages/IdentityPage'
+import SecuritySettingsPage from '../pages/SecuritySettingsPage'
+import UsersAdminPanel from '../components/UsersAdminPanel'
+
+const SECURITY_SETTINGS = {
+  session_duration_hours: 24,
+  session_idle_timeout_minutes: 60,
+  max_sessions_per_user: 5,
+  password_min_length: 12,
+  password_require_complexity: false,
+  login_max_attempts: 5,
+  login_lockout_minutes: 15,
+  trusted_proxies: [],
+  local_auth_enabled: true,
+  api_key_max_scopes_role: 'admin',
+}
+
+const USERS = [
+  {
+    id: 'u1',
+    username: 'alice',
+    email: 'alice@example.com',
+    display_name: 'Alice',
+    role: 'operator',
+    is_active: true,
+    failed_login_attempts: 0,
+    created_at: '2024-01-01T00:00:00Z',
+    last_login_at: '2024-01-02T00:00:00Z',
+  },
+]
+
+// Minimal stub API surface: every screen under test loads via api/client's
+// fetch wrapper, so route the handful of GETs they issue.
+function stubFetch() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const body = (data: unknown) =>
+      new Response(JSON.stringify(data), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    if (url.startsWith('/api/v1/settings/security')) return body(SECURITY_SETTINGS)
+    if (url.startsWith('/api/v1/settings/oidc/providers')) return body({ providers: [] })
+    if (url.startsWith('/api/v1/auth/users')) return body({ users: USERS, total: USERS.length })
+    if (url.startsWith('/api/v1/auth/roles')) return body({ roles: [] })
+    if (url.startsWith('/api/v1/auth/permissions')) return body({ permissions: [] })
+    if (url.startsWith('/api/v1/auth/keys')) return body({ keys: [] })
+    return body({})
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function authValue(permissions: string[], role = 'operator'): AuthContextValue {
+  return {
+    keyName: 'test',
+    role,
+    authType: 'session',
+    currentUser: null,
+    permissions,
+    hasPermission: (permission: string) => role === 'admin' || permissions.includes(permission),
+    isAuthenticated: true,
+    authEnabled: true,
+    localAuthEnabled: true,
+    needsSetup: false,
+    authChecked: true,
+    loginWithPassword: async () => {},
+    logout: () => {},
+  }
+}
+
+function renderWith(permissions: string[], ui: ReactElement, role = 'operator') {
+  return render(
+    <AuthContext.Provider value={authValue(permissions, role)}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </AuthContext.Provider>
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('SecuritySettingsPage read-only gating', () => {
+  it('hides the save control when the caller only holds settings:read', async () => {
+    stubFetch()
+    renderWith(['settings:read'], <SecuritySettingsPage />)
+
+    expect(await screen.findByText(/settings:write required/i)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /save settings/i })).toBeNull()
+  })
+
+  it('shows the save control when the caller holds settings:write', async () => {
+    stubFetch()
+    renderWith(['settings:read', 'settings:write'], <SecuritySettingsPage />)
+
+    expect(await screen.findByRole('button', { name: /save settings/i })).toBeTruthy()
+    expect(screen.queryByText(/settings:write required/i)).toBeNull()
+  })
+})
+
+describe('UsersAdminPanel action gating', () => {
+  it('exposes no mutating controls to a caller holding only users:list', async () => {
+    stubFetch()
+    renderWith(['users:list'], <UsersAdminPanel />)
+
+    expect(await screen.findByText('alice')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /create user/i })).toBeNull()
+    expect(screen.queryByTitle('Deactivate user')).toBeNull()
+    expect(screen.queryByTitle('Activate user')).toBeNull()
+  })
+
+  it('exposes create to a caller holding users:create', async () => {
+    stubFetch()
+    renderWith(['users:list', 'users:create'], <UsersAdminPanel />)
+
+    expect(await screen.findByRole('button', { name: /create user/i })).toBeTruthy()
+    // Still no deactivate: that needs users:delete.
+    expect(screen.queryByTitle('Deactivate user')).toBeNull()
+  })
+
+  it('exposes deactivate to a caller holding users:delete', async () => {
+    stubFetch()
+    renderWith(['users:list', 'users:delete'], <UsersAdminPanel />)
+
+    expect(await screen.findByTitle('Deactivate user')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /create user/i })).toBeNull()
+  })
+})
+
+describe('ApiKeysPage feature gating', () => {
+  it('refuses to list keys for a caller holding only settings:read', async () => {
+    const fetchMock = stubFetch()
+    renderWith(['settings:read'], <ApiKeysPage />)
+
+    expect(await screen.findByText(/apikeys:list or apikeys:read is required/i)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /create key/i })).toBeNull()
+
+    // The privileged listing request must never be issued.
+    const keyRequests = fetchMock.mock.calls.filter(([input]) =>
+      String(input).startsWith('/api/v1/auth/keys')
+    )
+    expect(keyRequests).toHaveLength(0)
+  })
+
+  it('lists keys but hides create for a caller holding only apikeys:list', async () => {
+    const fetchMock = stubFetch()
+    renderWith(['settings:read', 'apikeys:list'], <ApiKeysPage />)
+
+    await waitFor(() => {
+      const keyRequests = fetchMock.mock.calls.filter(([input]) =>
+        String(input).startsWith('/api/v1/auth/keys')
+      )
+      expect(keyRequests.length).toBeGreaterThan(0)
+    })
+    expect(screen.queryByRole('button', { name: /create key/i })).toBeNull()
+    expect(screen.queryByText(/apikeys:list or apikeys:read is required/i)).toBeNull()
+  })
+
+  it('shows create for a caller holding apikeys:create', async () => {
+    stubFetch()
+    renderWith(['settings:read', 'apikeys:list', 'apikeys:create'], <ApiKeysPage />)
+
+    expect(await screen.findByRole('button', { name: /create key/i })).toBeTruthy()
+  })
+})
+
+describe('IdentityPage tab gating', () => {
+  it('shows only the Users tab to a caller holding users:list', async () => {
+    stubFetch()
+    renderWith(['users:list'], <IdentityPage />)
+
+    expect(await screen.findByRole('button', { name: 'Users' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Providers' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'RBAC' })).toBeNull()
+  })
+
+  it('shows provider and RBAC tabs to a caller holding settings:read', async () => {
+    stubFetch()
+    renderWith(['settings:read'], <IdentityPage />)
+
+    expect(await screen.findByRole('button', { name: 'Providers' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'RBAC' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Users' })).toBeNull()
+  })
+
+  it('hides provider mutation controls without settings:write', async () => {
+    stubFetch()
+    renderWith(['settings:read'], <IdentityPage />)
+
+    await screen.findByRole('button', { name: 'Providers' })
+    expect(screen.queryByRole('button', { name: /add provider/i })).toBeNull()
+  })
+
+  it('shows provider mutation controls with settings:write', async () => {
+    stubFetch()
+    renderWith(['settings:read', 'settings:write'], <IdentityPage />)
+
+    expect(await screen.findByRole('button', { name: /add provider/i })).toBeTruthy()
+  })
+})

--- a/ui/src/__tests__/useSessionRefresh.test.ts
+++ b/ui/src/__tests__/useSessionRefresh.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { parseRefreshMessage } from '../hooks/useSessionRefresh'
+
+const ORIGIN = 'https://cloudpam.example.com'
+
+// Stand-in for the hidden refresh iframe's contentWindow.
+const iframeWindow = {} as MessageEventSource
+const otherWindow = {} as MessageEventSource
+
+function event(overrides: Partial<MessageEvent> = {}): MessageEvent {
+  return {
+    origin: ORIGIN,
+    source: iframeWindow,
+    data: { type: 'oidc-refresh', success: true },
+    ...overrides,
+  } as MessageEvent
+}
+
+describe('parseRefreshMessage', () => {
+  it('accepts a well-formed same-origin message from the refresh iframe', () => {
+    expect(parseRefreshMessage(event(), ORIGIN, iframeWindow)).toEqual({
+      type: 'oidc-refresh',
+      success: true,
+    })
+  })
+
+  it('accepts a failure report from the refresh iframe', () => {
+    const msg = event({ data: { type: 'oidc-refresh', success: false } })
+    expect(parseRefreshMessage(msg, ORIGIN, iframeWindow)).toEqual({
+      type: 'oidc-refresh',
+      success: false,
+    })
+  })
+
+  it('rejects a message from a different origin', () => {
+    const msg = event({ origin: 'https://attacker.example.com' })
+    expect(parseRefreshMessage(msg, ORIGIN, iframeWindow)).toBeNull()
+  })
+
+  it('rejects an origin that merely shares a prefix with ours', () => {
+    const msg = event({ origin: `${ORIGIN}.attacker.example.com` })
+    expect(parseRefreshMessage(msg, ORIGIN, iframeWindow)).toBeNull()
+  })
+
+  it('rejects a same-origin message from a window other than the refresh iframe', () => {
+    const msg = event({ source: otherWindow })
+    expect(parseRefreshMessage(msg, ORIGIN, iframeWindow)).toBeNull()
+  })
+
+  it('rejects any message when no refresh is in flight', () => {
+    expect(parseRefreshMessage(event(), ORIGIN, null)).toBeNull()
+    expect(parseRefreshMessage(event(), ORIGIN, undefined)).toBeNull()
+  })
+
+  it('rejects messages with the wrong type', () => {
+    const msg = event({ data: { type: 'other', success: true } })
+    expect(parseRefreshMessage(msg, ORIGIN, iframeWindow)).toBeNull()
+  })
+
+  it('rejects messages whose success flag is not a boolean', () => {
+    const msg = event({ data: { type: 'oidc-refresh', success: 'yes' } })
+    expect(parseRefreshMessage(msg, ORIGIN, iframeWindow)).toBeNull()
+  })
+
+  it('rejects non-object payloads', () => {
+    expect(parseRefreshMessage(event({ data: null }), ORIGIN, iframeWindow)).toBeNull()
+    expect(parseRefreshMessage(event({ data: 'oidc-refresh' }), ORIGIN, iframeWindow)).toBeNull()
+    expect(parseRefreshMessage(event({ data: undefined }), ORIGIN, iframeWindow)).toBeNull()
+  })
+
+  it('returns a normalised message rather than the attacker-controlled object', () => {
+    const msg = event({
+      data: { type: 'oidc-refresh', success: true, extra: 'ignored' },
+    })
+    expect(parseRefreshMessage(msg, ORIGIN, iframeWindow)).toEqual({
+      type: 'oidc-refresh',
+      success: true,
+    })
+  })
+})

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -213,41 +213,48 @@ export async function streamPost(path: string, data: unknown, callbacks: SSECall
   const decoder = new TextDecoder()
   let buffer = ''
 
-  try {
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
+  // Returns true when the line signals end of stream.
+  function handleLine(line: string): boolean {
+    const trimmed = line.trim()
+    if (trimmed === '') return false
 
-      buffer += decoder.decode(value, { stream: true })
+    if (trimmed === 'event: done') return true
+
+    if (trimmed.startsWith('data: ')) {
+      const jsonStr = trimmed.slice(6)
+      if (jsonStr === '{}') return true
+      try {
+        const parsed = JSON.parse(jsonStr)
+        if (parsed.delta !== undefined) {
+          callbacks.onDelta(parsed.delta)
+        }
+      } catch {
+        // skip malformed JSON
+      }
+    }
+    return false
+  }
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+
+      // Flush the decoder at EOF so a trailing multi-byte character is emitted.
+      buffer += done ? decoder.decode() : decoder.decode(value, { stream: true })
+
       const lines = buffer.split('\n')
-      buffer = lines.pop() || ''
+      // Mid-stream the trailing fragment may be an incomplete line, so hold it
+      // back. At EOF nothing more is coming, so parse it as a final event.
+      buffer = done ? '' : lines.pop() ?? ''
 
       for (const line of lines) {
-        const trimmed = line.trim()
-        if (trimmed === '') continue
-
-        if (trimmed === 'event: done') {
-          // Read the next data line then finish
+        if (handleLine(line)) {
           callbacks.onDone()
           return
         }
-
-        if (trimmed.startsWith('data: ')) {
-          const jsonStr = trimmed.slice(6)
-          if (jsonStr === '{}') {
-            callbacks.onDone()
-            return
-          }
-          try {
-            const parsed = JSON.parse(jsonStr)
-            if (parsed.delta !== undefined) {
-              callbacks.onDelta(parsed.delta)
-            }
-          } catch {
-            // skip malformed JSON
-          }
-        }
       }
+
+      if (done) break
     }
     callbacks.onDone()
   } catch (err) {

--- a/ui/src/components/DiscoveryWizard.tsx
+++ b/ui/src/components/DiscoveryWizard.tsx
@@ -3,6 +3,14 @@ import { X, Check, Copy, Download, ChevronLeft, ChevronRight, AlertTriangle, Loa
 import { useAgentProvisioning, useDiscoveryAgents } from '../hooks/useDiscovery'
 import { useAccounts } from '../hooks/useAccounts'
 import { useToast } from '../hooks/useToast'
+import {
+  hclHeredocShellQuote,
+  hclIdent,
+  hclQuote,
+  safeFilename,
+  shellQuote,
+  yamlQuote,
+} from '../utils/escape'
 import type { Account, CreateAccountRequest, AgentProvisionResponse, DiscoveryAgent } from '../api/types'
 
 type ConfigTab = 'shell' | 'yaml' | 'terraform' | 'docker' | 'iam'
@@ -175,54 +183,55 @@ export default function DiscoveryWizard({ accounts, onAccountCreated, onClose, o
 
   const orgRegions = orgRegionsInput.split(',').map(r => r.trim()).filter(Boolean)
   const orgExclude = orgExcludeInput.split(',').map(r => r.trim()).filter(Boolean)
+  const orgPrimaryRegion = orgRegions[0] ?? 'us-east-1'
 
   // Single-account configs
   const shellConfigSingle = `#!/bin/bash
-export CLOUDPAM_BOOTSTRAP_TOKEN="${token}"
+export CLOUDPAM_BOOTSTRAP_TOKEN=${shellQuote(token)}
 export CLOUDPAM_AGENT_ID_FILE="/var/lib/cloudpam-agent/agent-id"
 export CLOUDPAM_ACCOUNT_ID=${accountId}
-export CLOUDPAM_AWS_REGIONS="${accountRegions.join(',')}"
+export CLOUDPAM_AWS_REGIONS=${shellQuote(accountRegions.join(','))}
 ./cloudpam-agent`
 
-  const yamlConfigSingle = `server_url: "${serverUrl}"
-bootstrap_token: "${token}"
+  const yamlConfigSingle = `server_url: ${yamlQuote(serverUrl)}
+bootstrap_token: ${yamlQuote(token)}
 agent_id_file: "/var/lib/cloudpam-agent/agent-id"
 account_id: ${accountId}
-agent_name: "${agentNameFinal}"
+agent_name: ${yamlQuote(agentNameFinal)}
 sync_interval: "15m"
 heartbeat_interval: "1m"
-aws_regions: [${accountRegions.map(r => `"${r}"`).join(', ')}]`
+aws_regions: [${accountRegions.map(yamlQuote).join(', ')}]`
 
   // Org-mode configs
   const shellConfigOrg = `#!/bin/bash
-export CLOUDPAM_BOOTSTRAP_TOKEN="${token}"
+export CLOUDPAM_BOOTSTRAP_TOKEN=${shellQuote(token)}
 export CLOUDPAM_AGENT_ID_FILE="/var/lib/cloudpam-agent/agent-id"
 export CLOUDPAM_ACCOUNT_ID=${accountId}
-export AWS_REGION="${orgRegions[0] ?? 'us-east-1'}"
-export AWS_DEFAULT_REGION="${orgRegions[0] ?? 'us-east-1'}"
+export AWS_REGION=${shellQuote(orgPrimaryRegion)}
+export AWS_DEFAULT_REGION=${shellQuote(orgPrimaryRegion)}
 export CLOUDPAM_AWS_ORG_ENABLED=true
-export CLOUDPAM_AWS_ORG_ROLE_NAME="${orgRoleName}"${orgExternalId ? `
-export CLOUDPAM_AWS_ORG_EXTERNAL_ID="${orgExternalId}"` : ''}
-export CLOUDPAM_AWS_ORG_REGIONS="${orgRegions.join(',')}"${orgExclude.length > 0 ? `
-export CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS="${orgExclude.join(',')}"` : ''}
+export CLOUDPAM_AWS_ORG_ROLE_NAME=${shellQuote(orgRoleName)}${orgExternalId ? `
+export CLOUDPAM_AWS_ORG_EXTERNAL_ID=${shellQuote(orgExternalId)}` : ''}
+export CLOUDPAM_AWS_ORG_REGIONS=${shellQuote(orgRegions.join(','))}${orgExclude.length > 0 ? `
+export CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS=${shellQuote(orgExclude.join(','))}` : ''}
 ./cloudpam-agent`
 
-  const yamlConfigOrg = `server_url: "${serverUrl}"
-bootstrap_token: "${token}"
+  const yamlConfigOrg = `server_url: ${yamlQuote(serverUrl)}
+bootstrap_token: ${yamlQuote(token)}
 agent_id_file: "/var/lib/cloudpam-agent/agent-id"
 account_id: ${accountId}
-agent_name: "${agentNameFinal}"
+agent_name: ${yamlQuote(agentNameFinal)}
 sync_interval: "15m"
 heartbeat_interval: "1m"
 aws_org:
   enabled: true
-  role_name: "${orgRoleName}"${orgExternalId ? `
-  external_id: "${orgExternalId}"` : ''}
-  regions: [${orgRegions.map(r => `"${r}"`).join(', ')}]${orgExclude.length > 0 ? `
-  exclude_accounts: [${orgExclude.map(a => `"${a}"`).join(', ')}]` : ''}`
+  role_name: ${yamlQuote(orgRoleName)}${orgExternalId ? `
+  external_id: ${yamlQuote(orgExternalId)}` : ''}
+  regions: [${orgRegions.map(yamlQuote).join(', ')}]${orgExclude.length > 0 ? `
+  exclude_accounts: [${orgExclude.map(yamlQuote).join(', ')}]` : ''}`
 
   const terraformConfigSingle = `variable "cloudpam_bootstrap_token" {
-  default   = "${token}"
+  default   = ${hclQuote(token)}
   sensitive = true
 }
 
@@ -232,14 +241,14 @@ resource "null_resource" "cloudpam_agent" {
       CLOUDPAM_BOOTSTRAP_TOKEN=\${var.cloudpam_bootstrap_token} \\
       CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id \\
       CLOUDPAM_ACCOUNT_ID=${accountId} \\
-      CLOUDPAM_AWS_REGIONS=${accountRegions.join(',')} \\
+      CLOUDPAM_AWS_REGIONS=${hclHeredocShellQuote(accountRegions.join(','))} \\
       ./cloudpam-agent
     EOT
   }
 }`
 
   const terraformConfigOrg = `variable "cloudpam_bootstrap_token" {
-  default   = "${token}"
+  default   = ${hclQuote(token)}
   sensitive = true
 }
 
@@ -249,13 +258,13 @@ resource "null_resource" "cloudpam_agent" {
       CLOUDPAM_BOOTSTRAP_TOKEN=\${var.cloudpam_bootstrap_token} \\
       CLOUDPAM_AGENT_ID_FILE=/var/lib/cloudpam-agent/agent-id \\
       CLOUDPAM_ACCOUNT_ID=${accountId} \\
-      AWS_REGION=${orgRegions[0] ?? 'us-east-1'} \\
-      AWS_DEFAULT_REGION=${orgRegions[0] ?? 'us-east-1'} \\
+      AWS_REGION=${hclHeredocShellQuote(orgPrimaryRegion)} \\
+      AWS_DEFAULT_REGION=${hclHeredocShellQuote(orgPrimaryRegion)} \\
       CLOUDPAM_AWS_ORG_ENABLED=true \\
-      CLOUDPAM_AWS_ORG_ROLE_NAME=${orgRoleName} \\${orgExternalId ? `
-      CLOUDPAM_AWS_ORG_EXTERNAL_ID=${orgExternalId} \\` : ''}
-      CLOUDPAM_AWS_ORG_REGIONS=${orgRegions.join(',')} \\${orgExclude.length > 0 ? `
-      CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS=${orgExclude.join(',')} \\` : ''}
+      CLOUDPAM_AWS_ORG_ROLE_NAME=${hclHeredocShellQuote(orgRoleName)} \\${orgExternalId ? `
+      CLOUDPAM_AWS_ORG_EXTERNAL_ID=${hclHeredocShellQuote(orgExternalId)} \\` : ''}
+      CLOUDPAM_AWS_ORG_REGIONS=${hclHeredocShellQuote(orgRegions.join(','))} \\${orgExclude.length > 0 ? `
+      CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS=${hclHeredocShellQuote(orgExclude.join(','))} \\` : ''}
       ./cloudpam-agent
     EOT
   }
@@ -264,26 +273,28 @@ resource "null_resource" "cloudpam_agent" {
   const dockerConfigSingle = `docker run -d \\
   --name cloudpam-agent \\
   -v /var/lib/cloudpam-agent:/var/lib/cloudpam-agent \\
-  -e CLOUDPAM_BOOTSTRAP_TOKEN="${token}" \\
+  -e CLOUDPAM_BOOTSTRAP_TOKEN=${shellQuote(token)} \\
   -e CLOUDPAM_AGENT_ID_FILE="/var/lib/cloudpam-agent/agent-id" \\
   -e CLOUDPAM_ACCOUNT_ID=${accountId} \\
-  -e CLOUDPAM_AWS_REGIONS="${accountRegions.join(',')}" \\
+  -e CLOUDPAM_AWS_REGIONS=${shellQuote(accountRegions.join(','))} \\
   ghcr.io/badgerops/cloudpam/agent:latest`
 
   const dockerConfigOrg = `docker run -d \\
   --name cloudpam-agent \\
   -v /var/lib/cloudpam-agent:/var/lib/cloudpam-agent \\
-  -e CLOUDPAM_BOOTSTRAP_TOKEN="${token}" \\
+  -e CLOUDPAM_BOOTSTRAP_TOKEN=${shellQuote(token)} \\
   -e CLOUDPAM_AGENT_ID_FILE="/var/lib/cloudpam-agent/agent-id" \\
   -e CLOUDPAM_ACCOUNT_ID=${accountId} \\
-  -e AWS_REGION="${orgRegions[0] ?? 'us-east-1'}" \\
-  -e AWS_DEFAULT_REGION="${orgRegions[0] ?? 'us-east-1'}" \\
+  -e AWS_REGION=${shellQuote(orgPrimaryRegion)} \\
+  -e AWS_DEFAULT_REGION=${shellQuote(orgPrimaryRegion)} \\
   -e CLOUDPAM_AWS_ORG_ENABLED=true \\
-  -e CLOUDPAM_AWS_ORG_ROLE_NAME="${orgRoleName}" \\${orgExternalId ? `
-  -e CLOUDPAM_AWS_ORG_EXTERNAL_ID="${orgExternalId}" \\` : ''}
-  -e CLOUDPAM_AWS_ORG_REGIONS="${orgRegions.join(',')}" \\${orgExclude.length > 0 ? `
-  -e CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS="${orgExclude.join(',')}" \\` : ''}
+  -e CLOUDPAM_AWS_ORG_ROLE_NAME=${shellQuote(orgRoleName)} \\${orgExternalId ? `
+  -e CLOUDPAM_AWS_ORG_EXTERNAL_ID=${shellQuote(orgExternalId)} \\` : ''}
+  -e CLOUDPAM_AWS_ORG_REGIONS=${shellQuote(orgRegions.join(','))} \\${orgExclude.length > 0 ? `
+  -e CLOUDPAM_AWS_ORG_EXCLUDE_ACCOUNTS=${shellQuote(orgExclude.join(','))} \\` : ''}
   ghcr.io/badgerops/cloudpam/agent:latest`
+
+  const orgRoleIdent = hclIdent(orgRoleName, 'cloudpam_discovery_role')
 
   const iamSetupContent = `# IAM Setup for AWS Organizations Discovery
 #
@@ -296,8 +307,8 @@ resource "null_resource" "cloudpam_agent" {
 # --- Member Account Role (Terraform) ---
 # Deploy to each member account:
 
-resource "aws_iam_role" "${orgRoleName}" {
-  name = "${orgRoleName}"
+resource "aws_iam_role" "${orgRoleIdent}" {
+  name = ${hclQuote(orgRoleName)}
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -305,13 +316,13 @@ resource "aws_iam_role" "${orgRoleName}" {
       Effect    = "Allow"
       Principal = { AWS = "arn:aws:iam::<MANAGEMENT_ACCOUNT_ID>:root" }
       Action    = "sts:AssumeRole"${orgExternalId ? `
-      Condition = { StringEquals = { "sts:ExternalId" = "${orgExternalId}" } }` : ''}
+      Condition = { StringEquals = { "sts:ExternalId" = ${hclQuote(orgExternalId)} } }` : ''}
     }]
   })
 }
 
 resource "aws_iam_role_policy" "discovery" {
-  role = aws_iam_role.${orgRoleName}.id
+  role = aws_iam_role.${orgRoleIdent}.id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -342,7 +353,7 @@ resource "aws_iam_policy" "cloudpam_org" {
       {
         Effect   = "Allow"
         Action   = "sts:AssumeRole"
-        Resource = "arn:aws:iam::*:role/${orgRoleName}"
+        Resource = ${hclQuote(`arn:aws:iam::*:role/${orgRoleName}`)}
       }
     ]
   })
@@ -357,12 +368,14 @@ resource "aws_iam_policy" "cloudpam_org" {
     ? ['shell', 'yaml', 'terraform', 'docker', 'iam']
     : ['shell', 'yaml', 'terraform', 'docker']
 
+  const filenameStem = safeFilename(agentNameFinal)
+
   const configs: Record<ConfigTab, { content: string; filename: string; label: string }> = {
-    shell: { content: shellConfig, filename: `${agentNameFinal}.sh`, label: 'Shell' },
-    yaml: { content: yamlConfig, filename: `${agentNameFinal}.yaml`, label: 'YAML' },
-    terraform: { content: terraformConfig, filename: `${agentNameFinal}.tf`, label: 'Terraform' },
-    docker: { content: dockerConfig, filename: `${agentNameFinal}-docker.sh`, label: 'Docker' },
-    iam: { content: iamSetupContent, filename: `${agentNameFinal}-iam.tf`, label: 'IAM Setup' },
+    shell: { content: shellConfig, filename: `${filenameStem}.sh`, label: 'Shell' },
+    yaml: { content: yamlConfig, filename: `${filenameStem}.yaml`, label: 'YAML' },
+    terraform: { content: terraformConfig, filename: `${filenameStem}.tf`, label: 'Terraform' },
+    docker: { content: dockerConfig, filename: `${filenameStem}-docker.sh`, label: 'Docker' },
+    iam: { content: iamSetupContent, filename: `${filenameStem}-iam.tf`, label: 'IAM Setup' },
   }
 
   const canGoNext = (step === 1 && selectedAccountId !== null) ||

--- a/ui/src/components/UsersAdminPanel.tsx
+++ b/ui/src/components/UsersAdminPanel.tsx
@@ -3,6 +3,7 @@ import { Users, Plus, AlertCircle, UserCheck, UserX, LockOpen } from 'lucide-rea
 import { useUsers } from '../hooks/useUsers'
 import { useRoles } from '../hooks/useRoles'
 import { usePendingAction } from '../hooks/usePendingAction'
+import { useAuth } from '../hooks/useAuth'
 import type { CreateUserRequest, UserInfo } from '../api/types'
 
 interface UsersAdminPanelProps {
@@ -12,6 +13,13 @@ interface UsersAdminPanelProps {
 export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelProps) {
   const { users, loading, error, create, update, deactivate, unlock } = useUsers()
   const { roles } = useRoles()
+  // internal/api/user_handlers.go guards each verb separately: POST needs
+  // users:create, PATCH (role, reactivate, unlock) needs users:update, and
+  // DELETE (deactivate) needs users:delete. users:list only grants the listing.
+  const { hasPermission } = useAuth()
+  const canCreate = hasPermission('users:create')
+  const canUpdate = hasPermission('users:update')
+  const canDeactivate = hasPermission('users:delete')
   const roleOptions = roles.length > 0 ? roles : ['admin', 'operator', 'viewer', 'auditor'].map(name => ({ name, is_builtin: true }))
   const [showCreate, setShowCreate] = useState(false)
   const [form, setForm] = useState<CreateUserRequest>({
@@ -26,7 +34,7 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
   const [editRole, setEditRole] = useState('')
 
   async function createUser() {
-    if (!form.username.trim() || !form.password) return
+    if (!canCreate || !form.username.trim() || !form.password) return
     setCreateError('')
     try {
       await create(form)
@@ -41,6 +49,7 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
   const { pending: creating, run: handleCreate } = usePendingAction(createUser)
 
   async function handleRoleSave(id: string) {
+    if (!canUpdate) return
     try {
       await update(id, { role: editRole })
       setEditingId(null)
@@ -51,13 +60,16 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
 
   async function handleToggleActive(id: string, isActive: boolean) {
     if (isActive) {
+      if (!canDeactivate) return
       await deactivate(id)
     } else {
+      if (!canUpdate) return
       await update(id, { is_active: true })
     }
   }
 
   async function handleUnlock(id: string) {
+    if (!canUpdate) return
     await unlock(id)
   }
 
@@ -82,13 +94,15 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
               Manage local user accounts
             </p>
           </div>
-          <button
-            onClick={() => setShowCreate(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
-          >
-            <Plus className="w-4 h-4" />
-            Create User
-          </button>
+          {canCreate && (
+            <button
+              onClick={() => setShowCreate(true)}
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
+            >
+              <Plus className="w-4 h-4" />
+              Create User
+            </button>
+          )}
         </div>
       )}
 
@@ -100,13 +114,15 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
               Manage local user accounts and access levels
             </p>
           </div>
-          <button
-            onClick={() => setShowCreate(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
-          >
-            <Plus className="w-4 h-4" />
-            Create User
-          </button>
+          {canCreate && (
+            <button
+              onClick={() => setShowCreate(true)}
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
+            >
+              <Plus className="w-4 h-4" />
+              Create User
+            </button>
+          )}
         </div>
       )}
 
@@ -117,7 +133,7 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
         </div>
       )}
 
-      {showCreate && (
+      {showCreate && canCreate && (
         <div className="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow p-4 border dark:border-gray-700">
           <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">New User</h3>
           <div className="grid grid-cols-2 gap-3">
@@ -236,7 +252,11 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
                   </td>
                   <td className="hidden md:table-cell px-4 py-3 text-gray-600 dark:text-gray-400">{u.email || '—'}</td>
                   <td className="px-4 py-3">
-                    {editingId === u.id ? (
+                    {!canUpdate ? (
+                      <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded text-xs font-medium uppercase">
+                        {u.role}
+                      </span>
+                    ) : editingId === u.id ? (
                       <div className="flex items-center gap-1">
                         <select
                           value={editRole}
@@ -288,7 +308,7 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
                   <td className="hidden md:table-cell px-4 py-3 text-gray-600 dark:text-gray-400">{u.failed_login_attempts ?? 0}</td>
                   <td className="hidden md:table-cell px-4 py-3 text-gray-600 dark:text-gray-400">{formatDate(u.last_login_at)}</td>
                   <td className="px-4 py-3 text-right">
-                    {isLocked(u) && (
+                    {isLocked(u) && canUpdate && (
                       <button
                         onClick={() => handleUnlock(u.id)}
                         title="Unlock user"
@@ -297,13 +317,17 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
                         <LockOpen className="w-4 h-4" />
                       </button>
                     )}
-                    <button
-                      onClick={() => handleToggleActive(u.id, u.is_active)}
-                      title={u.is_active ? 'Deactivate user' : 'Activate user'}
-                      className="p-1.5 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-                    >
-                      {u.is_active ? <UserX className="w-4 h-4" /> : <UserCheck className="w-4 h-4" />}
-                    </button>
+                    {(u.is_active ? canDeactivate : canUpdate) ? (
+                      <button
+                        onClick={() => handleToggleActive(u.id, u.is_active)}
+                        title={u.is_active ? 'Deactivate user' : 'Activate user'}
+                        className="p-1.5 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+                      >
+                        {u.is_active ? <UserX className="w-4 h-4" /> : <UserCheck className="w-4 h-4" />}
+                      </button>
+                    ) : (
+                      <span className="text-xs text-gray-400 dark:text-gray-500">—</span>
+                    )}
                   </td>
                 </tr>
               ))

--- a/ui/src/hooks/useApiKeys.ts
+++ b/ui/src/hooks/useApiKeys.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { get, post, del } from '../api/client'
+import { useAuth } from './useAuth'
 import type { ApiKeyInfo, ApiKeyCreateRequest, ApiKeyCreateResponse } from '../api/types'
 
 interface ApiKeysListResponse {
@@ -11,7 +12,22 @@ export function useApiKeys() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  // internal/api/auth_handlers.go guards each verb separately: GET needs
+  // apikeys:list or apikeys:read, POST needs apikeys:create and DELETE needs
+  // apikeys:delete. Reaching the configuration area (settings:read) grants none
+  // of those, so mirror the server here instead of firing requests that 403.
+  const { hasPermission } = useAuth()
+  const canList = hasPermission('apikeys:list') || hasPermission('apikeys:read')
+  const canCreate = hasPermission('apikeys:create')
+  const canRevoke = hasPermission('apikeys:delete')
+
   const refresh = useCallback(async () => {
+    if (!canList) {
+      setKeys([])
+      setError(null)
+      setLoading(false)
+      return
+    }
     setLoading(true)
     setError(null)
     try {
@@ -22,21 +38,23 @@ export function useApiKeys() {
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [canList])
 
   useEffect(() => { refresh() }, [refresh])
 
   const create = useCallback(async (req: ApiKeyCreateRequest): Promise<ApiKeyCreateResponse> => {
+    if (!canCreate) throw new Error('apikeys:create permission required to create API keys')
     const res = await post<ApiKeyCreateResponse>('/api/v1/auth/keys', req)
     await refresh()
     return res
-  }, [refresh])
+  }, [canCreate, refresh])
 
   const revoke = useCallback(async (id: string) => {
+    if (!canRevoke) throw new Error('apikeys:delete permission required to revoke API keys')
     // Backend uses DELETE to revoke (soft delete)
     await del(`/api/v1/auth/keys/${id}`)
     await refresh()
-  }, [refresh])
+  }, [canRevoke, refresh])
 
-  return { keys, loading, error, create, revoke, refresh }
+  return { keys, loading, error, canList, canCreate, canRevoke, create, revoke, refresh }
 }

--- a/ui/src/hooks/useAuth.ts
+++ b/ui/src/hooks/useAuth.ts
@@ -173,9 +173,16 @@ export function useAuthState(): AuthContextValue {
     clearAuth()
   }, [])
 
+  // When the server runs with authentication disabled there is no identity to
+  // derive permissions from and every API route is unguarded, so permission
+  // gates must not lock the UI down. Until /healthz has answered we do not know
+  // which mode we are in, so stay closed rather than opening by default.
+  const authRequired = !authChecked || authEnabled || localAuthEnabled
+
   const hasPermission = useCallback((permission: string) => {
+    if (!authRequired) return true
     return role === 'admin' || permissions.includes(permission)
-  }, [permissions, role])
+  }, [authRequired, permissions, role])
 
   return {
     keyName,

--- a/ui/src/hooks/useSessionRefresh.ts
+++ b/ui/src/hooks/useSessionRefresh.ts
@@ -4,6 +4,38 @@ import type { MeResponse } from '../api/types'
 const POLL_INTERVAL_MS = 60_000 // 60 seconds
 const LIFETIME_THRESHOLD = 0.2 // trigger refresh when 20% of lifetime remains
 
+export interface OIDCRefreshMessage {
+  type: 'oidc-refresh'
+  success: boolean
+}
+
+/**
+ * parseRefreshMessage validates an incoming postMessage before it is allowed to
+ * change session state.
+ *
+ * The silent re-auth callback is served by CloudPAM itself, so only same-origin
+ * messages posted by the hidden refresh iframe are trusted. Anything else — a
+ * parent frame, an opener, or another window that happens to hold a handle to
+ * this one — is ignored. Returns null when the message must not be acted on.
+ */
+export function parseRefreshMessage(
+  event: MessageEvent,
+  expectedOrigin: string,
+  expectedSource: MessageEventSource | null | undefined
+): OIDCRefreshMessage | null {
+  if (event.origin !== expectedOrigin) return null
+  // No refresh in flight means there is nothing legitimate to report.
+  if (!expectedSource || event.source !== expectedSource) return null
+
+  const data = event.data
+  if (!data || typeof data !== 'object') return null
+  const message = data as Partial<OIDCRefreshMessage>
+  if (message.type !== 'oidc-refresh') return null
+  if (typeof message.success !== 'boolean') return null
+
+  return { type: 'oidc-refresh', success: message.success }
+}
+
 /**
  * useSessionRefresh - Silent session re-authentication for OIDC users.
  *
@@ -29,27 +61,28 @@ export function useSessionRefresh() {
     }
 
     function handleMessage(event: MessageEvent) {
-      if (
-        event.data &&
-        typeof event.data === 'object' &&
-        event.data.type === 'oidc-refresh'
-      ) {
-        cleanup()
-        if (!event.data.success) {
-          // Notify the user that silent re-auth failed.
-          window.dispatchEvent(
-            new CustomEvent('toast', {
-              detail: {
-                type: 'warning',
-                message: 'Session expiring \u2014 please log in again',
-              },
-            })
-          )
-        }
-        // On success the session cookie was already refreshed by the
-        // callback handler. Reset so we can refresh again later.
-        refreshAttemptedRef.current = false
+      const message = parseRefreshMessage(
+        event,
+        window.location.origin,
+        iframeRef.current?.contentWindow
+      )
+      if (!message) return
+
+      cleanup()
+      if (!message.success) {
+        // Notify the user that silent re-auth failed.
+        window.dispatchEvent(
+          new CustomEvent('toast', {
+            detail: {
+              type: 'warning',
+              message: 'Session expiring \u2014 please log in again',
+            },
+          })
+        )
       }
+      // On success the session cookie was already refreshed by the
+      // callback handler. Reset so we can refresh again later.
+      refreshAttemptedRef.current = false
     }
 
     window.addEventListener('message', handleMessage)

--- a/ui/src/hooks/useSettings.ts
+++ b/ui/src/hooks/useSettings.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { get, patch } from '../api/client'
+import { useAuth } from './useAuth'
 
 export interface SecuritySettings {
   session_duration_hours: number
@@ -22,7 +23,20 @@ export function useSecuritySettings() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  // GET /api/v1/settings/security requires settings:read and
+  // PATCH requires settings:write — mirror both here so the UI never issues a
+  // request it is not entitled to make.
+  const { hasPermission } = useAuth()
+  const canRead = hasPermission('settings:read')
+  const canEdit = hasPermission('settings:write')
+
   const fetchSettings = useCallback(async () => {
+    if (!canRead) {
+      setSettings(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
     try {
       setLoading(true)
       const data = await get<SecuritySettings>('/api/v1/settings/security')
@@ -33,15 +47,18 @@ export function useSecuritySettings() {
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [canRead])
 
   const updateSettings = useCallback(async (updated: SecuritySettings) => {
+    if (!canEdit) {
+      throw new Error('settings:write permission required to change security settings')
+    }
     const data = await patch<SecuritySettings>('/api/v1/settings/security', updated)
     setSettings(data)
     return data
-  }, [])
+  }, [canEdit])
 
   useEffect(() => { fetchSettings() }, [fetchSettings])
 
-  return { settings, loading, error, updateSettings, refetch: fetchSettings }
+  return { settings, loading, error, canRead, canEdit, updateSettings, refetch: fetchSettings }
 }

--- a/ui/src/hooks/useUsers.ts
+++ b/ui/src/hooks/useUsers.ts
@@ -8,6 +8,20 @@ import type {
   UsersListResponse,
 } from '../api/types'
 
+/**
+ * useChangePassword exposes only the self-service password change call.
+ *
+ * PATCH /api/v1/auth/users/{id}/password is allowed for the account owner,
+ * while listing users requires users:list. Screens that only change a password
+ * must not pull useUsers, or every visit fires a privileged list request that
+ * 403s for non-admins.
+ */
+export function useChangePassword() {
+  return useCallback(async (id: string, req: ChangePasswordRequest) => {
+    await patch(`/api/v1/auth/users/${id}/password`, req)
+  }, [])
+}
+
 export function useUsers() {
   const [users, setUsers] = useState<UserInfo[]>([])
   const [loading, setLoading] = useState(true)

--- a/ui/src/pages/ApiKeysPage.tsx
+++ b/ui/src/pages/ApiKeysPage.tsx
@@ -29,7 +29,7 @@ const SCOPE_LABELS: Record<string, string> = {
 }
 
 export default function ApiKeysPage() {
-  const { keys, loading, error, create, revoke } = useApiKeys()
+  const { keys, loading, error, canList, canCreate, canRevoke, create, revoke } = useApiKeys()
   const { settings } = useSecuritySettings()
   const [showCreate, setShowCreate] = useState(false)
   const [newKeyName, setNewKeyName] = useState('')
@@ -40,7 +40,7 @@ export default function ApiKeysPage() {
   const [createError, setCreateError] = useState('')
 
   async function createKey() {
-    if (!newKeyName.trim()) return
+    if (!canCreate || !newKeyName.trim()) return
     setCreateError('')
     try {
       const res = await create({
@@ -105,6 +105,18 @@ export default function ApiKeysPage() {
     return ['Active', 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400']
   }
 
+  if (!canList) {
+    return (
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">API Keys</h1>
+        <div className="mt-4 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 px-4 py-3 rounded-lg border dark:border-gray-700">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          You do not have permission to view API keys — apikeys:list or apikeys:read is required.
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
@@ -114,13 +126,15 @@ export default function ApiKeysPage() {
             Manage API keys for programmatic access
           </p>
         </div>
-        <button
-          onClick={() => { setShowCreate(true); setCreatedKey(null) }}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
-        >
-          <Plus className="w-4 h-4" />
-          Create Key
-        </button>
+        {canCreate && (
+          <button
+            onClick={() => { setShowCreate(true); setCreatedKey(null) }}
+            className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
+          >
+            <Plus className="w-4 h-4" />
+            Create Key
+          </button>
+        )}
       </div>
 
       {error && (
@@ -151,7 +165,7 @@ export default function ApiKeysPage() {
       )}
 
       {/* Create form */}
-      {showCreate && !createdKey && (
+      {showCreate && canCreate && !createdKey && (
         <div className="mb-6 bg-white dark:bg-gray-800 rounded-lg shadow p-4 border dark:border-gray-700">
           <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">New API Key</h3>
 
@@ -290,7 +304,7 @@ export default function ApiKeysPage() {
                     })()}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    {!k.revoked && (
+                    {!k.revoked && canRevoke && (
                       <button
                         onClick={() => revoke(k.id)}
                         title="Revoke key"

--- a/ui/src/pages/ChangelogPage.tsx
+++ b/ui/src/pages/ChangelogPage.tsx
@@ -282,7 +282,7 @@ function ReleaseCard({
 }
 
 export default function ChangelogPage() {
-  const { role } = useAuth()
+  const { hasPermission } = useAuth()
   const [markdown, setMarkdown] = useState('')
   const [systemInfo, setSystemInfo] = useState<SystemInfoResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -352,7 +352,8 @@ export default function ChangelogPage() {
           </div>
 
           <div className="flex flex-wrap gap-2">
-            {role === 'admin' ? (
+            {/* /config/updates is guarded by settings:read, matching GET /api/v1/updates. */}
+            {hasPermission('settings:read') ? (
               <Link
                 to="/config/updates"
                 className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white/85 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm shadow-slate-200/50 transition hover:border-blue-300 hover:text-blue-700 dark:border-slate-700 dark:bg-slate-900/85 dark:text-slate-200 dark:hover:border-blue-700 dark:hover:text-blue-200"

--- a/ui/src/pages/IdentityPage.tsx
+++ b/ui/src/pages/IdentityPage.tsx
@@ -5,13 +5,18 @@ import { useToast } from '../hooks/useToast'
 import { useSecuritySettings } from '../hooks/useSettings'
 import { useOIDCAdmin } from '../hooks/useOIDCAdmin'
 import { permissionID, useRoles } from '../hooks/useRoles'
+import { useAuth } from '../hooks/useAuth'
 import type { OIDCProvider, OIDCProviderCreate, OIDCProviderUpdate } from '../hooks/useOIDCAdmin'
 import UsersAdminPanel from '../components/UsersAdminPanel'
 
+// Each tab is gated on the permission the API enforces for the data it renders:
+// OIDC provider admin and role admin are guarded by settings:read
+// (internal/api/oidc_handlers.go, internal/api/role_handlers.go), and the user
+// list is guarded by users:list (internal/api/user_handlers.go).
 const TABS = [
-  { id: 'providers', label: 'Providers' },
-  { id: 'users', label: 'Users' },
-  { id: 'rbac', label: 'RBAC' },
+  { id: 'providers', label: 'Providers', permission: 'settings:read' },
+  { id: 'users', label: 'Users', permission: 'users:list' },
+  { id: 'rbac', label: 'RBAC', permission: 'settings:read' },
 ] as const
 
 function roleLabel(role: string) {
@@ -200,6 +205,9 @@ function ProviderFormModal({ provider, onSave, onClose }: ProviderFormProps) {
 
 function RolesAdminPanel() {
   const { showToast } = useToast()
+  const { hasPermission } = useAuth()
+  // Role create/update/delete are guarded by settings:write.
+  const canEditRoles = hasPermission('settings:write')
   const { roles, permissions, loading, error, create, update, remove } = useRoles()
   const [selectedName, setSelectedName] = useState<string>('')
   const [creating, setCreating] = useState(false)
@@ -211,7 +219,7 @@ function RolesAdminPanel() {
 
   const selectedRole = roles.find(role => role.name === selectedName) ?? roles[0] ?? null
   const activeRole = creating ? null : selectedRole
-  const readOnly = activeRole?.is_builtin === true
+  const readOnly = !canEditRoles || activeRole?.is_builtin === true
 
   const groupedPermissions = useMemo(() => {
     const groups = new Map<string, typeof permissions>()
@@ -312,13 +320,15 @@ function RolesAdminPanel() {
             Build custom roles from the same permissions enforced by the API.
           </p>
         </div>
-        <button
-          onClick={startCreate}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
-        >
-          <Plus className="w-4 h-4" />
-          Create Role
-        </button>
+        {canEditRoles && (
+          <button
+            onClick={startCreate}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+          >
+            <Plus className="w-4 h-4" />
+            Create Role
+          </button>
+        )}
       </div>
 
       {error && (
@@ -380,7 +390,9 @@ function RolesAdminPanel() {
 
             {readOnly && (
               <div className="mt-3 rounded-lg bg-gray-50 dark:bg-gray-900/40 px-3 py-2 text-sm text-gray-600 dark:text-gray-400">
-                Built-in roles are managed by CloudPAM and cannot be edited.
+                {canEditRoles
+                  ? 'Built-in roles are managed by CloudPAM and cannot be edited.'
+                  : 'Read-only \u2014 settings:write required to change roles.'}
               </div>
             )}
             {saveError && (
@@ -433,7 +445,7 @@ function RolesAdminPanel() {
                     Cancel
                   </button>
                 )}
-                {!creating && activeRole && !activeRole.is_builtin && (
+                {!creating && canEditRoles && activeRole && !activeRole.is_builtin && (
                   <button onClick={deleteRole} className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30">
                     <Trash2 className="w-4 h-4" />
                     Delete
@@ -460,8 +472,8 @@ function RolesAdminPanel() {
 
 export default function IdentityPage() {
   const [searchParams, setSearchParams] = useSearchParams()
-  const activeTab = (searchParams.get('tab') as typeof TABS[number]['id'] | null) ?? 'providers'
   const { showToast } = useToast()
+  const { hasPermission } = useAuth()
   const { settings, loading: settingsLoading, updateSettings } = useSecuritySettings()
   const oidcAdmin = useOIDCAdmin()
   const [editingProvider, setEditingProvider] = useState<OIDCProvider | null>(null)
@@ -470,10 +482,17 @@ export default function IdentityPage() {
   const [testingID, setTestingID] = useState<string | null>(null)
   const [testingMessage, setTestingMessage] = useState<string | null>(null)
 
-  const tabs = useMemo(() => TABS, [])
+  // Only offer tabs whose data the caller may actually read, and never leave the
+  // page pinned to a tab the URL asked for but the caller cannot see.
+  const tabs = useMemo(() => TABS.filter(tab => hasPermission(tab.permission)), [hasPermission])
+  const requestedTab = searchParams.get('tab') as typeof TABS[number]['id'] | null
+  const activeTab = tabs.some(tab => tab.id === requestedTab) ? requestedTab : tabs[0]?.id ?? null
+
+  // OIDC provider create/update/delete/test are guarded by settings:write.
+  const canEditProviders = hasPermission('settings:write')
 
   async function toggleLocalAuth() {
-    if (!settings) return
+    if (!settings || !canEditProviders) return
     try {
       await updateSettings({ ...settings, local_auth_enabled: !settings.local_auth_enabled })
       showToast(`Local authentication ${settings.local_auth_enabled ? 'disabled' : 'enabled'}`, 'success')
@@ -483,6 +502,7 @@ export default function IdentityPage() {
   }
 
   async function saveProvider(payload: OIDCProviderCreate | OIDCProviderUpdate) {
+    if (!canEditProviders) throw new Error('settings:write permission required to manage providers')
     if (editingProvider) {
       await oidcAdmin.updateProvider(editingProvider.id, payload)
       showToast('Provider updated', 'success')
@@ -495,13 +515,14 @@ export default function IdentityPage() {
   }
 
   async function deleteProvider() {
-    if (!deletingProvider) return
+    if (!deletingProvider || !canEditProviders) return
     await oidcAdmin.deleteProvider(deletingProvider.id)
     showToast('Provider deleted', 'success')
     setDeletingProvider(null)
   }
 
   async function testProvider(id: string) {
+    if (!canEditProviders) return
     try {
       setTestingID(id)
       const result = await oidcAdmin.testProvider(id)
@@ -524,6 +545,12 @@ export default function IdentityPage() {
           Authentication providers, local users, and built-in RBAC.
         </p>
       </div>
+
+      {tabs.length === 0 && (
+        <div className="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 px-4 py-6 text-sm text-gray-500 dark:text-gray-400">
+          You do not have permission to view identity settings.
+        </div>
+      )}
 
       <div className="flex gap-2 border-b border-gray-200 dark:border-gray-700">
         {tabs.map(tab => (
@@ -554,13 +581,15 @@ export default function IdentityPage() {
                   Configure OIDC sign-in providers and local password access.
                 </p>
               </div>
-              <button
-                onClick={() => { setEditingProvider(null); setShowProviderForm(true) }}
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
-              >
-                <Plus className="w-4 h-4" />
-                Add Provider
-              </button>
+              {canEditProviders && (
+                <button
+                  onClick={() => { setEditingProvider(null); setShowProviderForm(true) }}
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+                >
+                  <Plus className="w-4 h-4" />
+                  Add Provider
+                </button>
+              )}
             </div>
 
             <div className="mt-4 rounded-lg border border-gray-200 dark:border-gray-700 p-4 flex items-center justify-between gap-4">
@@ -572,7 +601,7 @@ export default function IdentityPage() {
               </div>
               <button
                 type="button"
-                disabled={settingsLoading || !settings}
+                disabled={settingsLoading || !settings || !canEditProviders}
                 onClick={toggleLocalAuth}
                 className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                   settings?.local_auth_enabled ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
@@ -641,6 +670,11 @@ export default function IdentityPage() {
                           </td>
                           <td className="py-3">
                             <div className="flex items-center justify-end gap-2">
+                              {!canEditProviders && (
+                                <span className="text-xs text-gray-400 dark:text-gray-500">Read-only</span>
+                              )}
+                              {canEditProviders && (
+                                <>
                               <button onClick={() => testProvider(provider.id)} className="p-2 text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400" title="Test provider">
                                 {testingID === provider.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Shield className="w-4 h-4" />}
                               </button>
@@ -650,6 +684,8 @@ export default function IdentityPage() {
                               <button onClick={() => setDeletingProvider(provider)} className="p-2 text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400" title="Delete provider">
                                 <Trash2 className="w-4 h-4" />
                               </button>
+                                </>
+                              )}
                             </div>
                           </td>
                         </tr>
@@ -667,7 +703,7 @@ export default function IdentityPage() {
 
       {activeTab === 'rbac' && <RolesAdminPanel />}
 
-      {showProviderForm && (
+      {showProviderForm && canEditProviders && (
         <ProviderFormModal
           provider={editingProvider}
           onSave={saveProvider}
@@ -678,7 +714,7 @@ export default function IdentityPage() {
         />
       )}
 
-      {deletingProvider && (
+      {deletingProvider && canEditProviders && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4" onClick={() => setDeletingProvider(null)}>
           <div className="w-full max-w-md rounded-xl bg-white dark:bg-gray-800 shadow-xl p-6" onClick={e => e.stopPropagation()}>
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Delete Provider</h2>

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { User } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
-import { useUsers } from '../hooks/useUsers'
+import { useChangePassword } from '../hooks/useUsers'
 import { useToast } from '../hooks/useToast'
 
 export default function ProfilePage() {
   const { currentUser } = useAuth()
-  const { changePassword } = useUsers()
+  const changePassword = useChangePassword()
   const { showToast } = useToast()
 
   const [currentPw, setCurrentPw] = useState('')

--- a/ui/src/pages/SecuritySettingsPage.tsx
+++ b/ui/src/pages/SecuritySettingsPage.tsx
@@ -4,6 +4,7 @@ import { Shield, Lock, Key, Globe, AlertCircle, Loader2, Fingerprint, UserCog } 
 import { useSecuritySettings } from '../hooks/useSettings'
 import type { SecuritySettings } from '../hooks/useSettings'
 import { useToast } from '../hooks/useToast'
+import { useAuth } from '../hooks/useAuth'
 
 const API_KEY_SCOPE_OPTIONS = [
   'pools:read', 'pools:write',
@@ -31,6 +32,10 @@ const API_KEY_SCOPE_OPTIONS_BY_ROLE: Record<string, string[]> = {
 export default function SecuritySettingsPage() {
   const { settings, loading, error, updateSettings } = useSecuritySettings()
   const { showToast } = useToast()
+  // PATCH /api/v1/settings/security requires settings:write; settings:read only
+  // grants the GET used to render this page.
+  const { hasPermission } = useAuth()
+  const canEdit = hasPermission('settings:write')
   const [form, setForm] = useState<SecuritySettings | null>(null)
   const [saving, setSaving] = useState(false)
   const [trustedProxiesText, setTrustedProxiesText] = useState('')
@@ -43,7 +48,7 @@ export default function SecuritySettingsPage() {
   }, [settings])
 
   async function handleSave() {
-    if (!form) return
+    if (!form || !canEdit) return
     setSaving(true)
     try {
       const proxies = trustedProxiesText
@@ -107,14 +112,20 @@ export default function SecuritySettingsPage() {
             Session, password, login protection, and network trust settings.
           </p>
         </div>
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
-        >
-          {saving && <Loader2 className="w-4 h-4 animate-spin" />}
-          Save Settings
-        </button>
+        {canEdit ? (
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving && <Loader2 className="w-4 h-4 animate-spin" />}
+            Save Settings
+          </button>
+        ) : (
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            Read-only — settings:write required to change security policy
+          </span>
+        )}
       </div>
 
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 border dark:border-gray-700">

--- a/ui/src/utils/escape.ts
+++ b/ui/src/utils/escape.ts
@@ -1,0 +1,78 @@
+/**
+ * Escaping helpers for generated deployment snippets.
+ *
+ * The discovery wizard renders shell, YAML, HCL and docker commands that embed
+ * user-supplied and API-supplied values (account names, IAM role names, region
+ * lists, external IDs). Without quoting, a value such as `foo"; rm -rf /; #`
+ * turns a copy-paste command into an injection, so every interpolation must go
+ * through the helper matching its output format.
+ */
+
+function asText(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  return String(value)
+}
+
+/**
+ * POSIX shell single-quoted literal. Safe for any character except NUL: inside
+ * single quotes the shell performs no expansion, and an embedded quote is
+ * closed, escaped and reopened.
+ */
+export function shellQuote(value: unknown): string {
+  return `'${asText(value).replace(/\0/g, '').replace(/'/g, `'\\''`)}'`
+}
+
+/**
+ * Double-quoted YAML scalar. JSON string syntax is a valid YAML 1.2
+ * double-quoted scalar, so JSON.stringify gives correct escaping.
+ */
+export function yamlQuote(value: unknown): string {
+  return JSON.stringify(asText(value).replace(/\0/g, ''))
+}
+
+/**
+ * Escapes HCL template interpolation markers in text that is already quoted or
+ * embedded in a heredoc. `$${` and `%%{` render as literal `${` and `%{`.
+ */
+export function hclTemplateEscape(value: string): string {
+  // Replacer functions, not replacement strings: "$$" in a replacement string
+  // is String.replace's own escape for a literal "$", which would silently
+  // collapse "$${" back to "${" and leave interpolation live.
+  return value.replace(/\$\{/g, () => '$${').replace(/%\{/g, () => '%%{')
+}
+
+/** Quoted HCL string literal with interpolation disabled. */
+export function hclQuote(value: unknown): string {
+  return hclTemplateEscape(JSON.stringify(asText(value).replace(/\0/g, '')))
+}
+
+/**
+ * Shell-quoted literal for use inside an HCL heredoc, which is itself a
+ * template: quote for the shell first, then neutralise HCL interpolation.
+ */
+export function hclHeredocShellQuote(value: unknown): string {
+  return hclTemplateEscape(shellQuote(value))
+}
+
+/**
+ * HCL identifier for resource labels and references (`aws_iam_role.<ident>`).
+ * Identifiers accept letters, digits, underscores and dashes and may not start
+ * with a digit or dash.
+ */
+export function hclIdent(value: unknown, fallback = 'cloudpam'): string {
+  const cleaned = asText(value).replace(/[^A-Za-z0-9_-]/g, '_')
+  if (!cleaned || !/^[A-Za-z_]/.test(cleaned)) return fallback
+  return cleaned
+}
+
+/**
+ * Filename for a generated download. Strips path separators and leading dots so
+ * a crafted agent name cannot escape the download directory.
+ */
+export function safeFilename(value: unknown, fallback = 'cloudpam-agent'): string {
+  const cleaned = asText(value)
+    .replace(/[^A-Za-z0-9._-]/g, '-')
+    .replace(/^[.-]+/, '')
+    .replace(/-+/g, '-')
+  return cleaned || fallback
+}


### PR DESCRIPTION
Permission-gating and correctness findings from #223.

## Permission gating

Several routes were gated only at the route level, so users saw and could trigger actions their permissions don't cover. **The server still enforces**, so this is privilege confusion in the UI rather than a bypass — but the affected surfaces now gate on the same permission the destination endpoint requires (determined by reading each Go handler registration, not inferred from the UI):

- Identity page tab rendering and OIDC provider actions
- User administration split from `users:list` — holding list no longer exposes create/update/delete
- Security settings edit surface vs. read-only settings permission
- `/config/api-keys` route guard
- Updates link visibility now matches the route's own gate
- ProfilePage no longer fires a privileged `GET /api/v1/auth/users` for every visitor just to change a password

## Security

**OIDC refresh `postMessage` trusted any origin** — the handler validated neither `event.origin` nor the message shape, so any opened origin could post a message it acted on.

**Generated deployment scripts interpolated unescaped input** — `DiscoveryWizard` inserted user- and API-derived values into generated shell, docker, YAML and Terraform snippets with no escaping, so a crafted account name yields a copy-paste command injection. New `ui/src/utils/escape.ts` applies per-format quoting.

## Discovery correctness

- GCP endpoint failures were logged and then reported as success
- IPv6 external addresses were recorded with an IPv4 `/32`

## openapi-validate

Two false rejections of valid specs:
- `components` is optional — a spec may define every schema inline. Previously any spec without `components.schemas` was rejected outright.
- References into `responses`, `parameters`, `requestBodies`, `headers` and `securitySchemes` are legitimate; only `schemas` was accepted. Missing targets now report the right namespace noun (`references missing parameter "X"`), and external/unknown-namespace refs are still rejected since this validator reasons about a single self-contained document.

## Tests

New tests for the security items, the permission gating, the GCP fixes, and full table coverage of the openapi-validate namespaces. No existing test assertion was changed — the one deletion in `client.test.ts` is an import line extended for a new export.

## Verification

```
go build ./... && go vet ./... && go test -race ./...   pass
go test -tags sqlite ./... && go build -tags postgres ./...   pass
npx tsc --noEmit                                        clean
npx vitest run                                          30 files, 171 tests passed
golangci-lint                                           0 issues
```

Refs #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)