### PR TITLE
lint: reintroduce revive with a narrow rule set

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,3 +12,78 @@ linters:
     - errcheck
     - gocritic
     - misspell
+    - revive
+  settings:
+    revive:
+      severity: warning
+      # Gradual reintroduction (issue #21). Only the rules listed here run --
+      # revive's default set is NOT applied. Rules are added deliberately, each
+      # one clean across the tree at the time it was enabled. Candidates that
+      # were measured and deferred because they demand large mechanical churn:
+      # exported (153), unused-parameter (109), use-any (37), unused-receiver
+      # (27), unchecked-type-assertion (8), confusing-results (5),
+      # early-return (4).
+      rules:
+        # --- correctness / latent-bug classes ---
+        - name: atomic
+        - name: constant-logical-expr
+        - name: context-keys-type
+        - name: datarace
+        - name: defer
+        - name: duplicated-imports
+        - name: identical-branches
+        - name: modifies-value-receiver
+        - name: string-of-int
+        - name: struct-tag
+        - name: unreachable-code
+        - name: waitgroup-by-value
+        # --- error handling idioms ---
+        - name: error-return
+        - name: error-naming
+        - name: error-strings
+        - name: errorf
+        - name: if-return
+        - name: indent-error-flow
+        # --- API shape & naming idioms ---
+        - name: context-as-argument
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: var-declaration
+        - name: var-naming
+          # Identifier casing only. The package-name check would demand
+          # renaming internal/api, which is core API surface for the whole
+          # server package graph.
+          arguments:
+            - [] # allowlist
+            - [] # blocklist
+            - - skipPackageNameChecks: true
+        # --- small, mechanical style rules ---
+        - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: dot-imports
+        - name: empty-block
+        - name: increment-decrement
+        - name: range
+        - name: superfluous-else
+        - name: useless-break
+  exclusions:
+    rules:
+      # These two rules only ever fire in test helpers today. Excluding tests
+      # keeps them as guardrails for production code without rewriting tests.
+      - path: _test\.go
+        linters:
+          - revive
+        text: "^(bool-literal-in-expr|context-as-argument):"
+      # GCP DTO structs mirror the Compute API JSON field names (IpCidrRange,
+      # IpVersion, PrivateIpGoogleAccess). They are fields of unexported types
+      # used only for json.Unmarshal; renaming them would churn tests for no
+      # behavioural gain.
+      - path: internal/discovery/gcp/collector\.go
+        linters:
+          - revive
+        text: "^var-naming:"
+
+formatters:
+  enable:
+    - gofmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ just cover-threshold thr=80  # Check coverage meets threshold
 ### Linting & Formatting
 ```bash
 just fmt              # Format code with go fmt
-just lint             # Run golangci-lint v2.1.6 (same as CI)
+just lint             # Run golangci-lint v2.4.0 (same as CI)
 just tidy             # Run go mod tidy
 just install-hooks    # Install pre-commit hook (runs golangci-lint on staged Go files)
 ```
@@ -350,7 +350,10 @@ This project has a Nix flake (`flake.nix`). **Always use `nix develop`** to ente
 
 - Go 1.23+ required (toolchain 1.24.x)
 - Use `go fmt` and pass `golangci-lint` (see `.golangci.yml` for enabled linters)
-- Linters enabled: `govet`, `staticcheck`, `ineffassign`, `errcheck`, `gocritic`, `misspell`
+- Linters enabled: `govet`, `staticcheck`, `ineffassign`, `errcheck`, `gocritic`, `misspell`, `revive`
+- `revive` runs a deliberately narrow rule set (see `.golangci.yml`); rules are added
+  gradually, only once the whole tree is already clean under them
+- `gofmt` runs as a golangci-lint formatter, so formatting drift fails CI
 - Keep errors lowercase and actionable
 - Prefer small, focused files
 
@@ -529,7 +532,7 @@ GitHub Actions workflows in `.github/workflows/`:
   - Uploads coverage artifacts (coverage.out, coverage.txt, coverage.html)
 
 - **lint.yml**: Runs on main/master and PRs
-  - Uses golangci-lint-action v8 with golangci-lint v2.1.6
+  - Uses golangci-lint-action v8 with golangci-lint v2.4.0
   - 5-minute timeout
 
 - **release-builds.yml**: Triggered on release publish
@@ -546,8 +549,8 @@ GitHub Actions workflows in `.github/workflows/`:
   - Uploads build artifacts
 
 CI pins:
-- Go `1.24.x`
-- golangci-lint `v2.1.6`
+- Go `1.25.x`
+- golangci-lint `v2.4.0`
 
 ## Error Tracking with Sentry
 

--- a/Justfile
+++ b/Justfile
@@ -59,7 +59,7 @@ lint:
       if command -v "$candidate" >/dev/null 2>&1; then LINT="$candidate"; break; fi
     done
     if [ -z "$LINT" ]; then
-      echo "golangci-lint not found. Install: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b \$(go env GOPATH)/bin v2.1.6"
+      echo "golangci-lint not found. Install: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b \$(go env GOPATH)/bin v2.4.0"
       exit 1
     fi
     echo "Using $($LINT --version 2>&1)"

--- a/internal/api/import_test.go
+++ b/internal/api/import_test.go
@@ -389,7 +389,9 @@ func TestAccountDelete_ForceTrue(t *testing.T) {
 
 	// Create account and pool referencing it
 	rr := doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/accounts", `{"key":"aws:111111111111","name":"Prod"}`, stdhttp.StatusCreated)
-	var acc struct{ ID int64 `json:"id"` }
+	var acc struct {
+		ID int64 `json:"id"`
+	}
 	_ = json.NewDecoder(rr.Body).Decode(&acc)
 
 	doJSON(t, srv.mux, stdhttp.MethodPost, "/api/v1/pools",

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -14,9 +14,9 @@ import (
 	"testing"
 	"time"
 
+	"cloudpam/internal/api"
 	"cloudpam/internal/audit"
 	"cloudpam/internal/auth"
-	"cloudpam/internal/api"
 	"cloudpam/internal/observability"
 	"cloudpam/internal/storage"
 	"cloudpam/internal/testutil"

--- a/internal/api/oidc_admin_test.go
+++ b/internal/api/oidc_admin_test.go
@@ -121,9 +121,9 @@ func TestOIDCAdmin_CreateProvider_MissingFields(t *testing.T) {
 	os := setupOIDCAdminTestEnv(t)
 
 	tests := []struct {
-		name     string
-		body     map[string]interface{}
-		wantErr  string
+		name    string
+		body    map[string]interface{}
+		wantErr string
 	}{
 		{
 			name:    "missing name",

--- a/internal/api/oidc_handlers_test.go
+++ b/internal/api/oidc_handlers_test.go
@@ -46,10 +46,10 @@ func setupOIDCTestEnv(t *testing.T) *testOIDCEnv {
 	idpMux := http.NewServeMux()
 	idpMux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		disc := map[string]interface{}{
-			"issuer":                 idpSrv.URL,
-			"authorization_endpoint": idpSrv.URL + "/authorize",
-			"token_endpoint":         idpSrv.URL + "/token",
-			"jwks_uri":               idpSrv.URL + "/keys",
+			"issuer":                                idpSrv.URL,
+			"authorization_endpoint":                idpSrv.URL + "/authorize",
+			"token_endpoint":                        idpSrv.URL + "/token",
+			"jwks_uri":                              idpSrv.URL + "/keys",
 			"id_token_signing_alg_values_supported": []string{"RS256"},
 			"subject_types_supported":               []string{"public"},
 			"response_types_supported":              []string{"code"},

--- a/internal/api/schema_handlers_test.go
+++ b/internal/api/schema_handlers_test.go
@@ -197,4 +197,3 @@ func TestSchemaApply_MethodNotAllowed(t *testing.T) {
 	srv, _ := setupTestServer()
 	doJSON(t, srv.mux, stdhttp.MethodGet, "/api/v1/schema/apply", "", stdhttp.StatusMethodNotAllowed)
 }
-

--- a/internal/audit/memory.go
+++ b/internal/audit/memory.go
@@ -24,10 +24,10 @@ type MemoryAuditLogger struct {
 type MemoryAuditLoggerOption func(*MemoryAuditLogger)
 
 // WithMaxEvents sets the maximum number of events to store.
-func WithMaxEvents(max int) MemoryAuditLoggerOption {
+func WithMaxEvents(n int) MemoryAuditLoggerOption {
 	return func(m *MemoryAuditLogger) {
-		if max > 0 {
-			m.maxEvents = max
+		if n > 0 {
+			m.maxEvents = n
 		}
 	}
 }
@@ -169,14 +169,14 @@ func copyEvent(e *AuditEvent) *AuditEvent {
 	if e == nil {
 		return nil
 	}
-	copy := *e
+	dup := *e
 	if e.Changes != nil {
-		copy.Changes = &Changes{
+		dup.Changes = &Changes{
 			Before: copyMap(e.Changes.Before),
 			After:  copyMap(e.Changes.After),
 		}
 	}
-	return &copy
+	return &dup
 }
 
 // copyMap creates a shallow copy of a map.
@@ -184,9 +184,9 @@ func copyMap(m map[string]any) map[string]any {
 	if m == nil {
 		return nil
 	}
-	copy := make(map[string]any, len(m))
+	dup := make(map[string]any, len(m))
 	for k, v := range m {
-		copy[k] = v
+		dup[k] = v
 	}
-	return copy
+	return dup
 }

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -32,10 +32,10 @@ func mockOIDCServer(t *testing.T) (*httptest.Server, *rsa.PrivateKey) {
 
 	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		discovery := map[string]interface{}{
-			"issuer":                 srv.URL,
-			"authorization_endpoint": srv.URL + "/authorize",
-			"token_endpoint":         srv.URL + "/token",
-			"jwks_uri":               srv.URL + "/keys",
+			"issuer":                                srv.URL,
+			"authorization_endpoint":                srv.URL + "/authorize",
+			"token_endpoint":                        srv.URL + "/token",
+			"jwks_uri":                              srv.URL + "/keys",
 			"id_token_signing_alg_values_supported": []string{"RS256"},
 			"subject_types_supported":               []string{"public"},
 			"response_types_supported":              []string{"code"},

--- a/internal/auth/postgres.go
+++ b/internal/auth/postgres.go
@@ -207,4 +207,3 @@ func scanAPIKey(row pgx.Row) (*APIKey, error) {
 
 	return &k, nil
 }
-

--- a/internal/auth/role_sqlite.go
+++ b/internal/auth/role_sqlite.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // CGO-less SQLite driver
 )
 
 type SQLiteRoleStore struct {

--- a/internal/auth/session_sqlite.go
+++ b/internal/auth/session_sqlite.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // CGO-less SQLite driver
 )
 
 // SQLiteSessionStore is a SQLite-backed implementation of SessionStore.
@@ -72,10 +72,10 @@ func (s *SQLiteSessionStore) Get(ctx context.Context, id string) (*Session, erro
 	}
 
 	var (
-		session                    Session
-		role                       string
-		createdAt, expiresAt       string
-		metadataJSON               string
+		session              Session
+		role                 string
+		createdAt, expiresAt string
+		metadataJSON         string
 	)
 
 	err := s.db.QueryRowContext(ctx, `

--- a/internal/auth/sqlite.go
+++ b/internal/auth/sqlite.go
@@ -136,12 +136,12 @@ func (s *SQLiteKeyStore) scanKeyList(rows *sql.Rows) ([]*APIKey, error) {
 	var keys []*APIKey
 	for rows.Next() {
 		var (
-			key                          APIKey
-			scopesJSON                   string
-			createdAt                    string
-			expiresAt, lastUsedAt        sql.NullString
-			revoked                      int
-			ownerID                      sql.NullString
+			key                   APIKey
+			scopesJSON            string
+			createdAt             string
+			expiresAt, lastUsedAt sql.NullString
+			revoked               int
+			ownerID               sql.NullString
 		)
 
 		if err := rows.Scan(&key.ID, &key.Prefix, &key.Name, &scopesJSON, &createdAt, &expiresAt, &lastUsedAt, &revoked, &ownerID); err != nil {
@@ -219,12 +219,12 @@ func (s *SQLiteKeyStore) Delete(ctx context.Context, id string) error {
 // Returns nil, nil if no row found.
 func (s *SQLiteKeyStore) scanKey(row *sql.Row) (*APIKey, error) {
 	var (
-		key                          APIKey
-		scopesJSON                   string
-		createdAt                    string
-		expiresAt, lastUsedAt        sql.NullString
-		revoked                      int
-		ownerID                      sql.NullString
+		key                   APIKey
+		scopesJSON            string
+		createdAt             string
+		expiresAt, lastUsedAt sql.NullString
+		revoked               int
+		ownerID               sql.NullString
 	)
 
 	err := row.Scan(&key.ID, &key.Prefix, &key.Name, &key.Hash, &key.Salt,
@@ -259,4 +259,3 @@ func (s *SQLiteKeyStore) scanKey(row *sql.Row) (*APIKey, error) {
 
 	return &key, nil
 }
-

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -210,7 +210,7 @@ func copyAPIKey(key *APIKey) *APIKey {
 		return nil
 	}
 
-	copy := &APIKey{
+	dup := &APIKey{
 		ID:        key.ID,
 		Prefix:    key.Prefix,
 		Name:      key.Name,
@@ -220,31 +220,31 @@ func copyAPIKey(key *APIKey) *APIKey {
 	}
 
 	if key.Hash != nil {
-		copy.Hash = make([]byte, len(key.Hash))
-		copyBytes(copy.Hash, key.Hash)
+		dup.Hash = make([]byte, len(key.Hash))
+		copyBytes(dup.Hash, key.Hash)
 	}
 
 	if key.Salt != nil {
-		copy.Salt = make([]byte, len(key.Salt))
-		copyBytes(copy.Salt, key.Salt)
+		dup.Salt = make([]byte, len(key.Salt))
+		copyBytes(dup.Salt, key.Salt)
 	}
 
 	if key.Scopes != nil {
-		copy.Scopes = make([]string, len(key.Scopes))
-		copyStrings(copy.Scopes, key.Scopes)
+		dup.Scopes = make([]string, len(key.Scopes))
+		copyStrings(dup.Scopes, key.Scopes)
 	}
 
 	if key.ExpiresAt != nil {
 		t := *key.ExpiresAt
-		copy.ExpiresAt = &t
+		dup.ExpiresAt = &t
 	}
 
 	if key.LastUsedAt != nil {
 		t := *key.LastUsedAt
-		copy.LastUsedAt = &t
+		dup.LastUsedAt = &t
 	}
 
-	return copy
+	return dup
 }
 
 func copyBytes(dst, src []byte) {

--- a/internal/auth/user_sqlite.go
+++ b/internal/auth/user_sqlite.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // CGO-less SQLite driver
 )
 
 // SQLiteUserStore is a SQLite-backed implementation of UserStore.

--- a/internal/domain/drift.go
+++ b/internal/domain/drift.go
@@ -10,11 +10,11 @@ import (
 type DriftType string
 
 const (
-	DriftTypeUnmanaged     DriftType = "unmanaged"
-	DriftTypeCIDRMismatch  DriftType = "cidr_mismatch"
-	DriftTypeOrphanedPool  DriftType = "orphaned_pool"
-	DriftTypeNameMismatch  DriftType = "name_mismatch"
-	DriftTypeAccountDrift  DriftType = "account_drift"
+	DriftTypeUnmanaged    DriftType = "unmanaged"
+	DriftTypeCIDRMismatch DriftType = "cidr_mismatch"
+	DriftTypeOrphanedPool DriftType = "orphaned_pool"
+	DriftTypeNameMismatch DriftType = "name_mismatch"
+	DriftTypeAccountDrift DriftType = "account_drift"
 )
 
 // DriftSeverity indicates urgency.

--- a/internal/domain/recommendations.go
+++ b/internal/domain/recommendations.go
@@ -8,8 +8,8 @@ import (
 type RecommendationType string
 
 const (
-	RecommendationTypeAllocation  RecommendationType = "allocation"
-	RecommendationTypeCompliance  RecommendationType = "compliance"
+	RecommendationTypeAllocation RecommendationType = "allocation"
+	RecommendationTypeCompliance RecommendationType = "compliance"
 	// Future types (stubbed):
 	// RecommendationTypeConsolidation RecommendationType = "consolidation"
 	// RecommendationTypeResize        RecommendationType = "resize"

--- a/internal/domain/search.go
+++ b/internal/domain/search.go
@@ -18,17 +18,17 @@ type SearchRequest struct {
 
 // SearchResultItem is a single search result that may be a pool or an account.
 type SearchResultItem struct {
-	Type        string `json:"type"`                   // "pool" or "account"
-	ID          int64  `json:"id"`                     // entity ID
-	Name        string `json:"name"`                   // pool name or account name
-	CIDR        string `json:"cidr,omitempty"`         // pool CIDR
-	Description string `json:"description,omitempty"`  // pool or account description
-	Status      string `json:"status,omitempty"`       // pool status
-	PoolType    string `json:"pool_type,omitempty"`    // pool type (supernet, region, etc.)
-	AccountKey  string `json:"account_key,omitempty"`  // account key
-	Provider    string `json:"provider,omitempty"`     // account provider
-	ParentID    *int64 `json:"parent_id,omitempty"`    // pool parent ID
-	AccountID   *int64 `json:"account_id,omitempty"`   // pool account ID
+	Type        string `json:"type"`                  // "pool" or "account"
+	ID          int64  `json:"id"`                    // entity ID
+	Name        string `json:"name"`                  // pool name or account name
+	CIDR        string `json:"cidr,omitempty"`        // pool CIDR
+	Description string `json:"description,omitempty"` // pool or account description
+	Status      string `json:"status,omitempty"`      // pool status
+	PoolType    string `json:"pool_type,omitempty"`   // pool type (supernet, region, etc.)
+	AccountKey  string `json:"account_key,omitempty"` // account key
+	Provider    string `json:"provider,omitempty"`    // account provider
+	ParentID    *int64 `json:"parent_id,omitempty"`   // pool parent ID
+	AccountID   *int64 `json:"account_id,omitempty"`  // pool account ID
 }
 
 // SearchResponse is the paginated response for a search query.

--- a/internal/planning/analysis.go
+++ b/internal/planning/analysis.go
@@ -91,7 +91,7 @@ func (s *AnalysisService) Analyze(ctx context.Context, req AnalysisRequest) (*Ne
 				healthScore -= 5
 			case "info":
 				infoCount++
-				healthScore -= 1
+				healthScore--
 			}
 		}
 	}

--- a/internal/planning/recommendations.go
+++ b/internal/planning/recommendations.go
@@ -115,11 +115,11 @@ func (s *RecommendationService) Apply(ctx context.Context, id string, req domain
 		}
 		parentID := rec.PoolID
 		newPool, err := s.mainStore.CreatePool(ctx, domain.CreatePool{
-			Name:     name,
-			CIDR:     rec.SuggestedCIDR,
-			ParentID: &parentID,
+			Name:      name,
+			CIDR:      rec.SuggestedCIDR,
+			ParentID:  &parentID,
 			AccountID: req.AccountID,
-			Source:   domain.PoolSourceManual,
+			Source:    domain.PoolSourceManual,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("create pool from recommendation: %w", err)

--- a/internal/storage/settings_memory.go
+++ b/internal/storage/settings_memory.go
@@ -60,8 +60,8 @@ func (s *MemorySettingsStore) UpdateSecuritySettings(_ context.Context, settings
 func (s *MemorySettingsStore) GetNetworkSchemaPolicy(_ context.Context) (*domain.NetworkSchemaPolicy, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	copy := *s.networkSchemaPolicy
-	return domain.NormalizeNetworkSchemaPolicy(&copy), nil
+	dup := *s.networkSchemaPolicy
+	return domain.NormalizeNetworkSchemaPolicy(&dup), nil
 }
 
 func (s *MemorySettingsStore) UpdateNetworkSchemaPolicy(_ context.Context, policy *domain.NetworkSchemaPolicy) error {

--- a/internal/storage/sqlite/migrator.go
+++ b/internal/storage/sqlite/migrator.go
@@ -3,128 +3,170 @@
 package sqlite
 
 import (
-    "database/sql"
-    "fmt"
-    "io/fs"
-    "os"
-    "path/filepath"
-    "regexp"
-    "sort"
-    "strings"
-    "time"
+	"database/sql"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
 
-    migfs "cloudpam/migrations"
+	migfs "cloudpam/migrations"
 )
 
 var migFileRe = regexp.MustCompile(`^(\d+)_.+\.sql$`)
 
-
 func runMigrations(db *sql.DB) error {
-    if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL)`); err != nil {
-        return err
-    }
-    if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_info (id INTEGER PRIMARY KEY CHECK(id=1), schema_version INTEGER NOT NULL, min_supported_schema INTEGER NOT NULL DEFAULT 1, app_version TEXT NOT NULL, applied_at TEXT NOT NULL)`); err != nil {
-        return err
-    }
-    // discover migrations dir
-    var useFS fs.FS
-    if dir, err := findMigrationsDir(); err == nil {
-        useFS = os.DirFS(dir)
-    } else {
-        // fallback to embedded
-        useFS = migfs.Files
-    }
-    entries, err := fs.ReadDir(useFS, ".")
-    if err != nil { return err }
-    type mig struct{ version int; name, path string }
-    var files []mig
-    for _, e := range entries {
-        if e.IsDir() { continue }
-        name := e.Name()
-        m := migFileRe.FindStringSubmatch(name)
-        if len(m) == 0 { continue }
-        v := 0
-        fmt.Sscanf(m[1], "%d", &v)
-        files = append(files, mig{version: v, name: name, path: name})
-    }
-    sort.Slice(files, func(i, j int) bool { return files[i].version < files[j].version })
-    applied := map[int]bool{}
-    rows, err := db.Query(`SELECT version FROM schema_migrations`)
-    if err != nil { return err }
-    defer rows.Close()
-    for rows.Next() {
-        var v int
-        if err := rows.Scan(&v); err != nil { return err }
-        applied[v] = true
-    }
-    if err := rows.Err(); err != nil { return err }
-    latest := 0
-    for _, f := range files {
-        if applied[f.version] { continue }
-        var sqlBytes []byte
-        // read from selected fs
-        if of, ok := useFS.(fs.ReadFileFS); ok {
-            b, e := of.ReadFile(f.path); if e != nil { return e }; sqlBytes = b
-        } else {
-            // should not happen, but keep fallback
-            b, e := os.ReadFile(filepath.Clean(f.path)); if e != nil { return e }; sqlBytes = b
-        }
-        if err != nil { return err }
-        stmt := strings.TrimSpace(string(sqlBytes))
-        if stmt == "" { continue }
-        tx, err := db.Begin()
-        if err != nil { return err }
-        if _, err := tx.Exec(stmt); err != nil {
-            _ = tx.Rollback()
-            return fmt.Errorf("migration %s failed: %w", f.name, err)
-        }
-        if _, err := tx.Exec(`INSERT INTO schema_migrations(version, name, applied_at) VALUES(?, ?, ?)`, f.version, f.name, time.Now().UTC().Format(time.RFC3339)); err != nil {
-            _ = tx.Rollback()
-            return err
-        }
-        if err := tx.Commit(); err != nil { return err }
-        if f.version > latest { latest = f.version }
-    }
-    // Update schema_info
-    if latest == 0 {
-        // compute current by reading max(version)
-        _ = db.QueryRow(`SELECT COALESCE(MAX(version),0) FROM schema_migrations`).Scan(&latest)
-    }
-    appVersion := os.Getenv("APP_VERSION")
-    if appVersion == "" { appVersion = "dev" }
-    // upsert id=1
-    _, _ = db.Exec(`INSERT INTO schema_info(id, schema_version, min_supported_schema, app_version, applied_at)
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_info (id INTEGER PRIMARY KEY CHECK(id=1), schema_version INTEGER NOT NULL, min_supported_schema INTEGER NOT NULL DEFAULT 1, app_version TEXT NOT NULL, applied_at TEXT NOT NULL)`); err != nil {
+		return err
+	}
+	// discover migrations dir
+	var useFS fs.FS
+	if dir, err := findMigrationsDir(); err == nil {
+		useFS = os.DirFS(dir)
+	} else {
+		// fallback to embedded
+		useFS = migfs.Files
+	}
+	entries, err := fs.ReadDir(useFS, ".")
+	if err != nil {
+		return err
+	}
+	type mig struct {
+		version    int
+		name, path string
+	}
+	var files []mig
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		m := migFileRe.FindStringSubmatch(name)
+		if len(m) == 0 {
+			continue
+		}
+		v := 0
+		fmt.Sscanf(m[1], "%d", &v)
+		files = append(files, mig{version: v, name: name, path: name})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].version < files[j].version })
+	applied := map[int]bool{}
+	rows, err := db.Query(`SELECT version FROM schema_migrations`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			return err
+		}
+		applied[v] = true
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	latest := 0
+	for _, f := range files {
+		if applied[f.version] {
+			continue
+		}
+		var sqlBytes []byte
+		// read from selected fs
+		if of, ok := useFS.(fs.ReadFileFS); ok {
+			b, e := of.ReadFile(f.path)
+			if e != nil {
+				return e
+			}
+			sqlBytes = b
+		} else {
+			// should not happen, but keep fallback
+			b, e := os.ReadFile(filepath.Clean(f.path))
+			if e != nil {
+				return e
+			}
+			sqlBytes = b
+		}
+		if err != nil {
+			return err
+		}
+		stmt := strings.TrimSpace(string(sqlBytes))
+		if stmt == "" {
+			continue
+		}
+		tx, err := db.Begin()
+		if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(stmt); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("migration %s failed: %w", f.name, err)
+		}
+		if _, err := tx.Exec(`INSERT INTO schema_migrations(version, name, applied_at) VALUES(?, ?, ?)`, f.version, f.name, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		if f.version > latest {
+			latest = f.version
+		}
+	}
+	// Update schema_info
+	if latest == 0 {
+		// compute current by reading max(version)
+		_ = db.QueryRow(`SELECT COALESCE(MAX(version),0) FROM schema_migrations`).Scan(&latest)
+	}
+	appVersion := os.Getenv("APP_VERSION")
+	if appVersion == "" {
+		appVersion = "dev"
+	}
+	// upsert id=1
+	_, _ = db.Exec(`INSERT INTO schema_info(id, schema_version, min_supported_schema, app_version, applied_at)
                     VALUES(1, ?, COALESCE((SELECT min_supported_schema FROM schema_info WHERE id=1),1), ?, ?)
                     ON CONFLICT(id) DO UPDATE SET schema_version=excluded.schema_version, app_version=excluded.app_version, applied_at=excluded.applied_at`,
-        latest, appVersion, time.Now().UTC().Format(time.RFC3339))
-    return nil
+		latest, appVersion, time.Now().UTC().Format(time.RFC3339))
+	return nil
 }
 
 func findMigrationsDir() (string, error) {
-    // Try common relative paths from various working dirs
-    candidates := []string{
-        "migrations",
-        filepath.Join("..", "migrations"),
-        filepath.Join("..", "..", "migrations"),
-        filepath.Join("..", "..", "..", "migrations"),
-        filepath.Join("..", "..", "..", "..", "migrations"),
-    }
-    for _, c := range candidates {
-        ok, err := dirHasSQL(c)
-        if err == nil && ok {
-            return c, nil
-        }
-    }
-    return "", fmt.Errorf("migrations directory not found; tried %v", candidates)
+	// Try common relative paths from various working dirs
+	candidates := []string{
+		"migrations",
+		filepath.Join("..", "migrations"),
+		filepath.Join("..", "..", "migrations"),
+		filepath.Join("..", "..", "..", "migrations"),
+		filepath.Join("..", "..", "..", "..", "migrations"),
+	}
+	for _, c := range candidates {
+		ok, err := dirHasSQL(c)
+		if err == nil && ok {
+			return c, nil
+		}
+	}
+	return "", fmt.Errorf("migrations directory not found; tried %v", candidates)
 }
 
 func dirHasSQL(dir string) (bool, error) {
-    var found bool
-    err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-        if err != nil { return err }
-        if d.IsDir() { return nil }
-        if strings.HasSuffix(d.Name(), ".sql") { found = true }
-        return nil
-    })
-    return found, err
+	var found bool
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), ".sql") {
+			found = true
+		}
+		return nil
+	})
+	return found, err
 }

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -3,28 +3,28 @@
 package sqlite
 
 import (
-    "context"
-    "database/sql"
-    "encoding/binary"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "net"
-    "net/netip"
-    "os"
-    "strconv"
-    "strings"
-    "time"
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
-    _ "modernc.org/sqlite" // CGO-less SQLite driver
+	_ "modernc.org/sqlite" // CGO-less SQLite driver
 
-    "cloudpam/internal/cidr"
-    "cloudpam/internal/domain"
-    "cloudpam/internal/storage"
+	"cloudpam/internal/cidr"
+	"cloudpam/internal/domain"
+	"cloudpam/internal/storage"
 )
 
 type Store struct {
-    db *sql.DB
+	db *sql.DB
 }
 
 // Connection pool defaults for SQLite.
@@ -34,452 +34,513 @@ type Store struct {
 //   - SQLITE_CONN_MAX_LIFETIME_SECS (default: 3600 — 1 hour)
 //   - SQLITE_CONN_MAX_IDLE_SECS (default: 600 — 10 minutes)
 const (
-    defaultMaxOpenConns     = 1
-    defaultMaxIdleConns     = 2
-    defaultConnMaxLifetime  = 3600 // seconds
-    defaultConnMaxIdleTime  = 600  // seconds
+	defaultMaxOpenConns    = 1
+	defaultMaxIdleConns    = 2
+	defaultConnMaxLifetime = 3600 // seconds
+	defaultConnMaxIdleTime = 600  // seconds
 )
 
 func New(dsn string) (*Store, error) {
-    db, err := sql.Open("sqlite", dsn)
-    if err != nil {
-        return nil, err
-    }
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
 
-    // Configure connection pool from env vars with sensible defaults.
-    db.SetMaxOpenConns(envIntOrDefault("SQLITE_MAX_OPEN_CONNS", defaultMaxOpenConns))
-    db.SetMaxIdleConns(envIntOrDefault("SQLITE_MAX_IDLE_CONNS", defaultMaxIdleConns))
-    db.SetConnMaxLifetime(time.Duration(envIntOrDefault("SQLITE_CONN_MAX_LIFETIME_SECS", defaultConnMaxLifetime)) * time.Second)
-    db.SetConnMaxIdleTime(time.Duration(envIntOrDefault("SQLITE_CONN_MAX_IDLE_SECS", defaultConnMaxIdleTime)) * time.Second)
+	// Configure connection pool from env vars with sensible defaults.
+	db.SetMaxOpenConns(envIntOrDefault("SQLITE_MAX_OPEN_CONNS", defaultMaxOpenConns))
+	db.SetMaxIdleConns(envIntOrDefault("SQLITE_MAX_IDLE_CONNS", defaultMaxIdleConns))
+	db.SetConnMaxLifetime(time.Duration(envIntOrDefault("SQLITE_CONN_MAX_LIFETIME_SECS", defaultConnMaxLifetime)) * time.Second)
+	db.SetConnMaxIdleTime(time.Duration(envIntOrDefault("SQLITE_CONN_MAX_IDLE_SECS", defaultConnMaxIdleTime)) * time.Second)
 
-    if _, err := db.Exec(`PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;`); err != nil {
-        _ = db.Close()
-        return nil, err
-    }
-    if err := runMigrations(db); err != nil {
-        _ = db.Close()
-        return nil, err
-    }
-    // Capture schema status silently; can be surfaced via Status()
-    var _schemaVersion, _minSupported int
-    var _appVersion, _appliedAt string
-    _ = db.QueryRow(`SELECT schema_version, min_supported_schema, app_version, applied_at FROM schema_info WHERE id=1`).Scan(&_schemaVersion, &_minSupported, &_appVersion, &_appliedAt)
-    return &Store{db: db}, nil
+	if _, err := db.Exec(`PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;`); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := runMigrations(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	// Capture schema status silently; can be surfaced via Status()
+	var _schemaVersion, _minSupported int
+	var _appVersion, _appliedAt string
+	_ = db.QueryRow(`SELECT schema_version, min_supported_schema, app_version, applied_at FROM schema_info WHERE id=1`).Scan(&_schemaVersion, &_minSupported, &_appVersion, &_appliedAt)
+	return &Store{db: db}, nil
 }
 
 // envIntOrDefault reads an integer from the named environment variable,
 // falling back to def if unset or unparseable.
 func envIntOrDefault(name string, def int) int {
-    v := os.Getenv(name)
-    if v == "" {
-        return def
-    }
-    n, err := strconv.Atoi(v)
-    if err != nil {
-        return def
-    }
-    return n
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
 }
 
 // Status returns schema_migrations and schema_info summary for the given DSN without creating a Store.
 func Status(dsn string) (string, error) {
-    db, err := sql.Open("sqlite", dsn)
-    if err != nil { return "", err }
-    defer db.Close()
-    // ensure tables may exist; do not run migrations here
-    var latest int
-    _ = db.QueryRow(`SELECT COALESCE(MAX(version),0) FROM schema_migrations`).Scan(&latest)
-    var schemaVersion, minSupported int
-    var appVersion, appliedAt string
-    _ = db.QueryRow(`SELECT schema_version, min_supported_schema, app_version, applied_at FROM schema_info WHERE id=1`).Scan(&schemaVersion, &minSupported, &appVersion, &appliedAt)
-    // Count applied
-    var count int
-    _ = db.QueryRow(`SELECT COUNT(1) FROM schema_migrations`).Scan(&count)
-    return fmt.Sprintf("schema_version=%d applied=%d latest=%d app_version=%s applied_at=%s min_supported=%d", schemaVersion, count, latest, appVersion, appliedAt, minSupported), nil
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return "", err
+	}
+	defer db.Close()
+	// ensure tables may exist; do not run migrations here
+	var latest int
+	_ = db.QueryRow(`SELECT COALESCE(MAX(version),0) FROM schema_migrations`).Scan(&latest)
+	var schemaVersion, minSupported int
+	var appVersion, appliedAt string
+	_ = db.QueryRow(`SELECT schema_version, min_supported_schema, app_version, applied_at FROM schema_info WHERE id=1`).Scan(&schemaVersion, &minSupported, &appVersion, &appliedAt)
+	// Count applied
+	var count int
+	_ = db.QueryRow(`SELECT COUNT(1) FROM schema_migrations`).Scan(&count)
+	return fmt.Sprintf("schema_version=%d applied=%d latest=%d app_version=%s applied_at=%s min_supported=%d", schemaVersion, count, latest, appVersion, appliedAt, minSupported), nil
 }
 
 var _ storage.Store = (*Store)(nil)
 
 // Close closes the underlying database connection and releases resources.
 func (s *Store) Close() error {
-    if s.db != nil {
-        return s.db.Close()
-    }
-    return nil
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
 }
 
 func (s *Store) ListPools(ctx context.Context) ([]domain.Pool, error) {
-    rows, err := s.db.QueryContext(ctx, `SELECT id, name, cidr, parent_id, account_id, type, status, source, description, tags, created_at, updated_at FROM pools WHERE deleted_at IS NULL ORDER BY id ASC`)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
-    var out []domain.Pool
-    for rows.Next() {
-        var p domain.Pool
-        var createdAt, updatedAt sql.NullString
-        var parent, account sql.NullInt64
-        var poolType, poolStatus, poolSource, description, tagsJSON sql.NullString
-        if err := rows.Scan(&p.ID, &p.Name, &p.CIDR, &parent, &account, &poolType, &poolStatus, &poolSource, &description, &tagsJSON, &createdAt, &updatedAt); err != nil {
-            return nil, err
-        }
-        if parent.Valid {
-            p.ParentID = &parent.Int64
-        }
-        if account.Valid {
-            p.AccountID = &account.Int64
-        }
-        // Set new fields with defaults
-        p.Type = domain.PoolTypeSubnet
-        if poolType.Valid && poolType.String != "" {
-            p.Type = domain.PoolType(poolType.String)
-        }
-        p.Status = domain.PoolStatusActive
-        if poolStatus.Valid && poolStatus.String != "" {
-            p.Status = domain.PoolStatus(poolStatus.String)
-        }
-        p.Source = domain.PoolSourceManual
-        if poolSource.Valid && poolSource.String != "" {
-            p.Source = domain.PoolSource(poolSource.String)
-        }
-        if description.Valid {
-            p.Description = description.String
-        }
-        if tagsJSON.Valid && tagsJSON.String != "" && tagsJSON.String != "{}" {
-            var tags map[string]string
-            if err := json.Unmarshal([]byte(tagsJSON.String), &tags); err == nil {
-                p.Tags = tags
-            }
-        }
-        if createdAt.Valid {
-            if t, e := time.Parse(time.RFC3339, createdAt.String); e == nil {
-                p.CreatedAt = t
-            }
-        }
-        if updatedAt.Valid {
-            if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil {
-                p.UpdatedAt = t
-            }
-        }
-        out = append(out, p)
-    }
-    return out, rows.Err()
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, cidr, parent_id, account_id, type, status, source, description, tags, created_at, updated_at FROM pools WHERE deleted_at IS NULL ORDER BY id ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []domain.Pool
+	for rows.Next() {
+		var p domain.Pool
+		var createdAt, updatedAt sql.NullString
+		var parent, account sql.NullInt64
+		var poolType, poolStatus, poolSource, description, tagsJSON sql.NullString
+		if err := rows.Scan(&p.ID, &p.Name, &p.CIDR, &parent, &account, &poolType, &poolStatus, &poolSource, &description, &tagsJSON, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		if parent.Valid {
+			p.ParentID = &parent.Int64
+		}
+		if account.Valid {
+			p.AccountID = &account.Int64
+		}
+		// Set new fields with defaults
+		p.Type = domain.PoolTypeSubnet
+		if poolType.Valid && poolType.String != "" {
+			p.Type = domain.PoolType(poolType.String)
+		}
+		p.Status = domain.PoolStatusActive
+		if poolStatus.Valid && poolStatus.String != "" {
+			p.Status = domain.PoolStatus(poolStatus.String)
+		}
+		p.Source = domain.PoolSourceManual
+		if poolSource.Valid && poolSource.String != "" {
+			p.Source = domain.PoolSource(poolSource.String)
+		}
+		if description.Valid {
+			p.Description = description.String
+		}
+		if tagsJSON.Valid && tagsJSON.String != "" && tagsJSON.String != "{}" {
+			var tags map[string]string
+			if err := json.Unmarshal([]byte(tagsJSON.String), &tags); err == nil {
+				p.Tags = tags
+			}
+		}
+		if createdAt.Valid {
+			if t, e := time.Parse(time.RFC3339, createdAt.String); e == nil {
+				p.CreatedAt = t
+			}
+		}
+		if updatedAt.Valid {
+			if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil {
+				p.UpdatedAt = t
+			}
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) CreatePool(ctx context.Context, in domain.CreatePool) (domain.Pool, error) {
-    if in.Name == "" || in.CIDR == "" {
-        return domain.Pool{}, fmt.Errorf("name and cidr required: %w", storage.ErrValidation)
-    }
-    now := time.Now().UTC()
+	if in.Name == "" || in.CIDR == "" {
+		return domain.Pool{}, fmt.Errorf("name and cidr required: %w", storage.ErrValidation)
+	}
+	now := time.Now().UTC()
 
-    // Apply defaults for new fields
-    poolType := in.Type
-    if poolType == "" {
-        poolType = domain.PoolTypeSubnet
-    }
-    poolStatus := in.Status
-    if poolStatus == "" {
-        poolStatus = domain.PoolStatusActive
-    }
-    poolSource := in.Source
-    if poolSource == "" {
-        poolSource = domain.PoolSourceManual
-    }
+	// Apply defaults for new fields
+	poolType := in.Type
+	if poolType == "" {
+		poolType = domain.PoolTypeSubnet
+	}
+	poolStatus := in.Status
+	if poolStatus == "" {
+		poolStatus = domain.PoolStatusActive
+	}
+	poolSource := in.Source
+	if poolSource == "" {
+		poolSource = domain.PoolSourceManual
+	}
 
-    // Serialize tags to JSON
-    var tagsJSON string
-    if in.Tags != nil {
-        if b, e := json.Marshal(in.Tags); e == nil {
-            tagsJSON = string(b)
-        }
-    } else {
-        tagsJSON = "{}"
-    }
+	// Serialize tags to JSON
+	var tagsJSON string
+	if in.Tags != nil {
+		if b, e := json.Marshal(in.Tags); e == nil {
+			tagsJSON = string(b)
+		}
+	} else {
+		tagsJSON = "{}"
+	}
 
-    nowStr := now.Format(time.RFC3339)
-    res, err := s.db.ExecContext(ctx, `INSERT INTO pools(name, cidr, parent_id, account_id, type, status, source, description, tags, created_at, updated_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        in.Name, in.CIDR, in.ParentID, in.AccountID, string(poolType), string(poolStatus), string(poolSource), in.Description, tagsJSON, nowStr, nowStr)
-    if err != nil {
-        return domain.Pool{}, storage.WrapIfConflict(err)
-    }
-    id, err := res.LastInsertId()
-    if err != nil {
-        return domain.Pool{}, err
-    }
+	nowStr := now.Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx, `INSERT INTO pools(name, cidr, parent_id, account_id, type, status, source, description, tags, created_at, updated_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		in.Name, in.CIDR, in.ParentID, in.AccountID, string(poolType), string(poolStatus), string(poolSource), in.Description, tagsJSON, nowStr, nowStr)
+	if err != nil {
+		return domain.Pool{}, storage.WrapIfConflict(err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return domain.Pool{}, err
+	}
 
-    // Copy tags to avoid shared reference
-    var tags map[string]string
-    if in.Tags != nil {
-        tags = make(map[string]string, len(in.Tags))
-        for k, v := range in.Tags {
-            tags[k] = v
-        }
-    }
+	// Copy tags to avoid shared reference
+	var tags map[string]string
+	if in.Tags != nil {
+		tags = make(map[string]string, len(in.Tags))
+		for k, v := range in.Tags {
+			tags[k] = v
+		}
+	}
 
-    return domain.Pool{
-        ID:          id,
-        Name:        in.Name,
-        CIDR:        in.CIDR,
-        ParentID:    in.ParentID,
-        AccountID:   in.AccountID,
-        Type:        poolType,
-        Status:      poolStatus,
-        Source:      poolSource,
-        Description: in.Description,
-        Tags:        tags,
-        CreatedAt:   now,
-        UpdatedAt:   now,
-    }, nil
+	return domain.Pool{
+		ID:          id,
+		Name:        in.Name,
+		CIDR:        in.CIDR,
+		ParentID:    in.ParentID,
+		AccountID:   in.AccountID,
+		Type:        poolType,
+		Status:      poolStatus,
+		Source:      poolSource,
+		Description: in.Description,
+		Tags:        tags,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}, nil
 }
 
 func (s *Store) GetPool(ctx context.Context, id int64) (domain.Pool, bool, error) {
-    var p domain.Pool
-    var createdAt, updatedAt sql.NullString
-    var parent, account sql.NullInt64
-    var poolType, poolStatus, poolSource, description, tagsJSON sql.NullString
-    row := s.db.QueryRowContext(ctx, `SELECT id, name, cidr, parent_id, account_id, type, status, source, description, tags, created_at, updated_at FROM pools WHERE id=? AND deleted_at IS NULL`, id)
-    if err := row.Scan(&p.ID, &p.Name, &p.CIDR, &parent, &account, &poolType, &poolStatus, &poolSource, &description, &tagsJSON, &createdAt, &updatedAt); err != nil {
-        if errors.Is(err, sql.ErrNoRows) {
-            return domain.Pool{}, false, nil
-        }
-        return domain.Pool{}, false, err
-    }
-    if parent.Valid {
-        p.ParentID = &parent.Int64
-    }
-    if account.Valid {
-        p.AccountID = &account.Int64
-    }
-    // Set new fields with defaults
-    p.Type = domain.PoolTypeSubnet
-    if poolType.Valid && poolType.String != "" {
-        p.Type = domain.PoolType(poolType.String)
-    }
-    p.Status = domain.PoolStatusActive
-    if poolStatus.Valid && poolStatus.String != "" {
-        p.Status = domain.PoolStatus(poolStatus.String)
-    }
-    p.Source = domain.PoolSourceManual
-    if poolSource.Valid && poolSource.String != "" {
-        p.Source = domain.PoolSource(poolSource.String)
-    }
-    if description.Valid {
-        p.Description = description.String
-    }
-    if tagsJSON.Valid && tagsJSON.String != "" && tagsJSON.String != "{}" {
-        var tags map[string]string
-        if err := json.Unmarshal([]byte(tagsJSON.String), &tags); err == nil {
-            p.Tags = tags
-        }
-    }
-    if createdAt.Valid {
-        if t, e := time.Parse(time.RFC3339, createdAt.String); e == nil {
-            p.CreatedAt = t
-        }
-    }
-    if updatedAt.Valid {
-        if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil {
-            p.UpdatedAt = t
-        }
-    }
-    return p, true, nil
+	var p domain.Pool
+	var createdAt, updatedAt sql.NullString
+	var parent, account sql.NullInt64
+	var poolType, poolStatus, poolSource, description, tagsJSON sql.NullString
+	row := s.db.QueryRowContext(ctx, `SELECT id, name, cidr, parent_id, account_id, type, status, source, description, tags, created_at, updated_at FROM pools WHERE id=? AND deleted_at IS NULL`, id)
+	if err := row.Scan(&p.ID, &p.Name, &p.CIDR, &parent, &account, &poolType, &poolStatus, &poolSource, &description, &tagsJSON, &createdAt, &updatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.Pool{}, false, nil
+		}
+		return domain.Pool{}, false, err
+	}
+	if parent.Valid {
+		p.ParentID = &parent.Int64
+	}
+	if account.Valid {
+		p.AccountID = &account.Int64
+	}
+	// Set new fields with defaults
+	p.Type = domain.PoolTypeSubnet
+	if poolType.Valid && poolType.String != "" {
+		p.Type = domain.PoolType(poolType.String)
+	}
+	p.Status = domain.PoolStatusActive
+	if poolStatus.Valid && poolStatus.String != "" {
+		p.Status = domain.PoolStatus(poolStatus.String)
+	}
+	p.Source = domain.PoolSourceManual
+	if poolSource.Valid && poolSource.String != "" {
+		p.Source = domain.PoolSource(poolSource.String)
+	}
+	if description.Valid {
+		p.Description = description.String
+	}
+	if tagsJSON.Valid && tagsJSON.String != "" && tagsJSON.String != "{}" {
+		var tags map[string]string
+		if err := json.Unmarshal([]byte(tagsJSON.String), &tags); err == nil {
+			p.Tags = tags
+		}
+	}
+	if createdAt.Valid {
+		if t, e := time.Parse(time.RFC3339, createdAt.String); e == nil {
+			p.CreatedAt = t
+		}
+	}
+	if updatedAt.Valid {
+		if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil {
+			p.UpdatedAt = t
+		}
+	}
+	return p, true, nil
 }
 
 func (s *Store) UpdatePoolAccount(ctx context.Context, id int64, accountID *int64) (domain.Pool, bool, error) {
-    // Update and then fetch
-    now := time.Now().UTC().Format(time.RFC3339)
-    if _, err := s.db.ExecContext(ctx, `UPDATE pools SET account_id=?, updated_at=? WHERE id=?`, accountID, now, id); err != nil {
-        return domain.Pool{}, false, err
-    }
-    return s.GetPool(ctx, id)
+	// Update and then fetch
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.ExecContext(ctx, `UPDATE pools SET account_id=?, updated_at=? WHERE id=?`, accountID, now, id); err != nil {
+		return domain.Pool{}, false, err
+	}
+	return s.GetPool(ctx, id)
 }
 
 func (s *Store) UpdatePoolMeta(ctx context.Context, id int64, name *string, accountID *int64) (domain.Pool, bool, error) {
-    // Fetch current
-    p, ok, err := s.GetPool(ctx, id)
-    if err != nil || !ok { return domain.Pool{}, ok, err }
-    if name != nil { p.Name = *name }
-    // Always set accountID (caller controls whether to clear or set)
-    p.AccountID = accountID
-    now := time.Now().UTC().Format(time.RFC3339)
-    if _, err := s.db.ExecContext(ctx, `UPDATE pools SET name=?, account_id=?, updated_at=? WHERE id=?`, p.Name, p.AccountID, now, id); err != nil {
-        return domain.Pool{}, false, err
-    }
-    return s.GetPool(ctx, id)
+	// Fetch current
+	p, ok, err := s.GetPool(ctx, id)
+	if err != nil || !ok {
+		return domain.Pool{}, ok, err
+	}
+	if name != nil {
+		p.Name = *name
+	}
+	// Always set accountID (caller controls whether to clear or set)
+	p.AccountID = accountID
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.ExecContext(ctx, `UPDATE pools SET name=?, account_id=?, updated_at=? WHERE id=?`, p.Name, p.AccountID, now, id); err != nil {
+		return domain.Pool{}, false, err
+	}
+	return s.GetPool(ctx, id)
 }
 
 // UpdatePool updates pool metadata with support for new fields.
 func (s *Store) UpdatePool(ctx context.Context, id int64, update domain.UpdatePool) (domain.Pool, bool, error) {
-    // Fetch current
-    p, ok, err := s.GetPool(ctx, id)
-    if err != nil || !ok {
-        return domain.Pool{}, ok, err
-    }
-    if update.Name != nil {
-        p.Name = *update.Name
-    }
-    // AccountID is always set (can be nil to clear)
-    p.AccountID = update.AccountID
-    if update.Type != nil {
-        p.Type = *update.Type
-    }
-    if update.Status != nil {
-        p.Status = *update.Status
-    }
-    if update.Description != nil {
-        p.Description = *update.Description
-    }
-    if update.Tags != nil {
-        if *update.Tags != nil {
-            p.Tags = make(map[string]string, len(*update.Tags))
-            for k, v := range *update.Tags {
-                p.Tags[k] = v
-            }
-        } else {
-            p.Tags = nil
-        }
-    }
+	// Fetch current
+	p, ok, err := s.GetPool(ctx, id)
+	if err != nil || !ok {
+		return domain.Pool{}, ok, err
+	}
+	if update.Name != nil {
+		p.Name = *update.Name
+	}
+	// AccountID is always set (can be nil to clear)
+	p.AccountID = update.AccountID
+	if update.Type != nil {
+		p.Type = *update.Type
+	}
+	if update.Status != nil {
+		p.Status = *update.Status
+	}
+	if update.Description != nil {
+		p.Description = *update.Description
+	}
+	if update.Tags != nil {
+		if *update.Tags != nil {
+			p.Tags = make(map[string]string, len(*update.Tags))
+			for k, v := range *update.Tags {
+				p.Tags[k] = v
+			}
+		} else {
+			p.Tags = nil
+		}
+	}
 
-    // Serialize tags to JSON
-    var tagsJSON string
-    if p.Tags != nil {
-        if b, e := json.Marshal(p.Tags); e == nil {
-            tagsJSON = string(b)
-        }
-    } else {
-        tagsJSON = "{}"
-    }
+	// Serialize tags to JSON
+	var tagsJSON string
+	if p.Tags != nil {
+		if b, e := json.Marshal(p.Tags); e == nil {
+			tagsJSON = string(b)
+		}
+	} else {
+		tagsJSON = "{}"
+	}
 
-    now := time.Now().UTC().Format(time.RFC3339)
-    if _, err := s.db.ExecContext(ctx, `UPDATE pools SET name=?, account_id=?, type=?, status=?, description=?, tags=?, updated_at=? WHERE id=?`,
-        p.Name, p.AccountID, string(p.Type), string(p.Status), p.Description, tagsJSON, now, id); err != nil {
-        return domain.Pool{}, false, err
-    }
-    return s.GetPool(ctx, id)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.ExecContext(ctx, `UPDATE pools SET name=?, account_id=?, type=?, status=?, description=?, tags=?, updated_at=? WHERE id=?`,
+		p.Name, p.AccountID, string(p.Type), string(p.Status), p.Description, tagsJSON, now, id); err != nil {
+		return domain.Pool{}, false, err
+	}
+	return s.GetPool(ctx, id)
 }
 
 func (s *Store) DeletePool(ctx context.Context, id int64) (bool, error) {
-    // check children (only non-deleted)
-    var cnt int
-    if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM pools WHERE parent_id=? AND deleted_at IS NULL`, id).Scan(&cnt); err != nil {
-        return false, err
-    }
-    if cnt > 0 { return false, fmt.Errorf("pool has child pools: %w", storage.ErrConflict) }
-    now := time.Now().UTC().Format(time.RFC3339)
-    res, err := s.db.ExecContext(ctx, `UPDATE pools SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, id)
-    if err != nil { return false, err }
-    n, _ := res.RowsAffected()
-    return n > 0, nil
+	// check children (only non-deleted)
+	var cnt int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM pools WHERE parent_id=? AND deleted_at IS NULL`, id).Scan(&cnt); err != nil {
+		return false, err
+	}
+	if cnt > 0 {
+		return false, fmt.Errorf("pool has child pools: %w", storage.ErrConflict)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx, `UPDATE pools SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, id)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 func (s *Store) DeletePoolCascade(ctx context.Context, id int64) (bool, error) {
-    // Load all non-deleted pools, compute subtree, soft-delete
-    ps, err := s.ListPools(ctx)
-    if err != nil { return false, err }
-    exists := false
-    children := map[int64][]int64{}
-    for _, p := range ps {
-        if p.ID == id { exists = true }
-        if p.ParentID != nil {
-            children[*p.ParentID] = append(children[*p.ParentID], p.ID)
-        }
-    }
-    if !exists { return false, nil }
-    // BFS
-    queue := []int64{id}
-    order := []int64{}
-    for len(queue) > 0 {
-        cur := queue[0]; queue = queue[1:]
-        order = append(order, cur)
-        for _, ch := range children[cur] { queue = append(queue, ch) }
-    }
-    now := time.Now().UTC().Format(time.RFC3339)
-    for _, pid := range order {
-        _, err := s.db.ExecContext(ctx, `UPDATE pools SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, pid)
-        if err != nil { return false, err }
-    }
-    return true, nil
+	// Load all non-deleted pools, compute subtree, soft-delete
+	ps, err := s.ListPools(ctx)
+	if err != nil {
+		return false, err
+	}
+	exists := false
+	children := map[int64][]int64{}
+	for _, p := range ps {
+		if p.ID == id {
+			exists = true
+		}
+		if p.ParentID != nil {
+			children[*p.ParentID] = append(children[*p.ParentID], p.ID)
+		}
+	}
+	if !exists {
+		return false, nil
+	}
+	// BFS
+	queue := []int64{id}
+	order := []int64{}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		order = append(order, cur)
+		for _, ch := range children[cur] {
+			queue = append(queue, ch)
+		}
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, pid := range order {
+		_, err := s.db.ExecContext(ctx, `UPDATE pools SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, pid)
+		if err != nil {
+			return false, err
+		}
+	}
+	return true, nil
 }
 
 // Accounts
 func (s *Store) ListAccounts(ctx context.Context) ([]domain.Account, error) {
-    rows, err := s.db.QueryContext(ctx, `SELECT id, key, name, provider, external_id, description, platform, tier, environment, regions, created_at, updated_at FROM accounts WHERE deleted_at IS NULL ORDER BY id ASC`)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
-    var out []domain.Account
-    for rows.Next() {
-        var a domain.Account
-        var ts string
-        var provider, extid, desc, platform, tier, env sql.NullString
-        var regions, updatedAt sql.NullString
-        if err := rows.Scan(&a.ID, &a.Key, &a.Name, &provider, &extid, &desc, &platform, &tier, &env, &regions, &ts, &updatedAt); err != nil {
-            return nil, err
-        }
-        if provider.Valid { a.Provider = provider.String }
-        if extid.Valid { a.ExternalID = extid.String }
-        if desc.Valid { a.Description = desc.String }
-        if platform.Valid { a.Platform = platform.String }
-        if tier.Valid { a.Tier = tier.String }
-        if env.Valid { a.Environment = env.String }
-        if regions.Valid && regions.String != "" {
-            var arr []string
-            if err := json.Unmarshal([]byte(regions.String), &arr); err == nil { a.Regions = arr }
-        }
-        if t, e := time.Parse(time.RFC3339, ts); e == nil {
-            a.CreatedAt = t
-        }
-        if updatedAt.Valid {
-            if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil { a.UpdatedAt = t }
-        }
-        out = append(out, a)
-    }
-    return out, rows.Err()
+	rows, err := s.db.QueryContext(ctx, `SELECT id, key, name, provider, external_id, description, platform, tier, environment, regions, created_at, updated_at FROM accounts WHERE deleted_at IS NULL ORDER BY id ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []domain.Account
+	for rows.Next() {
+		var a domain.Account
+		var ts string
+		var provider, extid, desc, platform, tier, env sql.NullString
+		var regions, updatedAt sql.NullString
+		if err := rows.Scan(&a.ID, &a.Key, &a.Name, &provider, &extid, &desc, &platform, &tier, &env, &regions, &ts, &updatedAt); err != nil {
+			return nil, err
+		}
+		if provider.Valid {
+			a.Provider = provider.String
+		}
+		if extid.Valid {
+			a.ExternalID = extid.String
+		}
+		if desc.Valid {
+			a.Description = desc.String
+		}
+		if platform.Valid {
+			a.Platform = platform.String
+		}
+		if tier.Valid {
+			a.Tier = tier.String
+		}
+		if env.Valid {
+			a.Environment = env.String
+		}
+		if regions.Valid && regions.String != "" {
+			var arr []string
+			if err := json.Unmarshal([]byte(regions.String), &arr); err == nil {
+				a.Regions = arr
+			}
+		}
+		if t, e := time.Parse(time.RFC3339, ts); e == nil {
+			a.CreatedAt = t
+		}
+		if updatedAt.Valid {
+			if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil {
+				a.UpdatedAt = t
+			}
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) CreateAccount(ctx context.Context, in domain.CreateAccount) (domain.Account, error) {
-    if in.Key == "" || in.Name == "" {
-        return domain.Account{}, fmt.Errorf("key and name required: %w", storage.ErrValidation)
-    }
-    var regions string
-    if len(in.Regions) > 0 { if b, e := json.Marshal(in.Regions); e == nil { regions = string(b) } }
-    res, err := s.db.ExecContext(ctx, `INSERT INTO accounts(key, name, provider, external_id, description, platform, tier, environment, regions, created_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, in.Key, in.Name, in.Provider, in.ExternalID, in.Description, in.Platform, in.Tier, in.Environment, regions, time.Now().UTC().Format(time.RFC3339))
-    if err != nil {
-        return domain.Account{}, storage.WrapIfConflict(err)
-    }
-    id, err := res.LastInsertId()
-    if err != nil {
-        return domain.Account{}, err
-    }
-    return domain.Account{ID: id, Key: in.Key, Name: in.Name, Provider: in.Provider, ExternalID: in.ExternalID, Description: in.Description, Platform: in.Platform, Tier: in.Tier, Environment: in.Environment, Regions: append([]string(nil), in.Regions...), CreatedAt: time.Now().UTC()}, nil
+	if in.Key == "" || in.Name == "" {
+		return domain.Account{}, fmt.Errorf("key and name required: %w", storage.ErrValidation)
+	}
+	var regions string
+	if len(in.Regions) > 0 {
+		if b, e := json.Marshal(in.Regions); e == nil {
+			regions = string(b)
+		}
+	}
+	res, err := s.db.ExecContext(ctx, `INSERT INTO accounts(key, name, provider, external_id, description, platform, tier, environment, regions, created_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, in.Key, in.Name, in.Provider, in.ExternalID, in.Description, in.Platform, in.Tier, in.Environment, regions, time.Now().UTC().Format(time.RFC3339))
+	if err != nil {
+		return domain.Account{}, storage.WrapIfConflict(err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return domain.Account{}, err
+	}
+	return domain.Account{ID: id, Key: in.Key, Name: in.Name, Provider: in.Provider, ExternalID: in.ExternalID, Description: in.Description, Platform: in.Platform, Tier: in.Tier, Environment: in.Environment, Regions: append([]string(nil), in.Regions...), CreatedAt: time.Now().UTC()}, nil
 }
 
 func (s *Store) GetAccount(ctx context.Context, id int64) (domain.Account, bool, error) {
-    row := s.db.QueryRowContext(ctx, `SELECT id, key, name, provider, external_id, description, platform, tier, environment, regions, created_at, updated_at FROM accounts WHERE id=? AND deleted_at IS NULL`, id)
-    var a domain.Account
-    var ts string
-    var provider, extid, desc, platform, tier, env sql.NullString
-    var regions, updatedAt sql.NullString
-    if err := row.Scan(&a.ID, &a.Key, &a.Name, &provider, &extid, &desc, &platform, &tier, &env, &regions, &ts, &updatedAt); err != nil {
-        if errors.Is(err, sql.ErrNoRows) { return domain.Account{}, false, nil }
-        return domain.Account{}, false, err
-    }
-    if provider.Valid { a.Provider = provider.String }
-    if extid.Valid { a.ExternalID = extid.String }
-    if desc.Valid { a.Description = desc.String }
-    if platform.Valid { a.Platform = platform.String }
-    if tier.Valid { a.Tier = tier.String }
-    if env.Valid { a.Environment = env.String }
-    if regions.Valid && regions.String != "" {
-        var arr []string
-        if err := json.Unmarshal([]byte(regions.String), &arr); err == nil { a.Regions = arr }
-    }
-    if t, e := time.Parse(time.RFC3339, ts); e == nil { a.CreatedAt = t }
-    if updatedAt.Valid {
-        if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil { a.UpdatedAt = t }
-    }
-    return a, true, nil
+	row := s.db.QueryRowContext(ctx, `SELECT id, key, name, provider, external_id, description, platform, tier, environment, regions, created_at, updated_at FROM accounts WHERE id=? AND deleted_at IS NULL`, id)
+	var a domain.Account
+	var ts string
+	var provider, extid, desc, platform, tier, env sql.NullString
+	var regions, updatedAt sql.NullString
+	if err := row.Scan(&a.ID, &a.Key, &a.Name, &provider, &extid, &desc, &platform, &tier, &env, &regions, &ts, &updatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.Account{}, false, nil
+		}
+		return domain.Account{}, false, err
+	}
+	if provider.Valid {
+		a.Provider = provider.String
+	}
+	if extid.Valid {
+		a.ExternalID = extid.String
+	}
+	if desc.Valid {
+		a.Description = desc.String
+	}
+	if platform.Valid {
+		a.Platform = platform.String
+	}
+	if tier.Valid {
+		a.Tier = tier.String
+	}
+	if env.Valid {
+		a.Environment = env.String
+	}
+	if regions.Valid && regions.String != "" {
+		var arr []string
+		if err := json.Unmarshal([]byte(regions.String), &arr); err == nil {
+			a.Regions = arr
+		}
+	}
+	if t, e := time.Parse(time.RFC3339, ts); e == nil {
+		a.CreatedAt = t
+	}
+	if updatedAt.Valid {
+		if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil {
+			a.UpdatedAt = t
+		}
+	}
+	return a, true, nil
 }
 
 func (s *Store) GetAccountByKey(ctx context.Context, key string) (*domain.Account, error) {
@@ -494,568 +555,647 @@ func (s *Store) GetAccountByKey(ctx context.Context, key string) (*domain.Accoun
 		}
 		return nil, err
 	}
-	if provider.Valid { a.Provider = provider.String }
-	if extid.Valid { a.ExternalID = extid.String }
-	if desc.Valid { a.Description = desc.String }
-	if platform.Valid { a.Platform = platform.String }
-	if tier.Valid { a.Tier = tier.String }
-	if env.Valid { a.Environment = env.String }
+	if provider.Valid {
+		a.Provider = provider.String
+	}
+	if extid.Valid {
+		a.ExternalID = extid.String
+	}
+	if desc.Valid {
+		a.Description = desc.String
+	}
+	if platform.Valid {
+		a.Platform = platform.String
+	}
+	if tier.Valid {
+		a.Tier = tier.String
+	}
+	if env.Valid {
+		a.Environment = env.String
+	}
 	if regions.Valid && regions.String != "" {
 		var arr []string
-		if err := json.Unmarshal([]byte(regions.String), &arr); err == nil { a.Regions = arr }
+		if err := json.Unmarshal([]byte(regions.String), &arr); err == nil {
+			a.Regions = arr
+		}
 	}
-	if t, e := time.Parse(time.RFC3339, ts); e == nil { a.CreatedAt = t }
+	if t, e := time.Parse(time.RFC3339, ts); e == nil {
+		a.CreatedAt = t
+	}
 	if updatedAt.Valid {
-		if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil { a.UpdatedAt = t }
+		if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil {
+			a.UpdatedAt = t
+		}
 	}
 	return &a, nil
 }
 
 func (s *Store) UpdateAccount(ctx context.Context, id int64, update domain.Account) (domain.Account, bool, error) {
-    // Fetch current (non-deleted)
-    rows, err := s.db.QueryContext(ctx, `SELECT id, key, name, provider, external_id, description, platform, tier, environment, regions, created_at, updated_at FROM accounts WHERE id=? AND deleted_at IS NULL`, id)
-    if err != nil { return domain.Account{}, false, err }
-    defer rows.Close()
-    if !rows.Next() { return domain.Account{}, false, nil }
-    var a domain.Account
-    var ts string
-    var provider, extid, desc, platform, tier, env sql.NullString
-    var regions, updatedAt sql.NullString
-    if err := rows.Scan(&a.ID, &a.Key, &a.Name, &provider, &extid, &desc, &platform, &tier, &env, &regions, &ts, &updatedAt); err != nil { return domain.Account{}, false, err }
-    if provider.Valid { a.Provider = provider.String }
-    if extid.Valid { a.ExternalID = extid.String }
-    if desc.Valid { a.Description = desc.String }
-    if platform.Valid { a.Platform = platform.String }
-    if tier.Valid { a.Tier = tier.String }
-    if env.Valid { a.Environment = env.String }
-    if regions.Valid && regions.String != "" { var arr []string; _ = json.Unmarshal([]byte(regions.String), &arr); a.Regions = arr }
-    // Apply update
-    if update.Name != "" { a.Name = update.Name }
-    a.Provider = update.Provider
-    a.ExternalID = update.ExternalID
-    a.Description = update.Description
-    a.Platform = update.Platform
-    a.Tier = update.Tier
-    a.Environment = update.Environment
-    if update.Regions != nil { a.Regions = append([]string(nil), update.Regions...) }
-    // persist
-    now := time.Now().UTC()
-    a.UpdatedAt = now
-    var regionsOut *string
-    if a.Regions != nil { if b, e := json.Marshal(a.Regions); e == nil { s := string(b); regionsOut = &s } }
-    if _, err := s.db.ExecContext(ctx, `UPDATE accounts SET name=?, provider=?, external_id=?, description=?, platform=?, tier=?, environment=?, regions=?, updated_at=? WHERE id=?`, a.Name, a.Provider, a.ExternalID, a.Description, a.Platform, a.Tier, a.Environment, regionsOut, now.Format(time.RFC3339), id); err != nil {
-        return domain.Account{}, false, err
-    }
-    return a, true, nil
+	// Fetch current (non-deleted)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, key, name, provider, external_id, description, platform, tier, environment, regions, created_at, updated_at FROM accounts WHERE id=? AND deleted_at IS NULL`, id)
+	if err != nil {
+		return domain.Account{}, false, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return domain.Account{}, false, nil
+	}
+	var a domain.Account
+	var ts string
+	var provider, extid, desc, platform, tier, env sql.NullString
+	var regions, updatedAt sql.NullString
+	if err := rows.Scan(&a.ID, &a.Key, &a.Name, &provider, &extid, &desc, &platform, &tier, &env, &regions, &ts, &updatedAt); err != nil {
+		return domain.Account{}, false, err
+	}
+	if provider.Valid {
+		a.Provider = provider.String
+	}
+	if extid.Valid {
+		a.ExternalID = extid.String
+	}
+	if desc.Valid {
+		a.Description = desc.String
+	}
+	if platform.Valid {
+		a.Platform = platform.String
+	}
+	if tier.Valid {
+		a.Tier = tier.String
+	}
+	if env.Valid {
+		a.Environment = env.String
+	}
+	if regions.Valid && regions.String != "" {
+		var arr []string
+		_ = json.Unmarshal([]byte(regions.String), &arr)
+		a.Regions = arr
+	}
+	// Apply update
+	if update.Name != "" {
+		a.Name = update.Name
+	}
+	a.Provider = update.Provider
+	a.ExternalID = update.ExternalID
+	a.Description = update.Description
+	a.Platform = update.Platform
+	a.Tier = update.Tier
+	a.Environment = update.Environment
+	if update.Regions != nil {
+		a.Regions = append([]string(nil), update.Regions...)
+	}
+	// persist
+	now := time.Now().UTC()
+	a.UpdatedAt = now
+	var regionsOut *string
+	if a.Regions != nil {
+		if b, e := json.Marshal(a.Regions); e == nil {
+			s := string(b)
+			regionsOut = &s
+		}
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE accounts SET name=?, provider=?, external_id=?, description=?, platform=?, tier=?, environment=?, regions=?, updated_at=? WHERE id=?`, a.Name, a.Provider, a.ExternalID, a.Description, a.Platform, a.Tier, a.Environment, regionsOut, now.Format(time.RFC3339), id); err != nil {
+		return domain.Account{}, false, err
+	}
+	return a, true, nil
 }
 
 func (s *Store) DeleteAccount(ctx context.Context, id int64) (bool, error) {
-    var cnt int
-    if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM pools WHERE account_id=? AND deleted_at IS NULL`, id).Scan(&cnt); err != nil { return false, err }
-    if cnt > 0 { return false, fmt.Errorf("account in use by pools: %w", storage.ErrConflict) }
-    now := time.Now().UTC().Format(time.RFC3339)
-    res, err := s.db.ExecContext(ctx, `UPDATE accounts SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, id)
-    if err != nil { return false, err }
-    n, _ := res.RowsAffected()
-    return n > 0, nil
+	var cnt int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM pools WHERE account_id=? AND deleted_at IS NULL`, id).Scan(&cnt); err != nil {
+		return false, err
+	}
+	if cnt > 0 {
+		return false, fmt.Errorf("account in use by pools: %w", storage.ErrConflict)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx, `UPDATE accounts SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, id)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 func (s *Store) DeleteAccountCascade(ctx context.Context, id int64) (bool, error) {
-    // Soft-delete all pools referencing this account, including their descendants, then soft-delete account
-    ps, err := s.ListPools(ctx)
-    if err != nil { return false, err }
-    // Check account exists (non-deleted)
-    var accCnt int
-    if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM accounts WHERE id=? AND deleted_at IS NULL`, id).Scan(&accCnt); err != nil { return false, err }
-    if accCnt == 0 { return false, nil }
-    // Build adjacency
-    children := map[int64][]int64{}
-    for _, p := range ps {
-        if p.ParentID != nil { children[*p.ParentID] = append(children[*p.ParentID], p.ID) }
-    }
-    // Collect roots: pools with account_id = id
-    roots := []int64{}
-    for _, p := range ps { if p.AccountID != nil && *p.AccountID == id { roots = append(roots, p.ID) } }
-    // Collect all to soft-delete
-    toDel := map[int64]struct{}{}
-    var dfs func(int64)
-    dfs = func(n int64){
-        if _, ok := toDel[n]; ok { return }
-        toDel[n] = struct{}{}
-        for _, ch := range children[n] { dfs(ch) }
-    }
-    for _, r := range roots { dfs(r) }
-    // Soft-delete pools
-    now := time.Now().UTC().Format(time.RFC3339)
-    for pid := range toDel { if _, err := s.db.ExecContext(ctx, `UPDATE pools SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, pid); err != nil { return false, err } }
-    // Soft-delete account
-    if _, err := s.db.ExecContext(ctx, `UPDATE accounts SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, id); err != nil { return false, err }
-    return true, nil
+	// Soft-delete all pools referencing this account, including their descendants, then soft-delete account
+	ps, err := s.ListPools(ctx)
+	if err != nil {
+		return false, err
+	}
+	// Check account exists (non-deleted)
+	var accCnt int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM accounts WHERE id=? AND deleted_at IS NULL`, id).Scan(&accCnt); err != nil {
+		return false, err
+	}
+	if accCnt == 0 {
+		return false, nil
+	}
+	// Build adjacency
+	children := map[int64][]int64{}
+	for _, p := range ps {
+		if p.ParentID != nil {
+			children[*p.ParentID] = append(children[*p.ParentID], p.ID)
+		}
+	}
+	// Collect roots: pools with account_id = id
+	roots := []int64{}
+	for _, p := range ps {
+		if p.AccountID != nil && *p.AccountID == id {
+			roots = append(roots, p.ID)
+		}
+	}
+	// Collect all to soft-delete
+	toDel := map[int64]struct{}{}
+	var dfs func(int64)
+	dfs = func(n int64) {
+		if _, ok := toDel[n]; ok {
+			return
+		}
+		toDel[n] = struct{}{}
+		for _, ch := range children[n] {
+			dfs(ch)
+		}
+	}
+	for _, r := range roots {
+		dfs(r)
+	}
+	// Soft-delete pools
+	now := time.Now().UTC().Format(time.RFC3339)
+	for pid := range toDel {
+		if _, err := s.db.ExecContext(ctx, `UPDATE pools SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, pid); err != nil {
+			return false, err
+		}
+	}
+	// Soft-delete account
+	if _, err := s.db.ExecContext(ctx, `UPDATE accounts SET deleted_at=?, updated_at=? WHERE id=? AND deleted_at IS NULL`, now, now, id); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // GetPoolWithStats returns a pool with its computed statistics.
 func (s *Store) GetPoolWithStats(ctx context.Context, id int64) (*domain.PoolWithStats, error) {
-    p, ok, err := s.GetPool(ctx, id)
-    if err != nil {
-        return nil, err
-    }
-    if !ok {
-        return nil, fmt.Errorf("pool not found: %w", storage.ErrNotFound)
-    }
-    stats, err := s.calculatePoolStats(ctx, p)
-    if err != nil {
-        return nil, err
-    }
-    return &domain.PoolWithStats{
-        Pool:  p,
-        Stats: *stats,
-    }, nil
+	p, ok, err := s.GetPool(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("pool not found: %w", storage.ErrNotFound)
+	}
+	stats, err := s.calculatePoolStats(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	return &domain.PoolWithStats{
+		Pool:  p,
+		Stats: *stats,
+	}, nil
 }
 
 // GetPoolHierarchy returns the pool hierarchy tree starting from rootID.
 // If rootID is nil, returns all top-level pools with their children.
 func (s *Store) GetPoolHierarchy(ctx context.Context, rootID *int64) ([]domain.PoolWithStats, error) {
-    // Load all pools
-    pools, err := s.ListPools(ctx)
-    if err != nil {
-        return nil, err
-    }
+	// Load all pools
+	pools, err := s.ListPools(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-    // Build maps for quick lookup
-    poolMap := make(map[int64]domain.Pool)
-    childrenMap := make(map[int64][]int64)
-    for _, p := range pools {
-        poolMap[p.ID] = p
-        if p.ParentID != nil {
-            childrenMap[*p.ParentID] = append(childrenMap[*p.ParentID], p.ID)
-        }
-    }
+	// Build maps for quick lookup
+	poolMap := make(map[int64]domain.Pool)
+	childrenMap := make(map[int64][]int64)
+	for _, p := range pools {
+		poolMap[p.ID] = p
+		if p.ParentID != nil {
+			childrenMap[*p.ParentID] = append(childrenMap[*p.ParentID], p.ID)
+		}
+	}
 
-    // Recursive function to build tree
-    var buildTree func(pid int64) (domain.PoolWithStats, error)
-    buildTree = func(pid int64) (domain.PoolWithStats, error) {
-        p := poolMap[pid]
-        stats, err := s.calculatePoolStats(ctx, p)
-        if err != nil {
-            return domain.PoolWithStats{}, err
-        }
-        result := domain.PoolWithStats{
-            Pool:  p,
-            Stats: *stats,
-        }
-        for _, childID := range childrenMap[pid] {
-            child, err := buildTree(childID)
-            if err != nil {
-                return domain.PoolWithStats{}, err
-            }
-            result.Children = append(result.Children, child)
-        }
-        return result, nil
-    }
+	// Recursive function to build tree
+	var buildTree func(pid int64) (domain.PoolWithStats, error)
+	buildTree = func(pid int64) (domain.PoolWithStats, error) {
+		p := poolMap[pid]
+		stats, err := s.calculatePoolStats(ctx, p)
+		if err != nil {
+			return domain.PoolWithStats{}, err
+		}
+		result := domain.PoolWithStats{
+			Pool:  p,
+			Stats: *stats,
+		}
+		for _, childID := range childrenMap[pid] {
+			child, err := buildTree(childID)
+			if err != nil {
+				return domain.PoolWithStats{}, err
+			}
+			result.Children = append(result.Children, child)
+		}
+		return result, nil
+	}
 
-    var result []domain.PoolWithStats
+	var result []domain.PoolWithStats
 
-    if rootID != nil {
-        // Return subtree from specific root
-        if _, ok := poolMap[*rootID]; !ok {
-            return nil, fmt.Errorf("root pool not found: %w", storage.ErrNotFound)
-        }
-        tree, err := buildTree(*rootID)
-        if err != nil {
-            return nil, err
-        }
-        result = append(result, tree)
-    } else {
-        // Return all top-level pools (no parent)
-        for _, p := range pools {
-            if p.ParentID == nil {
-                tree, err := buildTree(p.ID)
-                if err != nil {
-                    return nil, err
-                }
-                result = append(result, tree)
-            }
-        }
-    }
+	if rootID != nil {
+		// Return subtree from specific root
+		if _, ok := poolMap[*rootID]; !ok {
+			return nil, fmt.Errorf("root pool not found: %w", storage.ErrNotFound)
+		}
+		tree, err := buildTree(*rootID)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, tree)
+	} else {
+		// Return all top-level pools (no parent)
+		for _, p := range pools {
+			if p.ParentID == nil {
+				tree, err := buildTree(p.ID)
+				if err != nil {
+					return nil, err
+				}
+				result = append(result, tree)
+			}
+		}
+	}
 
-    return result, nil
+	return result, nil
 }
 
 // GetPoolChildren returns the direct children of a pool.
 func (s *Store) GetPoolChildren(ctx context.Context, parentID int64) ([]domain.Pool, error) {
-    // Check parent exists
-    _, ok, err := s.GetPool(ctx, parentID)
-    if err != nil {
-        return nil, err
-    }
-    if !ok {
-        return nil, fmt.Errorf("parent pool not found: %w", storage.ErrNotFound)
-    }
+	// Check parent exists
+	_, ok, err := s.GetPool(ctx, parentID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("parent pool not found: %w", storage.ErrNotFound)
+	}
 
-    rows, err := s.db.QueryContext(ctx, `SELECT id, name, cidr, parent_id, account_id, type, status, source, description, tags, created_at, updated_at FROM pools WHERE parent_id=? AND deleted_at IS NULL ORDER BY id ASC`, parentID)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	rows, err := s.db.QueryContext(ctx, `SELECT id, name, cidr, parent_id, account_id, type, status, source, description, tags, created_at, updated_at FROM pools WHERE parent_id=? AND deleted_at IS NULL ORDER BY id ASC`, parentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var children []domain.Pool
-    for rows.Next() {
-        var p domain.Pool
-        var createdAt, updatedAt sql.NullString
-        var parent, account sql.NullInt64
-        var poolType, poolStatus, poolSource, description, tagsJSON sql.NullString
-        if err := rows.Scan(&p.ID, &p.Name, &p.CIDR, &parent, &account, &poolType, &poolStatus, &poolSource, &description, &tagsJSON, &createdAt, &updatedAt); err != nil {
-            return nil, err
-        }
-        if parent.Valid {
-            p.ParentID = &parent.Int64
-        }
-        if account.Valid {
-            p.AccountID = &account.Int64
-        }
-        p.Type = domain.PoolTypeSubnet
-        if poolType.Valid && poolType.String != "" {
-            p.Type = domain.PoolType(poolType.String)
-        }
-        p.Status = domain.PoolStatusActive
-        if poolStatus.Valid && poolStatus.String != "" {
-            p.Status = domain.PoolStatus(poolStatus.String)
-        }
-        p.Source = domain.PoolSourceManual
-        if poolSource.Valid && poolSource.String != "" {
-            p.Source = domain.PoolSource(poolSource.String)
-        }
-        if description.Valid {
-            p.Description = description.String
-        }
-        if tagsJSON.Valid && tagsJSON.String != "" && tagsJSON.String != "{}" {
-            var tags map[string]string
-            if err := json.Unmarshal([]byte(tagsJSON.String), &tags); err == nil {
-                p.Tags = tags
-            }
-        }
-        if createdAt.Valid {
-            if t, e := time.Parse(time.RFC3339, createdAt.String); e == nil {
-                p.CreatedAt = t
-            }
-        }
-        if updatedAt.Valid {
-            if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil {
-                p.UpdatedAt = t
-            }
-        }
-        children = append(children, p)
-    }
-    return children, rows.Err()
+	var children []domain.Pool
+	for rows.Next() {
+		var p domain.Pool
+		var createdAt, updatedAt sql.NullString
+		var parent, account sql.NullInt64
+		var poolType, poolStatus, poolSource, description, tagsJSON sql.NullString
+		if err := rows.Scan(&p.ID, &p.Name, &p.CIDR, &parent, &account, &poolType, &poolStatus, &poolSource, &description, &tagsJSON, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		if parent.Valid {
+			p.ParentID = &parent.Int64
+		}
+		if account.Valid {
+			p.AccountID = &account.Int64
+		}
+		p.Type = domain.PoolTypeSubnet
+		if poolType.Valid && poolType.String != "" {
+			p.Type = domain.PoolType(poolType.String)
+		}
+		p.Status = domain.PoolStatusActive
+		if poolStatus.Valid && poolStatus.String != "" {
+			p.Status = domain.PoolStatus(poolStatus.String)
+		}
+		p.Source = domain.PoolSourceManual
+		if poolSource.Valid && poolSource.String != "" {
+			p.Source = domain.PoolSource(poolSource.String)
+		}
+		if description.Valid {
+			p.Description = description.String
+		}
+		if tagsJSON.Valid && tagsJSON.String != "" && tagsJSON.String != "{}" {
+			var tags map[string]string
+			if err := json.Unmarshal([]byte(tagsJSON.String), &tags); err == nil {
+				p.Tags = tags
+			}
+		}
+		if createdAt.Valid {
+			if t, e := time.Parse(time.RFC3339, createdAt.String); e == nil {
+				p.CreatedAt = t
+			}
+		}
+		if updatedAt.Valid {
+			if t, e := time.Parse(time.RFC3339, updatedAt.String); e == nil {
+				p.UpdatedAt = t
+			}
+		}
+		children = append(children, p)
+	}
+	return children, rows.Err()
 }
 
 // CalculatePoolUtilization calculates statistics for a pool.
 func (s *Store) CalculatePoolUtilization(ctx context.Context, id int64) (*domain.PoolStats, error) {
-    p, ok, err := s.GetPool(ctx, id)
-    if err != nil {
-        return nil, err
-    }
-    if !ok {
-        return nil, fmt.Errorf("pool not found: %w", storage.ErrNotFound)
-    }
-    return s.calculatePoolStats(ctx, p)
+	p, ok, err := s.GetPool(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("pool not found: %w", storage.ErrNotFound)
+	}
+	return s.calculatePoolStats(ctx, p)
 }
 
 // calculatePoolStats calculates stats for a pool.
 func (s *Store) calculatePoolStats(ctx context.Context, p domain.Pool) (*domain.PoolStats, error) {
-    // Parse the pool's CIDR to get total IPs
-    prefix, err := netip.ParsePrefix(p.CIDR)
-    if err != nil {
-        return &domain.PoolStats{}, nil
-    }
+	// Parse the pool's CIDR to get total IPs
+	prefix, err := netip.ParsePrefix(p.CIDR)
+	if err != nil {
+		return &domain.PoolStats{}, nil
+	}
 
-    var totalIPs int64
-    if prefix.Addr().Is4() {
-        totalIPs = int64(1) << (32 - prefix.Bits())
-    } else {
-        // For IPv6, cap at max int64 for practical purposes
-        bits := 128 - prefix.Bits()
-        if bits >= 63 {
-            totalIPs = 1<<63 - 1 // max int64
-        } else {
-            totalIPs = int64(1) << bits
-        }
-    }
+	var totalIPs int64
+	if prefix.Addr().Is4() {
+		totalIPs = int64(1) << (32 - prefix.Bits())
+	} else {
+		// For IPv6, cap at max int64 for practical purposes
+		bits := 128 - prefix.Bits()
+		if bits >= 63 {
+			totalIPs = 1<<63 - 1 // max int64
+		} else {
+			totalIPs = int64(1) << bits
+		}
+	}
 
-    // Get direct children (non-deleted)
-    rows, err := s.db.QueryContext(ctx, `SELECT cidr FROM pools WHERE parent_id=? AND deleted_at IS NULL`, p.ID)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	// Get direct children (non-deleted)
+	rows, err := s.db.QueryContext(ctx, `SELECT cidr FROM pools WHERE parent_id=? AND deleted_at IS NULL`, p.ID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var directChildren int
-    var usedIPs int64
-    for rows.Next() {
-        var childCIDR string
-        if err := rows.Scan(&childCIDR); err != nil {
-            return nil, err
-        }
-        directChildren++
+	var directChildren int
+	var usedIPs int64
+	for rows.Next() {
+		var childCIDR string
+		if err := rows.Scan(&childCIDR); err != nil {
+			return nil, err
+		}
+		directChildren++
 
-        // Calculate used IPs from child's CIDR
-        childPrefix, err := netip.ParsePrefix(childCIDR)
-        if err != nil {
-            continue
-        }
-        if childPrefix.Addr().Is4() {
-            usedIPs += int64(1) << (32 - childPrefix.Bits())
-        }
-    }
-    if err := rows.Err(); err != nil {
-        return nil, err
-    }
+		// Calculate used IPs from child's CIDR
+		childPrefix, err := netip.ParsePrefix(childCIDR)
+		if err != nil {
+			continue
+		}
+		if childPrefix.Addr().Is4() {
+			usedIPs += int64(1) << (32 - childPrefix.Bits())
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
-    // Count all descendants recursively
-    var totalChildCount int
-    var countDescendants func(parentID int64) (int, error)
-    countDescendants = func(parentID int64) (int, error) {
-        var count int
-        childRows, err := s.db.QueryContext(ctx, `SELECT id FROM pools WHERE parent_id=? AND deleted_at IS NULL`, parentID)
-        if err != nil {
-            return 0, err
-        }
-        defer childRows.Close()
-        for childRows.Next() {
-            var childID int64
-            if err := childRows.Scan(&childID); err != nil {
-                return 0, err
-            }
-            count++
-            subCount, err := countDescendants(childID)
-            if err != nil {
-                return 0, err
-            }
-            count += subCount
-        }
-        return count, childRows.Err()
-    }
+	// Count all descendants recursively
+	var totalChildCount int
+	var countDescendants func(parentID int64) (int, error)
+	countDescendants = func(parentID int64) (int, error) {
+		var count int
+		childRows, err := s.db.QueryContext(ctx, `SELECT id FROM pools WHERE parent_id=? AND deleted_at IS NULL`, parentID)
+		if err != nil {
+			return 0, err
+		}
+		defer childRows.Close()
+		for childRows.Next() {
+			var childID int64
+			if err := childRows.Scan(&childID); err != nil {
+				return 0, err
+			}
+			count++
+			subCount, err := countDescendants(childID)
+			if err != nil {
+				return 0, err
+			}
+			count += subCount
+		}
+		return count, childRows.Err()
+	}
 
-    totalChildCount, err = countDescendants(p.ID)
-    if err != nil {
-        return nil, err
-    }
+	totalChildCount, err = countDescendants(p.ID)
+	if err != nil {
+		return nil, err
+	}
 
-    // Calculate utilization percentage
-    var utilization float64
-    if totalIPs > 0 {
-        utilization = float64(usedIPs) / float64(totalIPs) * 100
-    }
+	// Calculate utilization percentage
+	var utilization float64
+	if totalIPs > 0 {
+		utilization = float64(usedIPs) / float64(totalIPs) * 100
+	}
 
-    return &domain.PoolStats{
-        TotalIPs:       totalIPs,
-        UsedIPs:        usedIPs,
-        AvailableIPs:   totalIPs - usedIPs,
-        Utilization:    utilization,
-        ChildCount:     totalChildCount,
-        DirectChildren: directChildren,
-    }, nil
+	return &domain.PoolStats{
+		TotalIPs:       totalIPs,
+		UsedIPs:        usedIPs,
+		AvailableIPs:   totalIPs - usedIPs,
+		Utilization:    utilization,
+		ChildCount:     totalChildCount,
+		DirectChildren: directChildren,
+	}, nil
 }
 
 // Search performs a paginated search across pools and accounts.
 // SQLite has no native CIDR type, so containment is done in Go after loading.
 func (s *Store) Search(ctx context.Context, req domain.SearchRequest) (domain.SearchResponse, error) {
-    // Parse CIDR filters once
-    var cidrContains, cidrWithin netip.Prefix
-    var hasCIDRContains, hasCIDRWithin bool
-    if req.CIDRContains != "" {
-        p, err := cidr.ParseCIDROrIP(req.CIDRContains)
-        if err != nil {
-            return domain.SearchResponse{}, fmt.Errorf("invalid cidr_contains: %w", err)
-        }
-        cidrContains = p
-        hasCIDRContains = true
-    }
-    if req.CIDRWithin != "" {
-        p, err := cidr.ParseCIDROrIP(req.CIDRWithin)
-        if err != nil {
-            return domain.SearchResponse{}, fmt.Errorf("invalid cidr_within: %w", err)
-        }
-        cidrWithin = p
-        hasCIDRWithin = true
-    }
+	// Parse CIDR filters once
+	var cidrContains, cidrWithin netip.Prefix
+	var hasCIDRContains, hasCIDRWithin bool
+	if req.CIDRContains != "" {
+		p, err := cidr.ParseCIDROrIP(req.CIDRContains)
+		if err != nil {
+			return domain.SearchResponse{}, fmt.Errorf("invalid cidr_contains: %w", err)
+		}
+		cidrContains = p
+		hasCIDRContains = true
+	}
+	if req.CIDRWithin != "" {
+		p, err := cidr.ParseCIDROrIP(req.CIDRWithin)
+		if err != nil {
+			return domain.SearchResponse{}, fmt.Errorf("invalid cidr_within: %w", err)
+		}
+		cidrWithin = p
+		hasCIDRWithin = true
+	}
 
-    // Determine which types to include
-    searchPools := true
-    searchAccounts := true
-    if len(req.Types) > 0 {
-        searchPools = false
-        searchAccounts = false
-        for _, t := range req.Types {
-            switch t {
-            case "pool":
-                searchPools = true
-            case "account":
-                searchAccounts = true
-            }
-        }
-    }
+	// Determine which types to include
+	searchPools := true
+	searchAccounts := true
+	if len(req.Types) > 0 {
+		searchPools = false
+		searchAccounts = false
+		for _, t := range req.Types {
+			switch t {
+			case "pool":
+				searchPools = true
+			case "account":
+				searchAccounts = true
+			}
+		}
+	}
 
-    query := strings.ToLower(req.Query)
-    var items []domain.SearchResultItem
+	query := strings.ToLower(req.Query)
+	var items []domain.SearchResultItem
 
-    // Search pools — use SQL LIKE for text search, then filter CIDR in Go
-    if searchPools {
-        var poolRows *sql.Rows
-        var err error
-        if query != "" {
-            like := "%" + query + "%"
-            poolRows, err = s.db.QueryContext(ctx,
-                `SELECT id, name, cidr, parent_id, account_id, type, status, source, description FROM pools WHERE deleted_at IS NULL AND (name LIKE ? OR cidr LIKE ? OR description LIKE ?) ORDER BY id`,
-                like, like, like)
-        } else {
-            poolRows, err = s.db.QueryContext(ctx,
-                `SELECT id, name, cidr, parent_id, account_id, type, status, source, description FROM pools WHERE deleted_at IS NULL ORDER BY id`)
-        }
-        if err != nil {
-            return domain.SearchResponse{}, err
-        }
-        defer poolRows.Close()
+	// Search pools — use SQL LIKE for text search, then filter CIDR in Go
+	if searchPools {
+		var poolRows *sql.Rows
+		var err error
+		if query != "" {
+			like := "%" + query + "%"
+			poolRows, err = s.db.QueryContext(ctx,
+				`SELECT id, name, cidr, parent_id, account_id, type, status, source, description FROM pools WHERE deleted_at IS NULL AND (name LIKE ? OR cidr LIKE ? OR description LIKE ?) ORDER BY id`,
+				like, like, like)
+		} else {
+			poolRows, err = s.db.QueryContext(ctx,
+				`SELECT id, name, cidr, parent_id, account_id, type, status, source, description FROM pools WHERE deleted_at IS NULL ORDER BY id`)
+		}
+		if err != nil {
+			return domain.SearchResponse{}, err
+		}
+		defer poolRows.Close()
 
-        for poolRows.Next() {
-            var id int64
-            var name, cidrStr string
-            var parent, account sql.NullInt64
-            var poolType, poolStatus, poolSource, description sql.NullString
-            if err := poolRows.Scan(&id, &name, &cidrStr, &parent, &account, &poolType, &poolStatus, &poolSource, &description); err != nil {
-                return domain.SearchResponse{}, err
-            }
+		for poolRows.Next() {
+			var id int64
+			var name, cidrStr string
+			var parent, account sql.NullInt64
+			var poolType, poolStatus, poolSource, description sql.NullString
+			if err := poolRows.Scan(&id, &name, &cidrStr, &parent, &account, &poolType, &poolStatus, &poolSource, &description); err != nil {
+				return domain.SearchResponse{}, err
+			}
 
-            // Apply CIDR filters in Go
-            if hasCIDRContains || hasCIDRWithin {
-                poolPrefix, err := netip.ParsePrefix(cidrStr)
-                if err != nil {
-                    continue
-                }
-                if hasCIDRContains && !cidr.PrefixContains(poolPrefix, cidrContains) {
-                    continue
-                }
-                if hasCIDRWithin && !cidr.PrefixContains(cidrWithin, poolPrefix) {
-                    continue
-                }
-            }
+			// Apply CIDR filters in Go
+			if hasCIDRContains || hasCIDRWithin {
+				poolPrefix, err := netip.ParsePrefix(cidrStr)
+				if err != nil {
+					continue
+				}
+				if hasCIDRContains && !cidr.PrefixContains(poolPrefix, cidrContains) {
+					continue
+				}
+				if hasCIDRWithin && !cidr.PrefixContains(cidrWithin, poolPrefix) {
+					continue
+				}
+			}
 
-            item := domain.SearchResultItem{
-                Type: "pool",
-                ID:   id,
-                Name: name,
-                CIDR: cidrStr,
-            }
-            if parent.Valid {
-                v := parent.Int64
-                item.ParentID = &v
-            }
-            if account.Valid {
-                v := account.Int64
-                item.AccountID = &v
-            }
-            if poolType.Valid {
-                item.PoolType = poolType.String
-            }
-            if poolStatus.Valid {
-                item.Status = poolStatus.String
-            }
-            if description.Valid {
-                item.Description = description.String
-            }
-            items = append(items, item)
-        }
-        if err := poolRows.Err(); err != nil {
-            return domain.SearchResponse{}, err
-        }
-    }
+			item := domain.SearchResultItem{
+				Type: "pool",
+				ID:   id,
+				Name: name,
+				CIDR: cidrStr,
+			}
+			if parent.Valid {
+				v := parent.Int64
+				item.ParentID = &v
+			}
+			if account.Valid {
+				v := account.Int64
+				item.AccountID = &v
+			}
+			if poolType.Valid {
+				item.PoolType = poolType.String
+			}
+			if poolStatus.Valid {
+				item.Status = poolStatus.String
+			}
+			if description.Valid {
+				item.Description = description.String
+			}
+			items = append(items, item)
+		}
+		if err := poolRows.Err(); err != nil {
+			return domain.SearchResponse{}, err
+		}
+	}
 
-    // Search accounts — CIDR filters don't apply to accounts
-    if searchAccounts && !hasCIDRContains && !hasCIDRWithin {
-        var accRows *sql.Rows
-        var err error
-        if query != "" {
-            like := "%" + query + "%"
-            accRows, err = s.db.QueryContext(ctx,
-                `SELECT id, key, name, provider, description FROM accounts WHERE deleted_at IS NULL AND (name LIKE ? OR key LIKE ? OR description LIKE ?) ORDER BY id`,
-                like, like, like)
-        } else {
-            accRows, err = s.db.QueryContext(ctx,
-                `SELECT id, key, name, provider, description FROM accounts WHERE deleted_at IS NULL ORDER BY id`)
-        }
-        if err != nil {
-            return domain.SearchResponse{}, err
-        }
-        defer accRows.Close()
+	// Search accounts — CIDR filters don't apply to accounts
+	if searchAccounts && !hasCIDRContains && !hasCIDRWithin {
+		var accRows *sql.Rows
+		var err error
+		if query != "" {
+			like := "%" + query + "%"
+			accRows, err = s.db.QueryContext(ctx,
+				`SELECT id, key, name, provider, description FROM accounts WHERE deleted_at IS NULL AND (name LIKE ? OR key LIKE ? OR description LIKE ?) ORDER BY id`,
+				like, like, like)
+		} else {
+			accRows, err = s.db.QueryContext(ctx,
+				`SELECT id, key, name, provider, description FROM accounts WHERE deleted_at IS NULL ORDER BY id`)
+		}
+		if err != nil {
+			return domain.SearchResponse{}, err
+		}
+		defer accRows.Close()
 
-        for accRows.Next() {
-            var id int64
-            var key, name string
-            var provider, description sql.NullString
-            if err := accRows.Scan(&id, &key, &name, &provider, &description); err != nil {
-                return domain.SearchResponse{}, err
-            }
-            item := domain.SearchResultItem{
-                Type:       "account",
-                ID:         id,
-                Name:       name,
-                AccountKey: key,
-            }
-            if provider.Valid {
-                item.Provider = provider.String
-            }
-            if description.Valid {
-                item.Description = description.String
-            }
-            items = append(items, item)
-        }
-        if err := accRows.Err(); err != nil {
-            return domain.SearchResponse{}, err
-        }
-    }
+		for accRows.Next() {
+			var id int64
+			var key, name string
+			var provider, description sql.NullString
+			if err := accRows.Scan(&id, &key, &name, &provider, &description); err != nil {
+				return domain.SearchResponse{}, err
+			}
+			item := domain.SearchResultItem{
+				Type:       "account",
+				ID:         id,
+				Name:       name,
+				AccountKey: key,
+			}
+			if provider.Valid {
+				item.Provider = provider.String
+			}
+			if description.Valid {
+				item.Description = description.String
+			}
+			items = append(items, item)
+		}
+		if err := accRows.Err(); err != nil {
+			return domain.SearchResponse{}, err
+		}
+	}
 
-    // Paginate
-    total := len(items)
-    page := req.Page
-    if page < 1 {
-        page = 1
-    }
-    pageSize := req.PageSize
-    if pageSize < 1 {
-        pageSize = 50
-    }
-    if pageSize > 200 {
-        pageSize = 200
-    }
+	// Paginate
+	total := len(items)
+	page := req.Page
+	if page < 1 {
+		page = 1
+	}
+	pageSize := req.PageSize
+	if pageSize < 1 {
+		pageSize = 50
+	}
+	if pageSize > 200 {
+		pageSize = 200
+	}
 
-    start := (page - 1) * pageSize
-    if start > total {
-        start = total
-    }
-    end := start + pageSize
-    if end > total {
-        end = total
-    }
+	start := (page - 1) * pageSize
+	if start > total {
+		start = total
+	}
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
 
-    return domain.SearchResponse{
-        Items:    items[start:end],
-        Total:    total,
-        Page:     page,
-        PageSize: pageSize,
-    }, nil
+	return domain.SearchResponse{
+		Items:    items[start:end],
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+	}, nil
 }
 
 // ipv4ToUint32 converts an IPv4 address to uint32.
 func ipv4ToUint32(a netip.Addr) uint32 {
-    b := a.As4()
-    return binary.BigEndian.Uint32(b[:])
+	b := a.As4()
+	return binary.BigEndian.Uint32(b[:])
 }
 
 // uint32ToIPv4 converts a uint32 to an IPv4 address.
 func uint32ToIPv4(u uint32) netip.Addr {
-    var b [4]byte
-    binary.BigEndian.PutUint32(b[:], u)
-    ip := net.IPv4(b[0], b[1], b[2], b[3])
-    addr, _ := netip.ParseAddr(ip.String())
-    return addr
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], u)
+	ip := net.IPv4(b[0], b[1], b[2], b[3])
+	addr, _ := netip.ParseAddr(ip.String())
+	return addr
 }

--- a/internal/storage/sqlite/sqlite_migrations_test.go
+++ b/internal/storage/sqlite/sqlite_migrations_test.go
@@ -3,48 +3,55 @@
 package sqlite
 
 import (
-    "context"
-    "os"
-    "path/filepath"
-    "testing"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
 
-    "cloudpam/internal/domain"
+	"cloudpam/internal/domain"
 )
 
 func TestMigrationsAndConstraints(t *testing.T) {
-    // Use a temp on-disk DB to exercise PRAGMAs and constraints
-    dir := t.TempDir()
-    dsn := "file:" + filepath.Join(dir, "test.db") + "?_fk=1&cache=shared"
-    s, err := New(dsn)
-    if err != nil { t.Fatalf("new sqlite store: %v", err) }
-    t.Cleanup(func(){ _ = s.db.Close(); _ = os.RemoveAll(dir) })
+	// Use a temp on-disk DB to exercise PRAGMAs and constraints
+	dir := t.TempDir()
+	dsn := "file:" + filepath.Join(dir, "test.db") + "?_fk=1&cache=shared"
+	s, err := New(dsn)
+	if err != nil {
+		t.Fatalf("new sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.db.Close(); _ = os.RemoveAll(dir) })
 
-    ctx := context.Background()
-    // Unique (COALESCE(parent_id,-1), cidr)
-    p1, err := s.CreatePool(ctx, domain.CreatePool{Name: "root1", CIDR: "10.0.0.0/16"})
-    if err != nil { t.Fatalf("create pool: %v", err) }
-    if _, err := s.CreatePool(ctx, domain.CreatePool{Name: "dupRoot", CIDR: p1.CIDR}); err == nil {
-        t.Fatalf("expected unique constraint error for duplicate root cidr")
-    }
+	ctx := context.Background()
+	// Unique (COALESCE(parent_id,-1), cidr)
+	p1, err := s.CreatePool(ctx, domain.CreatePool{Name: "root1", CIDR: "10.0.0.0/16"})
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	if _, err := s.CreatePool(ctx, domain.CreatePool{Name: "dupRoot", CIDR: p1.CIDR}); err == nil {
+		t.Fatalf("expected unique constraint error for duplicate root cidr")
+	}
 
-    // FK: account must exist
-    accID := int64(999999)
-    if _, err := s.CreatePool(ctx, domain.CreatePool{Name: "bad", CIDR: "10.1.0.0/16", AccountID: &accID}); err == nil {
-        t.Fatalf("expected FK error for non-existent account")
-    }
+	// FK: account must exist
+	accID := int64(999999)
+	if _, err := s.CreatePool(ctx, domain.CreatePool{Name: "bad", CIDR: "10.1.0.0/16", AccountID: &accID}); err == nil {
+		t.Fatalf("expected FK error for non-existent account")
+	}
 
-    // Parent/child and delete restriction
-    childCIDR := "10.0.1.0/24"
-    child, err := s.CreatePool(ctx, domain.CreatePool{Name: "child", CIDR: childCIDR, ParentID: &p1.ID})
-    if err != nil { t.Fatalf("create child: %v", err) }
-    if _, err := s.DeletePool(ctx, p1.ID); err == nil {
-        t.Fatalf("expected delete restriction when pool has child, got nil error")
-    }
-    // Cascade helper should delete both
-    ok, err := s.DeletePoolCascade(ctx, p1.ID)
-    if err != nil || !ok { t.Fatalf("cascade delete: %v ok=%v", err, ok) }
-    if _, ok, _ := s.GetPool(ctx, child.ID); ok {
-        t.Fatalf("expected child removed after cascade")
-    }
+	// Parent/child and delete restriction
+	childCIDR := "10.0.1.0/24"
+	child, err := s.CreatePool(ctx, domain.CreatePool{Name: "child", CIDR: childCIDR, ParentID: &p1.ID})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if _, err := s.DeletePool(ctx, p1.ID); err == nil {
+		t.Fatalf("expected delete restriction when pool has child, got nil error")
+	}
+	// Cascade helper should delete both
+	ok, err := s.DeletePoolCascade(ctx, p1.ID)
+	if err != nil || !ok {
+		t.Fatalf("cascade delete: %v ok=%v", err, ok)
+	}
+	if _, ok, _ := s.GetPool(ctx, child.ID); ok {
+		t.Fatalf("expected child removed after cascade")
+	}
 }
-

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -1187,8 +1187,8 @@ func TestSentinelErrors_CalculatePoolUtilizationNotFound(t *testing.T) {
 // TestWrapIfConflict tests the WrapIfConflict helper function.
 func TestWrapIfConflict(t *testing.T) {
 	tests := []struct {
-		name       string
-		err        error
+		name         string
+		err          error
 		wantConflict bool
 	}{
 		{"nil error", nil, false},

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -10,9 +10,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"cloudpam/internal/api"
 	"cloudpam/internal/audit"
 	"cloudpam/internal/auth"
-	"cloudpam/internal/api"
 	"cloudpam/internal/observability"
 	"cloudpam/internal/storage"
 )


### PR DESCRIPTION
Closes #21. "Gradually reintroduce revive with a minimal rule-set" — so this enables **32 explicitly-listed rules**, not revive's defaults.

## Selection principle

A rule earns its place only if the tree is *already* clean under it, or the fix is a handful of mechanical edits. That keeps "gradually" honest — later rules get added the same way, one measured batch at a time, instead of a mass-edit.

**Enabled**, grouped by why:
- **Latent-bug classes (12)** — `atomic`, `constant-logical-expr`, `context-keys-type`, `datarace`, `defer`, `duplicated-imports`, `identical-branches`, `modifies-value-receiver`, `string-of-int`, `struct-tag`, `unreachable-code`, `waitgroup-by-value`. Real defect classes (context key collisions, `string(int)`, malformed struct tags, copied WaitGroups) at zero current cost.
- **Error idioms (6)** — `error-return`, `error-naming`, `error-strings`, `errorf`, `if-return`, `indent-error-flow`. The core of what this issue asked for; all already clean.
- **API shape & naming (6)**, **mechanical style (8)**.

## Measured, then rejected

357 violations across a 40-rule probe. Rejected with counts:

| Rule | Count | Why rejected |
|---|---|---|
| `exported` | **153** | Doc comments on every exported symbol — far too large for one PR |
| `unused-parameter` | 109 | Mostly `http.HandlerFunc` signatures |
| `use-any` | 37 | Cosmetic |
| `unused-receiver` | 27 | Churn without value |
| `unchecked-type-assertion` | 8 | Fixing changes behaviour — see below |
| `early-return` | 4 | The only rule needing control-flow rewrites |

All 25 other candidates measured **zero** — free guardrails.

## Fixed

Local vars shadowing the `copy` builtin (3 files), one `-= 1` → `--`, and three blank driver imports missing the explanatory comment the other five already carry.

## gofmt

**18 files** failed `gofmt -l`, not just the one flagged during #67. The largest, `internal/storage/sqlite/sqlite.go` (~1994 lines), had been written with **spaces instead of tabs** throughout — hence the big diff, which is entirely whitespace.

Enabled the `gofmt` formatter so it can't regress. Every changed `.go` file was proven byte-identical to `gofmt(original)`:

```
for f in $(git diff --name-only -- "*.go"); do diff -q <(git show HEAD:"$f" | gofmt) "$f"; done
# → all match
```

I independently re-verified this for the 8 changed `_test.go` files: **pure gofmt, no assertion touched.**

`goimports` deliberately not added — it layers import-grouping opinions on top and deserves its own PR.

## Tooling references were stale

The brief for this work (and `CLAUDE.md`) said CI pins **v2.1.6**. It actually pins **golangci-lint v2.4.0 / Go 1.25.x**.

- **v2.4.0 (the real CI pin): verified against the downloaded release binary — `config verify` OK, `run` → 0 issues.** Not assumed.
- v2.8.0 (nix shell): 0 issues.
- v2.1.6 **cannot run against this repo at all** — it's built with Go 1.24 and the module targets 1.25.8. Pre-existing, independent of this change.

Updated the three stale `v2.1.6` references and the `Go 1.24.x` pin note.

## Genuine issues surfaced — reported, not fixed

1. **Unchecked type assertions that can panic** — `middleware.go:64`, `oidc_handlers.go:774`. Both read a `sync.Map` that today only stores that one type, so safe by construction but unenforced.
2. **`errors.Is` not used** — `oidc_handlers.go:611` compares `err == auth.ErrUserExists` directly; silently breaks the username-collision retry if the store ever wraps.
3. `copyBytes`/`copyStrings` in `internal/auth/store.go` existed only because a local var shadowed `copy` — now dead weight.

Left alone: this is a lint PR, and each deserves its own issue and test.

## Follow-up worth its own issue

**Build-tagged code is never linted.** CI runs golangci-lint untagged, so `internal/storage/sqlite/`, `internal/storage/postgres/` and `internal/auth/*_{sqlite,postgres}.go` go unchecked. Running with tags reveals **pre-existing** debt from already-enabled linters: `-tags sqlite` → 17 issues, `-tags postgres` → 11. Revive contributes **zero** under both. Worth cleaning up then adding a tagged lint matrix.

## Verification

```
gofmt -l .                                    empty
golangci-lint run  (v2.4.0 CI pin, v2.8.0)    0 issues
go build ./... && go vet ./... && go test -race ./...   pass
go test -tags sqlite ./... && go build -tags postgres ./...   pass
```

No test modified beyond gofmt whitespace. No exported API renamed. No behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)