### PR TITLE
chore(design-sync): add claude.ai/design sync inputs for ui/

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -103,6 +103,24 @@ All six `[GRID_OVERFLOW]` warns were resolved via `cfg.overrides` (`cardMode`
 ImportExportModal, SearchModal; `column` for the wide SchemaPlanner and
 TreeNode). A re-sync should see **zero** warns — anything new is genuinely new.
 
+## Conventions-header validation
+
+Re-validating `conventions.md` against a fresh build flags **`MemoryRouter`** as
+"not a component and not a bundle export". That is expected and correct as
+written: it ships inside the bundle (used internally by `DSPreviewProvider`) but
+is deliberately *not* on `window.CloudPAM`, and the header only mentions it
+descriptively. Don't "fix" it by exporting it. A `---` hit for a token is just a
+markdown table separator.
+
+**Known false positives in any naive validator** — all three verify fine when
+checked properly, so don't "fix" the conventions file for them:
+
+| Flag | Why it's spurious |
+|---|---|
+| `MemoryRouter` | in the bundle, intentionally not an export (above) |
+| `---` | a markdown table separator, not a `--token` |
+| `gap-1.5` | Tailwind escapes the dot, so it ships as `.gap-1\.5`; a `includes("." + cls)` check misses it. Any arbitrary-value or decimal class (`h-[28rem]`, `gap-1.5`) has the same problem — match against the escaped form. |
+
 ## Deliberately not covered
 
 - `SearchModal` results require typing (300ms debounce) — not statically

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,134 @@
+# design-sync notes — CloudPAM
+
+Repo-specific gotchas for syncing `ui/` to claude.ai/design. Read this before
+re-running the converter.
+
+## The big one: this is an app, not a component library
+
+`ui/` is `private: true` with no library build and no exports entry. Everything
+below follows from that.
+
+- **`ui/node_modules/cloudpam-ui` is a self-link** (`ln -sfn .. ui/node_modules/cloudpam-ui`).
+  The converter resolves `<node_modules>/<pkg>` for both the `.d.ts` tree and
+  preview `import … from 'cloudpam-ui'`. `npm ci` wipes it — **recreate it on
+  every fresh install** or the build dies with
+  `ENOENT … node_modules/cloudpam-ui/package.json`.
+- Because `PKG_DIR` is that symlink, `../` in a config path escapes
+  `ui/node_modules/`, not `ui/`. Hence `extraEntries` and `docsDir` use
+  `../../../` (three levels up from `ui/node_modules/cloudpam-ui`). Paths that
+  point *into* the package (`cssEntry`, `tsconfig`) resolve normally through the
+  link.
+- There is no `dist/`, so the converter runs in **synth-entry mode**.
+
+## Forked `lib/source-kit.mjs` (declared in `cfg.libOverrides`)
+
+Two repo-specific changes; diff against the bundled `lib/source-kit.mjs` on
+re-sync and merge upstream changes.
+
+1. **Default exports.** Every component is `export default function <Name>`.
+   The stock synth entry emits only `export * from …`, which does **not**
+   re-export defaults — discovery finds the components but
+   `window.CloudPAM.<Name>` is `undefined` and every preview fails
+   "Element type is invalid". The fork adds `export { default as <Name> }`.
+2. **Scoping `srcFiles` to `src/components` + `src/wizard`.** Unscoped, the
+   synth entry pulls in `main.tsx` → `index.css` → `@import "tailwindcss"`,
+   which esbuild cannot resolve (no `style` condition) and the whole build
+   fails. It also over-discovers ~46 "components" (every `*Page`) against the 19
+   in scope. Also added `wizard` and `steps` to `GENERIC_DIR` so the doc
+   frontmatter `category` can merge the six wizard files into one group — a
+   non-generic directory name outranks `category` in `package-build.mjs`.
+
+## Declarations are generated, not shipped
+
+`ui/tsconfig.dts.json` emits `.d.ts` into `ui/types/` (gitignored), which
+`findTypesRoot` auto-detects — **no `package.json` change needed**. Without it
+every emitted `<Name>Props` is an empty `[key: string]: unknown`, i.e. the design
+agent gets no API contract at all. `cfg.buildCmd` runs it.
+
+Five wizard components name their props interface `Props`, not `<Name>Props`, so
+the extractor can't match them — they're hand-written in `cfg.dtsPropsFor`
+(TemplateStep, DimensionsStep, StrategyStep, PreviewStep, TreeNode).
+
+## CSS is the app's compiled Tailwind output
+
+`cfg.cssEntry` points at `ui/.ds-css/compiled.css`, copied by `buildCmd` from
+the hash-named `web/dist/assets/index-*.css`. Consequences:
+
+- **Tailwind v4 only compiles classes it finds under `ui/src`.** Authored
+  previews live outside it, so any class they use that the app doesn't already
+  use *does not exist*. This silently cost real debugging: `h-40`/`h-56`/`h-96`/
+  `max-w-xl` all resolved to nothing, so wrappers had zero height and
+  `fixed`-positioned children (ToastContainer, the modals) rendered clipped
+  slivers. **Preview-only layout must use inline `style={{}}`.** The same
+  constraint is documented for the design agent in `conventions.md`.
+- No webfonts ship — type is the system stack, which is why there's no
+  `[FONT_MISSING]`.
+
+## Preview provider
+
+`.design-sync/preview-provider.tsx` (via `cfg.extraEntries`) supplies
+`MemoryRouter` + a signed-in admin. The three app contexts all have *defaults*,
+but those defaults are a signed-out user (`hasPermission: () => false`), which
+makes `Sidebar`'s nav filter to empty and `Header` render signed-out.
+
+It also re-exports `Routes`/`Route`/`Navigate`/`Outlet`. **A preview that imports
+`react-router-dom` directly gets a second module instance whose `<Routes>` can't
+see the provider's `MemoryRouter`** — `Layout` and `ProtectedRoute` rendered
+blank until this was fixed.
+
+## Per-component gotchas
+
+- **Backend-driven components need a stubbed `fetch`** or they render 404 error
+  banners: `UsersAdminPanel` (`/api/v1/auth/users`, `/auth/roles`,
+  `/auth/permissions`) and `UpdateBanner` (`/api/v1/updates`). The stubs live at
+  module scope in each preview `.tsx` — preview code compiles into the card
+  only, never into `_ds_bundle.js`.
+- `UpdateBanner` also returns `null` unless `role === 'admin'`.
+- `ProtectedRoute` has **two** failure branches: a missing permission redirects
+  to `/`, only an unauthenticated session goes to `/login`. Pointing both at
+  `/login` produces a redirect loop and a blank card.
+- `TemplateStep`'s selected-summary panel reads `rootCidr`, `hierarchy` and
+  `recommended` — an id-only `Blueprint` stub renders blank.
+- `TreeNode`'s `defaultExpanded` falls back to `depth < 2` only when
+  *undefined*; pass an empty `Set` to actually collapse everything.
+- `PoolDetailPanel` without `onEdit` swaps "Edit Pool" for a "Manage Pool" link
+  (it does not hide the action).
+- `Sidebar` needs `cfg.overrides.Sidebar.viewport = 900x1080`; the default
+  900x700 capture crops its ~974px nav.
+
+## Known render warns
+
+All six `[GRID_OVERFLOW]` warns were resolved via `cfg.overrides` (`cardMode`
+`single` for the fixed/portal overlays ToastContainer, DiscoveryWizard,
+ImportExportModal, SearchModal; `column` for the wide SchemaPlanner and
+TreeNode). A re-sync should see **zero** warns — anything new is genuinely new.
+
+## Deliberately not covered
+
+- `SearchModal` results require typing (300ms debounce) — not statically
+  renderable, so the card shows the opened palette and its empty state.
+- `Header` has a single cell: `sidebarOpen` only toggles a viewport-gated menu
+  button, so a second card would be pixel-identical.
+- Only `ui/src/components` and `ui/src/wizard` are synced. `ui/src/pages` is
+  deliberately out of scope (user's choice, 2026-08-02).
+
+## Re-sync risks
+
+- **The self-link and `ui/types/` are both gitignored/ephemeral.** A fresh clone
+  needs `npm ci`, then the `ln -sfn`, then `cfg.buildCmd`. Forgetting either is
+  the most likely first failure.
+- **`cssEntry` is a copy, not a live file.** If someone runs the converter
+  without `buildCmd`, `ui/.ds-css/compiled.css` is stale (or absent) and the
+  cards render against old CSS. When in doubt, re-run `buildCmd`.
+- **`dtsPropsFor` is hand-copied** from five `Props` interfaces. If those props
+  change, the shipped `.d.ts` silently lies. Re-check them on any wizard change.
+- **The fetch stubs inline API response shapes** (`UserInfo`, `RoleInfo`,
+  `UpdateCheckResponse`). If those types change, the stubbed cards keep
+  rendering the old shape and will drift from reality without failing.
+- **The class vocabulary table in `conventions.md` was generated from this
+  build's `_ds_bundle.css`.** It shifts whenever CloudPAM's own class usage
+  changes; re-validate the names on each sync (the conventions step does this).
+- The fork of `source-kit.mjs` pins behavior against a specific converter
+  version — diff it against the bundled lib on every sync.
+- Grading used the system Chrome-independent playwright chromium installed at
+  `~/Library/Caches/ms-playwright` (2026-08-02).

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,53 @@
+{
+  "projectId": "3bcc26aa-5738-4d21-af57-ba0b81e8d1cc",
+  "shape": "package",
+  "pkg": "cloudpam-ui",
+  "globalName": "CloudPAM",
+  "buildCmd": "npm run build && mkdir -p .ds-css && cp ../web/dist/assets/index-*.css .ds-css/compiled.css && npx tsc -p tsconfig.dts.json",
+  "srcDir": "src",
+  "tsconfig": "tsconfig.json",
+  "cssEntry": ".ds-css/compiled.css",
+  "docsDir": "../../../.design-sync/docs",
+  "readmeHeader": ".design-sync/conventions.md",
+  "extraEntries": ["../../../.design-sync/preview-provider.tsx"],
+  "provider": {
+    "component": "DSPreviewProvider"
+  },
+  "overrides": {
+    "Sidebar": {
+      "viewport": "900x1080"
+    },
+    "ToastContainer": {
+      "cardMode": "single",
+      "primaryStory": "Stacked"
+    },
+    "DiscoveryWizard": {
+      "cardMode": "single",
+      "primaryStory": "AccountSelection"
+    },
+    "ImportExportModal": {
+      "cardMode": "single",
+      "primaryStory": "Open"
+    },
+    "SearchModal": {
+      "cardMode": "single",
+      "primaryStory": "Open"
+    },
+    "SchemaPlanner": {
+      "cardMode": "column"
+    },
+    "TreeNode": {
+      "cardMode": "column"
+    }
+  },
+  "dtsPropsFor": {
+    "TemplateStep": "selectedBlueprint: Blueprint | null; setSelectedBlueprint: (bp: Blueprint) => void; customCidr: string; setCustomCidr: (cidr: string) => void;",
+    "DimensionsStep": "dimensions: { regions: string[]; environments: string[]; accountTiers: string[]; accountsPerEnv: number; growthYears: number }; setDimensions: React.Dispatch<React.SetStateAction<{ regions: string[]; environments: string[]; accountTiers: string[]; accountsPerEnv: number; growthYears: number }>>; strategy: string;",
+    "StrategyStep": "strategy: string; setStrategy: (s: string) => void;",
+    "PreviewStep": "schema: SchemaNode; conflicts: SchemaConflict[]; conflictsLoading: boolean; conflictsError: string | null; onExport: (format: 'csv' | 'terraform') => void;",
+    "TreeNode": "node: SchemaNode; depth?: number; defaultExpanded?: Set<string>;"
+  },
+  "libOverrides": {
+    "source-kit.mjs": "components are all `export default function <Name>`, which `export * from` drops from the synth entry"
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,116 @@
+# Building with CloudPAM's UI
+
+CloudPAM is an IP Address Management platform. These components come from its
+real application frontend (`ui/`), not a standalone component library — so they
+assume an app context (router + auth) and they style themselves with Tailwind.
+
+## Wrap everything in DSPreviewProvider
+
+Nearly every component here reads React Router and/or CloudPAM's auth context.
+Rendered bare, `Sidebar` shows an empty nav, `Header` renders signed-out, and
+`Layout` / `ProtectedRoute` render **nothing at all** (they redirect or hit a
+router-less crash).
+
+`DSPreviewProvider` supplies a `MemoryRouter` plus a signed-in admin, and is the
+correct root for anything you build:
+
+```jsx
+const { DSPreviewProvider, Layout, Routes, Route } = window.CloudPAM
+
+<DSPreviewProvider>
+  <Routes>
+    <Route element={<Layout />}>
+      <Route path="*" element={<YourPage />} />
+    </Route>
+  </Routes>
+</DSPreviewProvider>
+```
+
+**Import `Routes` / `Route` / `Navigate` / `Outlet` from the design system, not
+from `react-router-dom`.** A separate copy of react-router is a separate context
+— its `<Routes>` cannot see `DSPreviewProvider`'s router, and route-composed UI
+silently renders blank.
+
+To vary the signed-in principal, override the context directly. Permission-gated
+nav and guards respond to `hasPermission`:
+
+```jsx
+const { AuthContext, previewAuth } = window.CloudPAM
+const viewer = { ...previewAuth, role: 'viewer', hasPermission: (p) => p === 'pools:read' }
+
+<AuthContext.Provider value={viewer}>…</AuthContext.Provider>
+```
+
+`ThemeContext` (light/dark) and `ToastContext` (`{ toasts, showToast }`) work the
+same way; `ToastContainer` renders nothing until `toasts` is non-empty.
+
+## Styling: Tailwind, but a CLOSED set of classes
+
+The shipped stylesheet is CloudPAM's **compiled** Tailwind v4 output. It contains
+only the ~745 utilities the app itself uses. **A Tailwind class that CloudPAM
+doesn't already use does not exist here and will silently do nothing** — this is
+the single most common way to produce broken-looking output.
+
+Two safe options:
+1. Reuse the vocabulary below (all verified present in the bundle).
+2. For anything else — especially explicit sizing — use **inline `style={{}}`**.
+
+Verified families:
+
+| Purpose | Available |
+|---|---|
+| Brand / primary | `bg-blue-500` `bg-blue-600` `bg-blue-100` `text-blue-600` `text-blue-700` `border-blue-500` |
+| Neutrals | `bg-gray-100`–`bg-gray-400`, `bg-gray-600`, `bg-gray-900`; `text-gray-400`–`text-gray-900`; `border-gray-100`–`border-gray-300` |
+| Status color | `green` (active/ok), `red` (error/deprecated), `amber` (warning), all at `-100` bg / `-700` text |
+| Type scale | `text-xs` `text-sm` `text-base` `text-lg` `text-xl` `text-2xl` |
+| Weight | `font-normal` `font-medium` `font-semibold` `font-bold`; `font-mono` for CIDRs |
+| Padding | `p-0`–`p-6`, `p-8` (plus `px-*` / `py-*`) |
+| Gap | `gap-1` `gap-1.5` `gap-2` `gap-3` `gap-4` `gap-6` |
+| Radius | `rounded` `rounded-md` `rounded-lg` `rounded-xl` `rounded-full` |
+| Elevation | `shadow-sm` `shadow` `shadow-md` `shadow-lg` `shadow-xl` |
+| Width | `max-w-xs` `max-w-sm` `max-w-md` `max-w-2xl` `max-w-4xl` `max-w-5xl` |
+
+Heights are sparse — only `h-2`…`h-12`, `h-16` exist. Use inline styles for
+anything taller.
+
+**Dark mode** is class-based, not media-based: it activates under a `.dark`
+ancestor. 170 `dark:` variants ship, so pair colors as
+`bg-white dark:bg-gray-800`, `text-gray-900 dark:text-gray-100`.
+
+There are no brand webfonts — type is the system stack (`--font-sans`), with
+`font-mono` for addresses. CIDRs are always monospace in this product.
+
+## Where the truth lives
+
+- `_ds/<folder>/styles.css` → `@import`s `_ds_bundle.css`, the full compiled
+  stylesheet. Read it to confirm a class exists before using it.
+- `components/<group>/<Name>/<Name>.d.ts` — the real prop contract.
+- `components/<group>/<Name>/<Name>.prompt.md` — per-component usage notes.
+
+## Product idiom
+
+- CIDRs render monospace next to a colored type dot. `getPoolTypeColor` drives
+  it: supernet/root=`bg-purple-500`, region=`bg-blue-500`,
+  environment=`bg-green-500`, vpc/account=`bg-amber-500`,
+  subnet=`bg-orange-500`, unknown=`bg-gray-400`. (The Schema Wizard's `TreeNode`
+  keeps its own near-identical map that greys out subnets — match whichever
+  surface you're building alongside.)
+- Utilization is a bar plus a percentage; it turns red as a pool fills.
+- `StatusBadge` is the one labeling primitive — `variant` picks the vocabulary
+  (`status` / `provider` / `tier` / `action` / `type`), so use it instead of
+  hand-rolling pills.
+
+```jsx
+const { DSPreviewProvider, PoolDetailPanel, StatusBadge } = window.CloudPAM
+
+<DSPreviewProvider>
+  <div className="p-6 space-y-4 max-w-md">
+    <div className="flex items-center gap-2">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">production</h2>
+      <StatusBadge label="active" />
+      <StatusBadge label="aws" variant="provider" />
+    </div>
+    <PoolDetailPanel pool={pool} onClose={() => {}} onEdit={() => {}} />
+  </div>
+</DSPreviewProvider>
+```

--- a/.design-sync/docs/DimensionsStep.md
+++ b/.design-sync/docs/DimensionsStep.md
@@ -1,0 +1,5 @@
+---
+category: Schema Wizard
+---
+
+Step 2 — define the dimensions (environment, region, tier) that expand into the pool hierarchy.

--- a/.design-sync/docs/DiscoveryWizard.md
+++ b/.design-sync/docs/DiscoveryWizard.md
@@ -1,0 +1,5 @@
+---
+category: Overlays
+---
+
+Multi-step wizard for provisioning a cloud discovery agent, covering account selection, configuration, and generated deployment artifacts.

--- a/.design-sync/docs/Header.md
+++ b/.design-sync/docs/Header.md
@@ -1,0 +1,5 @@
+---
+category: App Shell
+---
+
+Top bar for the authenticated app: search trigger, theme toggle, notification bell, and the user menu (profile, API keys, sign out).

--- a/.design-sync/docs/ImportExportModal.md
+++ b/.design-sync/docs/ImportExportModal.md
@@ -1,0 +1,5 @@
+---
+category: Overlays
+---
+
+Dialog for exporting datasets as CSV-in-ZIP and importing accounts or pools from CSV.

--- a/.design-sync/docs/Layout.md
+++ b/.design-sync/docs/Layout.md
@@ -1,0 +1,5 @@
+---
+category: App Shell
+---
+
+The authenticated application frame: sidebar, header, toast layer, update banner, and a routed content outlet. Rendered once at the top of the protected route tree.

--- a/.design-sync/docs/PoolDetailPanel.md
+++ b/.design-sync/docs/PoolDetailPanel.md
@@ -1,0 +1,5 @@
+---
+category: Data Display
+---
+
+Side panel summarizing a single pool: CIDR, utilization, host counts, and account assignment, with edit and close affordances.

--- a/.design-sync/docs/PoolTree.md
+++ b/.design-sync/docs/PoolTree.md
@@ -1,0 +1,5 @@
+---
+category: Data Display
+---
+
+Expandable hierarchy of IP pools with per-node utilization and host counts. Purely presentational — selection is controlled by the parent.

--- a/.design-sync/docs/PreviewStep.md
+++ b/.design-sync/docs/PreviewStep.md
@@ -1,0 +1,5 @@
+---
+category: Schema Wizard
+---
+
+Step 4 — review the generated pool tree and any conflicts before applying the plan.

--- a/.design-sync/docs/ProtectedRoute.md
+++ b/.design-sync/docs/ProtectedRoute.md
@@ -1,0 +1,5 @@
+---
+category: Routing
+---
+
+Route guard. Renders the nested route when the session satisfies the required role or permissions, otherwise redirects. Renders no UI of its own.

--- a/.design-sync/docs/SchemaPlanner.md
+++ b/.design-sync/docs/SchemaPlanner.md
@@ -1,0 +1,5 @@
+---
+category: Schema Wizard
+---
+
+Top-level Schema Planner wizard shell, sequencing the template, dimensions, strategy, and preview steps.

--- a/.design-sync/docs/SearchModal.md
+++ b/.design-sync/docs/SearchModal.md
@@ -1,0 +1,5 @@
+---
+category: Overlays
+---
+
+Command-palette style search over pools, accounts, and discovered resources, including CIDR containment queries.

--- a/.design-sync/docs/Sidebar.md
+++ b/.design-sync/docs/Sidebar.md
@@ -1,0 +1,5 @@
+---
+category: App Shell
+---
+
+Primary navigation rail. Nav entries are permission-gated, so items appear only for users holding the matching permission.

--- a/.design-sync/docs/StatusBadge.md
+++ b/.design-sync/docs/StatusBadge.md
@@ -1,0 +1,5 @@
+---
+category: Data Display
+---
+
+Small pill label. The variant selects the color vocabulary: status, provider, tier, action, or pool type.

--- a/.design-sync/docs/StrategyStep.md
+++ b/.design-sync/docs/StrategyStep.md
@@ -1,0 +1,5 @@
+---
+category: Schema Wizard
+---
+
+Step 3 — choose the allocation strategy and prefix sizing for the generated plan.

--- a/.design-sync/docs/TemplateStep.md
+++ b/.design-sync/docs/TemplateStep.md
@@ -1,0 +1,5 @@
+---
+category: Schema Wizard
+---
+
+Step 1 — pick a starting addressing template or begin from scratch.

--- a/.design-sync/docs/ToastContainer.md
+++ b/.design-sync/docs/ToastContainer.md
@@ -1,0 +1,5 @@
+---
+category: Feedback
+---
+
+Fixed-position stack of transient notifications. Reads the toast list from context; renders nothing when empty.

--- a/.design-sync/docs/TreeNode.md
+++ b/.design-sync/docs/TreeNode.md
@@ -1,0 +1,5 @@
+---
+category: Schema Wizard
+---
+
+Single node in the planned-schema preview tree, showing the generated CIDR and its nesting depth.

--- a/.design-sync/docs/UpdateBanner.md
+++ b/.design-sync/docs/UpdateBanner.md
@@ -1,0 +1,5 @@
+---
+category: Feedback
+---
+
+Banner announcing an available CloudPAM release, with upgrade trigger and progress state for privileged users.

--- a/.design-sync/docs/UsersAdminPanel.md
+++ b/.design-sync/docs/UsersAdminPanel.md
@@ -1,0 +1,5 @@
+---
+category: Admin
+---
+
+Local user administration: list users, create accounts, toggle active state, and unlock locked-out users.

--- a/.design-sync/overrides/source-kit.mjs
+++ b/.design-sync/overrides/source-kit.mjs
@@ -1,0 +1,189 @@
+// forked from design-sync lib/source-kit.mjs — CloudPAM components are all `export default function <Name>`, which `export * from` drops from the synth entry
+//
+// Non-storybook `package` adapter. Bundles dist/ when present (the authoritative
+// component list comes from shipped .d.ts; with no dist it synthesizes an
+// entry from src/ as a last resort) and opportunistically enriches each
+// component from src/ — JSDoc and dir-derived group. Every enrichment miss
+// degrades to the plain-dist behaviour.
+//
+// Discovery is heuristic-based; each heuristic has a `.design-sync/config.json`
+// override (ASSUMPTION comments below name them) so repos that don't match the
+// defaults write config, not code. `componentSrcMap` is the single override
+// knob for component inclusion: non-null value = add/pin src path, null =
+// exclude a .d.ts-exported internal.
+
+import { existsSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { Project, Node, ts } from 'ts-morph';
+import { leadingJsdoc, readText, slash, walk } from '../../.ds-sync/lib/common.mjs';
+import { resolveDistEntry } from '../../.ds-sync/lib/bundle.mjs';
+import { exportedNames, isComponentName } from '../../.ds-sync/lib/dts.mjs';
+
+const NON_IMPL_RX = /\.(stories|test|spec)\./;
+const SRC_IMPL_RX = /\.(tsx|jsx)$/;
+// Dir names that don't usefully group components — skip so the emitted path
+// is `components/<group>/<Name>` not `components/components/<Name>`.
+// FORK: added 'wizard' and 'steps'. The Schema Planner is split across
+// wizard/, wizard/components/ and wizard/steps/, so the dir-derived group
+// splits six related components into "wizard" + "steps" — and a non-generic
+// dir group outranks the doc frontmatter `category` (package-build.mjs), so
+// the stubs in .design-sync/docs/ can't merge them back into "Schema Wizard".
+const GENERIC_DIR = new Set(['components', 'component', 'src', 'lib', 'ui', 'packages', 'react', 'wizard', 'steps']);
+const slug = (s) => s.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'general';
+
+// No .d.ts → scan src files for PascalCase value exports via ts-morph.
+function deriveComponentsFromSrc(srcFiles) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: { jsx: ts.JsxEmit.Preserve, allowJs: true, skipLibCheck: true },
+  });
+  const seen = new Set();
+  for (const p of srcFiles) {
+    if (NON_IMPL_RX.test(p) || !SRC_IMPL_RX.test(p)) continue;
+    const sf = project.addSourceFileAtPathIfExists(p);
+    if (!sf) continue;
+    for (const [name, decls] of sf.getExportedDeclarations()) {
+      // `export default function Button()` is keyed as 'default' — recover
+      // the declared name from the function/class node.
+      const real = name === 'default'
+        ? decls.map((d) => d.getName?.()).find((n) => n && n !== 'default')
+        : name;
+      if (!real || !/^[A-Z][A-Za-z0-9]*$/.test(real)) continue;
+      if (decls.some((d) => Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d))) {
+        seen.add(real);
+      }
+    }
+  }
+  return [...seen].sort().map((name) => ({ name, group: 'general' }));
+}
+
+export async function resolvePackage(ctx) {
+  const { PKG_DIR, pkgJson, ENTRY_OVERRIDE, PKG, OUT, cfg } = ctx;
+  const srcMap = cfg.componentSrcMap ?? {};
+
+  // ── 1. src/ discovery (best-effort; feeds enrichment + synth-entry fallback).
+  // ASSUMPTION: source root is first of src/ | lib/ | components/. Override: cfg.srcDir.
+  const srcRoot = [cfg.srcDir, 'src', 'lib', 'components']
+    .map((d) => d && resolve(PKG_DIR, d))
+    .find((d) => d && existsSync(d));
+  // FORK: CloudPAM's ui/ is an application, not a component library — src/ also
+  // holds pages/, api/, hooks/ and main.tsx. Unscoped, the synth entry
+  // `export * from`s main.tsx, which imports index.css, which `@import`s
+  // "tailwindcss" — esbuild can't resolve that (no "style" condition) and the
+  // whole bundle fails. It also over-discovers ~46 "components" (every
+  // PascalCase *Page export) against the 19 the user scoped in. Restrict the
+  // source set to the two directories that actually hold reusable components.
+  const SCOPE_RX = /\/src\/(components|wizard)\//;
+  const srcFiles = srcRoot
+    ? walk(srcRoot, (n) => /\.(tsx|jsx|mdx?)$/.test(n)).filter((p) => SCOPE_RX.test(slash(p)))
+    : [];
+
+  // ── 2. entry: dist if it exists, else synthesize from src/ (last resort).
+  let entry = resolveDistEntry({ pkgDir: PKG_DIR, pkgJson, override: ENTRY_OVERRIDE, pkgName: PKG, soft: true });
+  let synthEntry = false;
+  if (!entry) {
+    if (!srcRoot) {
+      console.error(`[NO_DIST] ${PKG} has no built entry and no src/ to synthesize from — run its build.`);
+      process.exit(1);
+    }
+    const comps = srcFiles.filter((p) => SRC_IMPL_RX.test(p) && !NON_IMPL_RX.test(p));
+    entry = join(OUT, '.pkg-entry.mjs');
+    // FORK: `export * from` does not re-export a module's default binding, and
+    // every CloudPAM component is `export default function <Name>`. Without
+    // this, discovery finds the components (deriveComponentsFromSrc recovers
+    // the declared name) but `window.<globalName>.<Name>` is undefined and
+    // every preview fails "Element type is invalid". Emit a named re-export of
+    // the default alongside the star export for named siblings.
+    const DEFAULT_RX = /export\s+default\s+(?:function|class)\s+([A-Z][A-Za-z0-9]*)/;
+    writeFileSync(
+      entry,
+      comps
+        .map((p) => {
+          const lines = [`export * from ${JSON.stringify(p)};`];
+          const name = DEFAULT_RX.exec(readText(p))?.[1];
+          if (name) lines.push(`export { default as ${name} } from ${JSON.stringify(p)};`);
+          return lines.join('\n');
+        })
+        .join('\n') + '\n',
+    );
+    synthEntry = true;
+    console.error(
+      `[NO_DIST] no built entry — synthesizing from ${comps.length} src files (run the package's build for best results)`,
+    );
+  }
+
+  // ── 3. component list: from shipped .d.ts (authoritative when dist exists).
+  // ASSUMPTION: components = PascalCase value exports in the .d.ts tree.
+  // Override: cfg.componentSrcMap (non-null adds/pins, null excludes).
+  const exported = exportedNames(PKG_DIR, pkgJson);
+  const names = new Set([...exported].filter(isComponentName));
+  for (const [k, v] of Object.entries(srcMap)) {
+    if (v === null) { names.delete(k); continue; }
+    // Names reach `<script>` blocks in the emitted HTML — reject anything
+    // that isn't a plain PascalCase identifier.
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(k)) {
+      console.error(`[CONFIG] componentSrcMap: "${k}" is not a valid component name (PascalCase identifiers only)`);
+      continue;
+    }
+    names.add(k);
+  }
+  let components = [...names].sort().map((name) => ({ name, group: 'general' }));
+  if (!components.length && synthEntry) {
+    components = deriveComponentsFromSrc(srcFiles).filter((c) => srcMap[c.name] !== null);
+  }
+  if (!components.length) {
+    if (cfg.cssEntry || existsSync(join(PKG_DIR, 'styles.css'))) {
+      console.error('[ZERO_MATCH] no component exports — treating as tokens-only DS');
+      return { shape: 'package', entry, components: [], tokensOnly: true };
+    }
+    console.error(`[ZERO_MATCH] no PascalCase exports in ${PKG} and no styles — nothing to sync`);
+    process.exit(1);
+  }
+
+  // ── 4. src/ enrichment per component. Every miss degrades to plain-dist.
+  if (srcRoot) {
+    for (const c of components) {
+      // Pinned via config → skip fuzzy-find entirely.
+      let hit = typeof srcMap[c.name] === 'string' ? slash(resolve(PKG_DIR, srcMap[c.name])) : null;
+      if (!hit) {
+        // ASSUMPTION: <Name>.tsx | <name>/<name>.tsx | <Name>/index.tsx |
+        // <kebab-name>.tsx, case-insensitive; dir-match ranks above
+        // bare-file match, then prefer one that actually exports `c.name`.
+        // Override: cfg.componentSrcMap.
+        const kebab = c.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2');
+        const nameRx = new RegExp(
+          `(?:^|/)(?:${c.name}/(?:index|${c.name})\\.(tsx|jsx)|(?:${c.name}|${kebab})\\.(tsx|jsx))$`,
+          'i',
+        );
+        const hits = srcFiles
+          .filter((p) => nameRx.test(p) && !NON_IMPL_RX.test(p))
+          .sort(
+            (a, b) =>
+              (b.toLowerCase().includes(`/${c.name.toLowerCase()}/`) ? 1 : 0) -
+              (a.toLowerCase().includes(`/${c.name.toLowerCase()}/`) ? 1 : 0),
+          );
+        const exportRx = new RegExp(`export\\s+(?:default\\s+)?(?:const|let|var|function|class)\\s+${c.name}\\b`);
+        hit = hits.find((p) => exportRx.test(readText(p))) ?? hits[0];
+      }
+      if (!hit || !existsSync(hit)) continue;
+      c.srcPath = hit;
+      c.doc = leadingJsdoc(readText(hit), c.name) || undefined;
+      // group = last src/ path segment that isn't the component's own dir or
+      // a generic container name — else JSDoc @category — else 'general'.
+      c.group = slug(
+        slash(relative(srcRoot, dirname(hit)))
+          .split('/')
+          .filter((s) => s && s.toLowerCase() !== c.name.toLowerCase() && !GENERIC_DIR.has(s.toLowerCase()))
+          .at(-1)
+        || (c.doc && /@category\s+(\S+)/.exec(c.doc)?.[1])
+        || 'general',
+      );
+    }
+  }
+
+  console.error(
+    `  package: ${components.length} components` +
+      (srcRoot ? ` (${components.filter((c) => c.srcPath).length} src-matched)` : ' (no src/ — dist-only)'),
+  );
+  return { shape: 'package', entry, components, synthEntry, exported };
+}

--- a/.design-sync/preview-provider.tsx
+++ b/.design-sync/preview-provider.tsx
@@ -1,0 +1,81 @@
+// Preview provider for design-sync cards.
+//
+// CloudPAM's UI is an application, not a component library: its components read
+// react-router-dom and three React contexts. The contexts all have defaults, but
+// those defaults represent a signed-out user (hasPermission -> false), which
+// makes Sidebar's nav filter to empty and Header render its logged-out state.
+// This wrapper supplies a router plus a realistic signed-in admin so preview
+// cards show the UI as an operator actually sees it.
+//
+// The contexts are re-exported so an individual preview can override one
+// locally (e.g. ToastContainer supplying its own toasts) without every other
+// card inheriting that state.
+import { MemoryRouter } from 'react-router-dom'
+import { AuthContext } from '../ui/src/hooks/useAuth'
+import { ThemeContext } from '../ui/src/hooks/useTheme'
+import { ToastContext } from '../ui/src/hooks/useToast'
+
+// Re-exported so previews get the SAME react-router-dom module instance that
+// is bundled here. A preview that imports 'react-router-dom' directly gets a
+// second copy whose <Routes> can't see this file's <MemoryRouter>, and any
+// route-composed preview (Layout, ProtectedRoute) silently renders blank.
+export { Routes, Route, Navigate, Outlet } from 'react-router-dom'
+
+export { AuthContext } from '../ui/src/hooks/useAuth'
+export { ThemeContext } from '../ui/src/hooks/useTheme'
+export { ToastContext } from '../ui/src/hooks/useToast'
+
+export const previewUser = {
+  id: 'u-1024',
+  username: 'dana.reyes',
+  email: 'dana.reyes@example.com',
+  display_name: 'Dana Reyes',
+  role: 'admin',
+  is_active: true,
+  created_at: '2026-01-14T09:20:00Z',
+  updated_at: '2026-07-02T16:41:00Z',
+  last_login_at: '2026-08-01T08:12:00Z',
+  failed_login_attempts: 0,
+}
+
+export const previewAuth = {
+  keyName: null,
+  role: 'admin',
+  authType: 'session' as const,
+  currentUser: previewUser,
+  permissions: ['*'],
+  hasPermission: () => true,
+  isAuthenticated: true,
+  authEnabled: true,
+  localAuthEnabled: true,
+  needsSetup: false,
+  authChecked: true,
+  loginWithPassword: async () => {},
+  logout: () => {},
+}
+
+export const previewTheme = {
+  mode: 'light' as const,
+  resolvedTheme: 'light' as const,
+  cycle: () => {},
+  toggle: () => {},
+}
+
+// Empty by default so cards don't all render floating toasts; ToastContainer's
+// own preview supplies toasts via a nested ToastContext.Provider.
+export const previewToast = {
+  toasts: [],
+  showToast: () => {},
+}
+
+export function DSPreviewProvider({ children }: { children?: React.ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={['/pools']}>
+      <ThemeContext.Provider value={previewTheme}>
+        <AuthContext.Provider value={previewAuth}>
+          <ToastContext.Provider value={previewToast}>{children}</ToastContext.Provider>
+        </AuthContext.Provider>
+      </ThemeContext.Provider>
+    </MemoryRouter>
+  )
+}

--- a/.design-sync/previews/DimensionsStep.tsx
+++ b/.design-sync/previews/DimensionsStep.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+import { DimensionsStep } from 'cloudpam-ui'
+
+const enterprise = {
+  regions: ['us-east-1', 'us-west-2', 'eu-west-1'],
+  environments: ['production', 'staging', 'development'],
+  accountTiers: ['prd', 'stg', 'dev'],
+  accountsPerEnv: 12,
+  growthYears: 5,
+}
+
+const startup = {
+  regions: ['us-east-1'],
+  environments: ['production', 'development'],
+  accountTiers: ['prd', 'dev'],
+  accountsPerEnv: 2,
+  growthYears: 3,
+}
+
+export function EnterpriseScale() {
+  const [dimensions, setDimensions] = useState(enterprise)
+  return <DimensionsStep dimensions={dimensions} setDimensions={setDimensions} strategy="region-first" />
+}
+
+export function SmallFootprint() {
+  const [dimensions, setDimensions] = useState(startup)
+  return <DimensionsStep dimensions={dimensions} setDimensions={setDimensions} strategy="environment-first" />
+}

--- a/.design-sync/previews/DiscoveryWizard.tsx
+++ b/.design-sync/previews/DiscoveryWizard.tsx
@@ -1,0 +1,66 @@
+import { DiscoveryWizard } from 'cloudpam-ui'
+import type { Account } from 'cloudpam-ui'
+
+const accounts = [
+  {
+    id: 1,
+    key: 'prod-payments',
+    name: 'Production — Payments',
+    provider: 'aws',
+    external_id: '123456789012',
+    tier: 'prd',
+    environment: 'production',
+    regions: ['us-east-1', 'us-west-2'],
+    created_at: '2026-01-20T10:00:00Z',
+  },
+  {
+    id: 2,
+    key: 'staging-core',
+    name: 'Staging — Core',
+    provider: 'aws',
+    external_id: '210987654321',
+    tier: 'stg',
+    environment: 'staging',
+    regions: ['us-east-1'],
+    created_at: '2026-02-14T10:00:00Z',
+  },
+  {
+    id: 3,
+    key: 'analytics-gcp',
+    name: 'Analytics Platform',
+    provider: 'gcp',
+    external_id: 'analytics-prod-8842',
+    tier: 'prd',
+    environment: 'production',
+    regions: ['europe-west1'],
+    created_at: '2026-04-02T10:00:00Z',
+  },
+] as unknown as Account[]
+
+// The wizard owns its step state, so a card shows step 1 — account selection —
+// against a realistic multi-cloud account list.
+export function AccountSelection() {
+  return (
+    <div style={{ position: 'relative', height: 700, width: '100%', transform: 'translateZ(0)' }}>
+      <DiscoveryWizard
+        accounts={accounts}
+        onAccountCreated={() => {}}
+        onClose={() => {}}
+        onComplete={() => {}}
+      />
+    </div>
+  )
+}
+
+export function NoAccountsYet() {
+  return (
+    <div style={{ position: 'relative', height: 700, width: '100%', transform: 'translateZ(0)' }}>
+      <DiscoveryWizard
+        accounts={[]}
+        onAccountCreated={() => {}}
+        onClose={() => {}}
+        onComplete={() => {}}
+      />
+    </div>
+  )
+}

--- a/.design-sync/previews/Header.tsx
+++ b/.design-sync/previews/Header.tsx
@@ -1,0 +1,8 @@
+import { Header } from 'cloudpam-ui'
+
+// Only one cell: the `sidebarOpen` menu toggle is viewport-gated (hidden at
+// desktop widths), so a second card at preview width would be pixel-identical
+// to this one.
+export function Default() {
+  return <Header onSearchClick={() => {}} onMenuClick={() => {}} sidebarOpen={true} />
+}

--- a/.design-sync/previews/ImportExportModal.tsx
+++ b/.design-sync/previews/ImportExportModal.tsx
@@ -1,0 +1,11 @@
+import { ImportExportModal } from 'cloudpam-ui'
+
+// Same containing-block trick as SearchModal: the dialog is `fixed`, so a
+// transformed wrapper keeps the backdrop and panel inside the card.
+export function Open() {
+  return (
+    <div style={{ position: 'relative', height: 544, width: '100%', transform: 'translateZ(0)' }}>
+      <ImportExportModal open={true} onClose={() => {}} />
+    </div>
+  )
+}

--- a/.design-sync/previews/Layout.tsx
+++ b/.design-sync/previews/Layout.tsx
@@ -1,0 +1,28 @@
+import { Layout, Routes, Route } from 'cloudpam-ui'
+
+// Layout is the authenticated frame and renders its page content through an
+// <Outlet>. Mounted bare it shows the chrome around an empty hole, so the
+// preview supplies a route tree — the only composition that shows what the
+// shell actually looks like in use.
+function SamplePage() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Address Pools</h1>
+      <p className="text-gray-600 dark:text-gray-300">
+        Page content renders here, inside Layout's outlet.
+      </p>
+    </div>
+  )
+}
+
+export function AppFrame() {
+  return (
+    <div style={{ height: 800 }}>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route path="*" element={<SamplePage />} />
+        </Route>
+      </Routes>
+    </div>
+  )
+}

--- a/.design-sync/previews/PoolDetailPanel.tsx
+++ b/.design-sync/previews/PoolDetailPanel.tsx
@@ -1,0 +1,118 @@
+import { PoolDetailPanel } from 'cloudpam-ui'
+import type { PoolWithStats } from 'cloudpam-ui'
+
+function pool(over: Record<string, unknown>): PoolWithStats {
+  return {
+    id: 42,
+    name: 'production',
+    cidr: '10.0.0.0/16',
+    parent_id: 2,
+    account_id: 7,
+    type: 'environment',
+    status: 'active',
+    source: 'manual',
+    description: 'Primary production environment for the us-east-1 region.',
+    created_at: '2026-02-11T09:00:00Z',
+    updated_at: '2026-07-28T14:35:00Z',
+    stats: {
+      total_ips: 65536,
+      used_ips: 58982,
+      available_ips: 6554,
+      utilization: 90.0,
+      child_count: 12,
+      direct_children: 4,
+    },
+    ...over,
+  } as unknown as PoolWithStats
+}
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div className="max-w-md">{children}</div>
+)
+
+export function NearCapacity() {
+  return (
+    <Frame>
+      <PoolDetailPanel pool={pool({})} onClose={() => {}} onEdit={() => {}} />
+    </Frame>
+  )
+}
+
+export function HealthyUtilization() {
+  return (
+    <Frame>
+      <PoolDetailPanel
+        pool={pool({
+          id: 43,
+          name: 'staging',
+          cidr: '10.1.0.0/16',
+          description: 'Pre-production staging environment, refreshed nightly.',
+          stats: {
+            total_ips: 65536,
+            used_ips: 19660,
+            available_ips: 45876,
+            utilization: 30.0,
+            child_count: 5,
+            direct_children: 2,
+          },
+        })}
+        onClose={() => {}}
+        onEdit={() => {}}
+      />
+    </Frame>
+  )
+}
+
+export function PlannedPool() {
+  return (
+    <Frame>
+      <PoolDetailPanel
+        pool={pool({
+          id: 44,
+          name: 'eu-west-1 supernet',
+          cidr: '10.16.0.0/12',
+          type: 'region',
+          status: 'planned',
+          description: 'Reserved for the upcoming Frankfurt expansion.',
+          stats: {
+            total_ips: 1048576,
+            used_ips: 0,
+            available_ips: 1048576,
+            utilization: 0,
+            child_count: 0,
+            direct_children: 0,
+          },
+        })}
+        onClose={() => {}}
+        onEdit={() => {}}
+      />
+    </Frame>
+  )
+}
+
+// onEdit is optional: omitting it swaps the inline "Edit Pool" action for a
+// "Manage Pool" link that routes to the pool's own page.
+export function WithoutEditHandler() {
+  return (
+    <Frame>
+      <PoolDetailPanel
+        pool={pool({
+          id: 45,
+          name: 'legacy-dc1',
+          cidr: '172.16.0.0/16',
+          status: 'deprecated',
+          description: 'Retired datacenter range. Scheduled for reclamation in Q4.',
+          stats: {
+            total_ips: 65536,
+            used_ips: 3277,
+            available_ips: 62259,
+            utilization: 5.0,
+            child_count: 2,
+            direct_children: 2,
+          },
+        })}
+        onClose={() => {}}
+      />
+    </Frame>
+  )
+}

--- a/.design-sync/previews/PoolTree.tsx
+++ b/.design-sync/previews/PoolTree.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { PoolTree } from 'cloudpam-ui'
+import type { PoolWithStats } from 'cloudpam-ui'
+
+// Stats are derived from the CIDR so utilization colors are believable rather
+// than arbitrary: a /8 really does hold 16.7M addresses.
+function pool(
+  id: number,
+  name: string,
+  cidr: string,
+  type: string,
+  total: number,
+  used: number,
+  children: PoolWithStats[] = [],
+): PoolWithStats {
+  return {
+    id,
+    name,
+    cidr,
+    type,
+    status: 'active',
+    source: 'manual',
+    created_at: '2026-02-11T09:00:00Z',
+    updated_at: '2026-07-28T14:35:00Z',
+    children,
+    stats: {
+      total_ips: total,
+      used_ips: used,
+      available_ips: total - used,
+      utilization: Math.round((used / total) * 1000) / 10,
+      child_count: children.length,
+      direct_children: children.length,
+    },
+  } as unknown as PoolWithStats
+}
+
+const corpNetwork: PoolWithStats[] = [
+  pool(1, 'Corporate Supernet', '10.0.0.0/8', 'supernet', 16777216, 4194304, [
+    pool(2, 'us-east-1', '10.0.0.0/12', 'region', 1048576, 733184, [
+      pool(4, 'production', '10.0.0.0/16', 'environment', 65536, 58982),
+      pool(5, 'staging', '10.1.0.0/16', 'environment', 65536, 19660),
+    ]),
+    pool(3, 'eu-west-1', '10.16.0.0/12', 'region', 1048576, 209715, [
+      pool(6, 'production', '10.16.0.0/16', 'environment', 65536, 26214),
+    ]),
+  ]),
+]
+
+export function Hierarchy() {
+  const [selected, setSelected] = useState<number | null>(null)
+  return (
+    <div className="max-w-2xl">
+      <PoolTree nodes={corpNetwork} selectedId={selected} onSelect={(p) => setSelected(p.id)} />
+    </div>
+  )
+}
+
+export function WithSelection() {
+  return (
+    <div className="max-w-2xl">
+      <PoolTree nodes={corpNetwork} selectedId={2} onSelect={() => {}} />
+    </div>
+  )
+}
+
+export function FlatList() {
+  return (
+    <div className="max-w-2xl">
+      <PoolTree
+        nodes={[
+          pool(10, 'dmz', '192.168.10.0/24', 'subnet', 256, 231),
+          pool(11, 'management', '192.168.20.0/24', 'subnet', 256, 64),
+          pool(12, 'transit', '192.168.30.0/24', 'subnet', 256, 12),
+        ]}
+        onSelect={() => {}}
+      />
+    </div>
+  )
+}
+

--- a/.design-sync/previews/PreviewStep.tsx
+++ b/.design-sync/previews/PreviewStep.tsx
@@ -1,0 +1,83 @@
+import { PreviewStep } from 'cloudpam-ui'
+import type { SchemaNode, SchemaConflict } from 'cloudpam-ui'
+
+const node = (
+  id: string,
+  name: string,
+  type: SchemaNode['type'],
+  cidr: string,
+  children: SchemaNode[] = [],
+  conflict = false,
+): SchemaNode => ({ id, name, type, cidr, children, conflict })
+
+const schema = node('root', 'Corporate Supernet', 'supernet', '10.0.0.0/8', [
+  node('r1', 'us-east-1', 'region', '10.0.0.0/12', [
+    node('e1', 'production', 'environment', '10.0.0.0/16', [
+      node('v1', 'app-vpc', 'vpc', '10.0.0.0/18'),
+      node('v2', 'data-vpc', 'vpc', '10.0.64.0/18'),
+    ]),
+    node('e2', 'staging', 'environment', '10.1.0.0/16'),
+  ]),
+  node('r2', 'eu-west-1', 'region', '10.16.0.0/12', [
+    node('e3', 'production', 'environment', '10.16.0.0/16'),
+  ]),
+])
+
+const conflicts: SchemaConflict[] = [
+  {
+    planned_cidr: '10.16.0.0/16',
+    planned_name: 'eu-west-1 / production',
+    existing_pool_id: 314,
+    existing_pool_name: 'frankfurt-legacy',
+    existing_cidr: '10.16.0.0/18',
+    overlap_type: 'contains',
+  },
+]
+
+export function CleanPlan() {
+  return (
+    <PreviewStep
+      schema={schema}
+      conflicts={[]}
+      conflictsLoading={false}
+      conflictsError={null}
+      onExport={() => {}}
+    />
+  )
+}
+
+export function WithConflicts() {
+  return (
+    <PreviewStep
+      schema={schema}
+      conflicts={conflicts}
+      conflictsLoading={false}
+      conflictsError={null}
+      onExport={() => {}}
+    />
+  )
+}
+
+export function CheckingConflicts() {
+  return (
+    <PreviewStep
+      schema={schema}
+      conflicts={[]}
+      conflictsLoading={true}
+      conflictsError={null}
+      onExport={() => {}}
+    />
+  )
+}
+
+export function ConflictCheckFailed() {
+  return (
+    <PreviewStep
+      schema={schema}
+      conflicts={[]}
+      conflictsLoading={false}
+      conflictsError="Could not reach the conflict checker (503)."
+      onExport={() => {}}
+    />
+  )
+}

--- a/.design-sync/previews/ProtectedRoute.tsx
+++ b/.design-sync/previews/ProtectedRoute.tsx
@@ -1,0 +1,68 @@
+import { ProtectedRoute, AuthContext, previewAuth, Routes, Route } from 'cloudpam-ui'
+
+// ProtectedRoute renders no UI of its own — it either passes through to the
+// nested route via <Outlet> or redirects. Each cell therefore shows the
+// *outcome* of the guard against a small route tree, which is the only way to
+// see it work. Note the two failure modes land in different places: a missing
+// permission redirects to "/", while an unauthenticated session goes to
+// "/login". The shared provider starts the router at /pools, so the guard is
+// mounted there.
+const Box = ({ tone, title, body }: { tone: 'green' | 'amber' | 'red'; title: string; body: string }) => {
+  const palette = {
+    green: { border: '#bbf7d0', background: '#f0fdf4', title: '#166534', body: '#15803d' },
+    amber: { border: '#fde68a', background: '#fffbeb', title: '#92400e', body: '#b45309' },
+    red: { border: '#fecaca', background: '#fef2f2', title: '#991b1b', body: '#b91c1c' },
+  }[tone]
+  return (
+    <div
+      style={{
+        padding: 16,
+        border: `1px solid ${palette.border}`,
+        background: palette.background,
+        borderRadius: 8,
+      }}
+    >
+      <div style={{ fontSize: 14, fontWeight: 500, color: palette.title }}>{title}</div>
+      <div style={{ fontSize: 14, color: palette.body }}>{body}</div>
+    </div>
+  )
+}
+
+function Tree() {
+  return (
+    <Routes>
+      <Route path="/pools" element={<ProtectedRoute requiredPermission="users:list" />}>
+        <Route index element={<Box tone="green" title="Protected page rendered" body="The session satisfied the guard, so <Outlet> renders the nested route." />} />
+      </Route>
+      <Route path="/" element={<Box tone="amber" title="Redirected to /" body="Authenticated, but missing the required permission." />} />
+      <Route path="/login" element={<Box tone="red" title="Redirected to /login" body="No authenticated session while auth is enabled." />} />
+    </Routes>
+  )
+}
+
+export function PermissionGranted() {
+  return <Tree />
+}
+
+export function PermissionDenied() {
+  const viewer = {
+    ...previewAuth,
+    role: 'viewer',
+    permissions: ['pools:read'],
+    hasPermission: (p: string) => p === 'pools:read',
+  }
+  return (
+    <AuthContext.Provider value={viewer}>
+      <Tree />
+    </AuthContext.Provider>
+  )
+}
+
+export function NotAuthenticated() {
+  const anon = { ...previewAuth, isAuthenticated: false, role: null, permissions: [], hasPermission: () => false }
+  return (
+    <AuthContext.Provider value={anon}>
+      <Tree />
+    </AuthContext.Provider>
+  )
+}

--- a/.design-sync/previews/SchemaPlanner.tsx
+++ b/.design-sync/previews/SchemaPlanner.tsx
@@ -1,0 +1,12 @@
+import { SchemaPlanner } from 'cloudpam-ui'
+
+// SchemaPlanner is the wizard shell: it owns the step state internally and
+// takes no props, so a card shows it at step 1 (template selection) with the
+// step rail across the top.
+export function Wizard() {
+  return (
+    <div style={{ height: 900 }}>
+      <SchemaPlanner />
+    </div>
+  )
+}

--- a/.design-sync/previews/SearchModal.tsx
+++ b/.design-sync/previews/SearchModal.tsx
@@ -1,0 +1,17 @@
+import { SearchModal } from 'cloudpam-ui'
+
+// SearchModal renders a `fixed` backdrop + centered panel. A transform on the
+// wrapper makes it a containing block for those fixed children so the overlay
+// fills the card instead of anchoring to the viewport and being clipped.
+//
+// The component owns its query state via useSearch and only fetches after the
+// user types (300ms debounce), so a static card shows the opened palette and
+// its empty-state hint. A results-populated card would need simulated
+// keystrokes, which isn't statically renderable.
+export function Open() {
+  return (
+    <div style={{ position: 'relative', height: 448, width: '100%', transform: 'translateZ(0)' }}>
+      <SearchModal open={true} onClose={() => {}} />
+    </div>
+  )
+}

--- a/.design-sync/previews/Sidebar.tsx
+++ b/.design-sync/previews/Sidebar.tsx
@@ -1,0 +1,28 @@
+import { Sidebar, AuthContext, previewAuth } from 'cloudpam-ui'
+
+export function AdminNavigation() {
+  return (
+    <div style={{ height: 1000 }}>
+      <Sidebar onImportExport={() => {}} open={true} onClose={() => {}} />
+    </div>
+  )
+}
+
+// Nav entries are permission-gated: settings, users and audit only appear for
+// principals holding the matching permission. An operator without them sees a
+// visibly shorter rail.
+export function OperatorNavigation() {
+  const operator = {
+    ...previewAuth,
+    role: 'operator',
+    permissions: ['pools:read', 'accounts:read'],
+    hasPermission: (p: string) => ['pools:read', 'accounts:read'].includes(p),
+  }
+  return (
+    <AuthContext.Provider value={operator}>
+      <div style={{ height: 1000 }}>
+        <Sidebar onImportExport={() => {}} open={true} onClose={() => {}} />
+      </div>
+    </AuthContext.Provider>
+  )
+}

--- a/.design-sync/previews/StatusBadge.tsx
+++ b/.design-sync/previews/StatusBadge.tsx
@@ -1,0 +1,59 @@
+import { StatusBadge } from 'cloudpam-ui'
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex flex-wrap items-center gap-2">{children}</div>
+)
+
+export function PoolStatus() {
+  return (
+    <Row>
+      <StatusBadge label="active" />
+      <StatusBadge label="planned" />
+      <StatusBadge label="deprecated" />
+    </Row>
+  )
+}
+
+export function CloudProvider() {
+  return (
+    <Row>
+      <StatusBadge label="aws" variant="provider" />
+      <StatusBadge label="gcp" variant="provider" />
+      <StatusBadge label="azure" variant="provider" />
+      <StatusBadge label="on-prem" variant="provider" />
+    </Row>
+  )
+}
+
+export function AccountTier() {
+  return (
+    <Row>
+      <StatusBadge label="prd" variant="tier" />
+      <StatusBadge label="stg" variant="tier" />
+      <StatusBadge label="dev" variant="tier" />
+      <StatusBadge label="sbx" variant="tier" />
+    </Row>
+  )
+}
+
+export function AuditAction() {
+  return (
+    <Row>
+      <StatusBadge label="pool.create" variant="action" />
+      <StatusBadge label="pool.update" variant="action" />
+      <StatusBadge label="account.delete" variant="action" />
+    </Row>
+  )
+}
+
+export function PoolType() {
+  return (
+    <Row>
+      <StatusBadge label="supernet" variant="type" />
+      <StatusBadge label="region" variant="type" />
+      <StatusBadge label="environment" variant="type" />
+      <StatusBadge label="vpc" variant="type" />
+      <StatusBadge label="subnet" variant="type" />
+    </Row>
+  )
+}

--- a/.design-sync/previews/StrategyStep.tsx
+++ b/.design-sync/previews/StrategyStep.tsx
@@ -1,0 +1,13 @@
+import { StrategyStep } from 'cloudpam-ui'
+
+export function RegionFirst() {
+  return <StrategyStep strategy="region-first" setStrategy={() => {}} />
+}
+
+export function EnvironmentFirst() {
+  return <StrategyStep strategy="environment-first" setStrategy={() => {}} />
+}
+
+export function AccountFirst() {
+  return <StrategyStep strategy="account-first" setStrategy={() => {}} />
+}

--- a/.design-sync/previews/TemplateStep.tsx
+++ b/.design-sync/previews/TemplateStep.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import { TemplateStep } from 'cloudpam-ui'
+import type { Blueprint } from 'cloudpam-ui'
+
+// TemplateStep renders the built-in BLUEPRINTS list itself (and pulls each
+// card's icon from there), so a preview only has to supply the fields the
+// *selected* summary panel reads: rootCidr, hierarchy and recommended. The
+// 'custom' branch reads none of them, hence the id-only stand-in for it.
+const asBlueprint = (id: string) => ({ id }) as Blueprint
+
+const enterpriseBlueprint = {
+  id: 'enterprise-multi-region',
+  name: 'Enterprise Multi-Region',
+  description: 'For organizations with 3+ regions and 50+ accounts',
+  rootCidr: '10.0.0.0/8',
+  hierarchy: [
+    { level: 'region', prefixSize: 12, description: '16 regions, 1M IPs each' },
+    { level: 'environment', prefixSize: 16, description: '16 envs/region, 65K IPs' },
+    { level: 'vpc', prefixSize: 20, description: '16 accounts/env, 4K IPs' },
+    { level: 'subnet', prefixSize: 24, description: '16 subnets/account, 254 hosts' },
+  ],
+  recommended: [
+    'AWS Organizations with 50+ accounts',
+    'Multi-region active-active',
+    'Large Kubernetes deployments',
+  ],
+} as unknown as Blueprint
+
+export function Unselected() {
+  return (
+    <TemplateStep
+      selectedBlueprint={null}
+      setSelectedBlueprint={() => {}}
+      customCidr="10.0.0.0/8"
+      setCustomCidr={() => {}}
+    />
+  )
+}
+
+export function EnterpriseSelected() {
+  return (
+    <TemplateStep
+      selectedBlueprint={enterpriseBlueprint}
+      setSelectedBlueprint={() => {}}
+      customCidr="10.0.0.0/8"
+      setCustomCidr={() => {}}
+    />
+  )
+}
+
+export function CustomSchema() {
+  const [cidr, setCidr] = useState('172.16.0.0/12')
+  return (
+    <TemplateStep
+      selectedBlueprint={asBlueprint('custom')}
+      setSelectedBlueprint={() => {}}
+      customCidr={cidr}
+      setCustomCidr={setCidr}
+    />
+  )
+}

--- a/.design-sync/previews/ToastContainer.tsx
+++ b/.design-sync/previews/ToastContainer.tsx
@@ -1,0 +1,39 @@
+import { ToastContainer, ToastContext } from 'cloudpam-ui'
+
+// ToastContainer reads its list from ToastContext and renders nothing when the
+// list is empty. The shared preview provider deliberately supplies an empty
+// list (so every other card isn't covered in floating toasts), so this preview
+// nests its own provider to show the real populated states.
+// The container is `fixed right-4 bottom-4`, so in a preview card it would
+// anchor to the viewport and be clipped. A transform on the wrapper makes it a
+// containing block for fixed descendants, so the real component renders in
+// place with its own positioning intact.
+const withToasts = (toasts: Array<{ id: string; message: string; type: 'info' | 'error' | 'success' }>) => (
+  <ToastContext.Provider value={{ toasts, showToast: () => {} }}>
+    <div style={{ position: 'relative', height: 224, width: '100%', transform: 'translateZ(0)' }}>
+      <ToastContainer />
+    </div>
+  </ToastContext.Provider>
+)
+
+export function Success() {
+  return withToasts([{ id: '1', message: 'Pool "production" created.', type: 'success' }])
+}
+
+export function Error() {
+  return withToasts([
+    { id: '2', message: 'Could not delete pool: 12 child pools still assigned.', type: 'error' },
+  ])
+}
+
+export function Info() {
+  return withToasts([{ id: '3', message: 'Discovery sync queued for 4 accounts.', type: 'info' }])
+}
+
+export function Stacked() {
+  return withToasts([
+    { id: '4', message: 'Schema applied — 18 pools created.', type: 'success' },
+    { id: '5', message: 'Drift detected in us-west-2.', type: 'info' },
+    { id: '6', message: 'Import failed on row 37.', type: 'error' },
+  ])
+}

--- a/.design-sync/previews/TreeNode.tsx
+++ b/.design-sync/previews/TreeNode.tsx
@@ -1,0 +1,64 @@
+import { TreeNode } from 'cloudpam-ui'
+import type { SchemaNode } from 'cloudpam-ui'
+
+const node = (
+  id: string,
+  name: string,
+  type: SchemaNode['type'],
+  cidr: string,
+  children: SchemaNode[] = [],
+  conflict = false,
+): SchemaNode => ({ id, name, type, cidr, children, conflict })
+
+const plannedRegion = node('r1', 'us-east-1', 'region', '10.0.0.0/12', [
+  node('e1', 'production', 'environment', '10.0.0.0/16', [
+    node('v1', 'app-vpc', 'vpc', '10.0.0.0/18'),
+    node('v2', 'data-vpc', 'vpc', '10.0.64.0/18'),
+  ]),
+  node('e2', 'staging', 'environment', '10.1.0.0/16', [node('v3', 'app-vpc', 'vpc', '10.1.0.0/18')]),
+])
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ maxWidth: 576, fontSize: 14 }}>{children}</div>
+)
+
+// An empty set collapses every node. Omitting defaultExpanded entirely instead
+// auto-expands anything above depth 2.
+export function Collapsed() {
+  return (
+    <Frame>
+      <TreeNode node={plannedRegion} defaultExpanded={new Set()} />
+    </Frame>
+  )
+}
+
+// defaultExpanded takes the set of node ids that start open.
+export function Expanded() {
+  return (
+    <Frame>
+      <TreeNode node={plannedRegion} defaultExpanded={new Set(['r1', 'e1', 'e2'])} />
+    </Frame>
+  )
+}
+
+export function WithConflict() {
+  return (
+    <Frame>
+      <TreeNode
+        node={node('r2', 'eu-west-1', 'region', '10.16.0.0/12', [
+          node('e3', 'production', 'environment', '10.16.0.0/16', [], true),
+          node('e4', 'staging', 'environment', '10.17.0.0/16'),
+        ])}
+        defaultExpanded={new Set(['r2'])}
+      />
+    </Frame>
+  )
+}
+
+export function LeafSubnet() {
+  return (
+    <Frame>
+      <TreeNode node={node('s1', 'private-a', 'subnet', '10.0.1.0/24')} />
+    </Frame>
+  )
+}

--- a/.design-sync/previews/UpdateBanner.tsx
+++ b/.design-sync/previews/UpdateBanner.tsx
@@ -1,0 +1,37 @@
+import { UpdateBanner } from 'cloudpam-ui'
+
+// UpdateBanner is admin-gated and driven entirely by GET /api/v1/updates.
+// Preview cards run with no CloudPAM backend, so the real fetch 404s and the
+// banner correctly renders nothing. Serving the release payload the API would
+// return is what makes the component's actual UI visible; the component code
+// itself is untouched.
+if (!(globalThis as { __dsUpdateStub?: boolean }).__dsUpdateStub) {
+  ;(globalThis as { __dsUpdateStub?: boolean }).__dsUpdateStub = true
+  const real = globalThis.fetch
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(typeof input === 'string' ? input : (input as Request).url ?? input)
+    if (url.includes('/api/v1/updates')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            current_version: 'v1.3.2',
+            latest_version: '1.4.0',
+            update_available: true,
+            release_url: 'https://github.com/BadgerOps/cloudpam/releases/tag/v1.4.0',
+            release_notes:
+              '- Drift detection for discovered VPCs\n- Faster CIDR containment search\n- Fixes an OIDC group-mapping regression',
+            published_at: '2026-07-30T12:00:00Z',
+            checked_at: '2026-08-02T09:15:00Z',
+            upgrade_supported: true,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    }
+    return real(input, init)
+  }) as typeof fetch
+}
+
+export function ReleaseAvailable() {
+  return <UpdateBanner />
+}

--- a/.design-sync/previews/UsersAdminPanel.tsx
+++ b/.design-sync/previews/UsersAdminPanel.tsx
@@ -1,0 +1,87 @@
+import { UsersAdminPanel } from 'cloudpam-ui'
+
+// UsersAdminPanel loads /api/v1/auth/users, /auth/roles and /auth/permissions.
+// With no CloudPAM backend behind the preview those 404 and the panel renders
+// two red error banners over an empty table. Serving the payloads the real API
+// returns is what makes the populated table visible; the component is unchanged.
+if (!(globalThis as { __dsUsersStub?: boolean }).__dsUsersStub) {
+  ;(globalThis as { __dsUsersStub?: boolean }).__dsUsersStub = true
+  const real = globalThis.fetch
+  const json = (body: unknown) =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  const users = [
+    {
+      id: 'u-1024',
+      username: 'dana.reyes',
+      email: 'dana.reyes@example.com',
+      display_name: 'Dana Reyes',
+      role: 'admin',
+      is_active: true,
+      created_at: '2026-01-14T09:20:00Z',
+      last_login_at: '2026-08-01T08:12:00Z',
+      failed_login_attempts: 0,
+    },
+    {
+      id: 'u-1088',
+      username: 'sam.okafor',
+      email: 'sam.okafor@example.com',
+      display_name: 'Sam Okafor',
+      role: 'operator',
+      is_active: true,
+      created_at: '2026-03-02T11:05:00Z',
+      last_login_at: '2026-07-31T17:44:00Z',
+      failed_login_attempts: 0,
+    },
+    {
+      id: 'u-1131',
+      username: 'ci-pipeline',
+      email: 'ci@example.com',
+      display_name: 'CI Pipeline',
+      role: 'viewer',
+      is_active: false,
+      created_at: '2026-05-19T13:30:00Z',
+      last_login_at: null,
+      failed_login_attempts: 0,
+    },
+    {
+      id: 'u-1150',
+      username: 'jules.tan',
+      email: 'jules.tan@example.com',
+      display_name: 'Jules Tan',
+      role: 'operator',
+      is_active: true,
+      created_at: '2026-06-08T08:00:00Z',
+      last_login_at: '2026-07-20T09:02:00Z',
+      failed_login_attempts: 5,
+      locked_at: '2026-07-20T09:05:00Z',
+      lockout_until: '2026-08-03T09:05:00Z',
+    },
+  ]
+  const roles = ['admin', 'operator', 'viewer'].map((r) => ({
+    id: r,
+    name: r,
+    description: `Built-in ${r} role`,
+    is_builtin: true,
+    permissions: [],
+  }))
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(typeof input === 'string' ? input : (input as Request).url ?? input)
+    if (url.includes('/api/v1/auth/users')) return json({ users })
+    if (url.includes('/api/v1/auth/roles')) return json({ roles })
+    if (url.includes('/api/v1/auth/permissions')) return json({ permissions: [] })
+    return real(input, init)
+  }) as typeof fetch
+}
+
+export function UserList() {
+  return <UsersAdminPanel />
+}
+
+export function Embedded() {
+  return <UsersAdminPanel embedded={true} />
+}

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,12 @@ result-*
 *.tsbuildinfo
 .codex
 PROMPTING.txt
+
+# design-sync (claude.ai/design import)
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+ui/.ds-css/
+ui/types/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ The storage layer uses build tags to switch between implementations:
 |---------|---------|--------|
 | `internal/auth` | Authentication, RBAC, users, sessions | Implemented |
 | `internal/audit` | Audit logging | Implemented |
-| `internal/discovery` | Cloud resource discovery (Collector, SyncService, AWS Org) | Implemented (AWS single + org) |
+| `internal/discovery` | Cloud resource discovery (Collector, SyncService, AWS Org, GCP, drift) | Implemented (AWS single + org, GCP; **no Azure collector**) |
 | `internal/observability` | Logging, metrics, OpenTelemetry tracing (opt-in, OTLP/HTTP) | Implemented |
 | `internal/cidr` | CIDR math utilities | Implemented |
 | `internal/planning` | Smart planning engine (analysis, gaps, fragmentation, compliance, recommendations) | Implemented (Phase 3 analysis + recommendations) |
@@ -679,6 +679,12 @@ cloudpam/
 │   │   ├── settings_memory.go   # In-memory SettingsStore
 │   │   ├── oidc.go              # OIDCProviderStore interface
 │   │   ├── oidc_memory.go       # In-memory OIDCProviderStore
+│   │   ├── drift.go / drift_memory.go             # DriftStore
+│   │   ├── network.go / network_memory.go         # NetworkObject + relationship store
+│   │   ├── conversations.go / conversations_memory.go # AI planning sessions
+│   │   ├── utilization.go / utilization_memory.go # Pool utilization
+│   │   ├── clone.go        # Deep-copy helpers
+│   │   ├── interfaces.go   # Shared store interfaces
 │   │   ├── errors.go       # Sentinel errors (ErrNotFound, etc.)
 │   │   ├── sqlite/         # SQLite implementation
 │   │   │   ├── sqlite.go
@@ -692,6 +698,9 @@ cloudpam/
 │   │       └── migrator.go
 │   ├── discovery/          # Cloud resource discovery
 │   │   ├── collector.go    # Collector interface + SyncService
+│   │   ├── drift.go        # Drift detection (discovered vs managed)
+│   │   ├── gcp/            # GCP collector
+│   │   │   └── collector.go
 │   │   └── aws/            # AWS collector (VPCs, subnets, EIPs)
 │   │       ├── collector.go
 │   │       ├── org.go          # ListOrgAccounts (AWS Organizations)
@@ -710,6 +719,7 @@ cloudpam/
 │   ├── audit/              # Audit logging
 │   ├── cidr/               # Reusable CIDR math utilities
 │   ├── validation/         # Input validation
+│   ├── testutil/           # Shared test helpers
 │   ├── planning/           # Smart planning engine (analysis, gaps, fragmentation, compliance, recommendations)
 │   │   └── llm/            # LLM provider abstraction (OpenAI-compatible)
 │   ├── observability/      # Logging, metrics, tracing
@@ -788,9 +798,13 @@ See `IMPLEMENTATION_ROADMAP.md` for the detailed 20-week plan. Summary:
 ### Remaining Work
 
 **Phase 2 gaps (Cloud Integration):**
-- GCP discovery collector
-- Azure discovery collector
+- ~~GCP discovery collector~~ ✅ implemented (`internal/discovery/gcp/collector.go`, wired in `cmd/cloudpam/main.go`)
+- Azure discovery collector — **still missing** (`internal/discovery/` has `aws/` and `gcp/` only)
 - ~~Drift detection (discovered vs managed state)~~ ✅ implemented (`internal/api/drift_handlers.go`, migration `0018`, `DriftPage`)
+
+**IPv4 only.** `internal/validation/validation.go` exports `ErrIPv6NotSupported` and
+rejects any non-`Is4()` prefix; `internal/cidr/` and `internal/api/cidr.go` assume IPv4
+throughout. Dual-stack IPAM is a substantial unbuilt workstream, not a config flag.
 
 **Phase 5 (Enterprise):**
 - Multi-tenancy enforcement (schema exists, not enforced)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,12 @@ CloudPAM is an intelligent IP Address Management (IPAM) platform designed to man
 
 The project is in **Phase 5** of a 5-phase, 20-week roadmap. See `IMPLEMENTATION_ROADMAP.md` for the complete plan.
 
-**Current State** (Sprint 20 complete):
+**Current State** (Sprint 20 complete; further work has landed since — drift detection, network objects/relationships, custom roles, and self-upgrade are all implemented and are NOT reflected in the sprint numbering below):
+- Self-upgrade: release check, in-place upgrade, progress polling (`update_handlers.go`, `UpdatesPage`)
+- Network objects & relationships with conflict detection (`network_handlers.go`, migration `0021`)
+- Custom roles + permission catalog (`role_handlers.go`, migration `0020`)
+- Drift detection: discovered vs managed state (`drift_handlers.go`, migration `0018`)
+- Account lockout (migration `0019`)
 - SSO/OIDC: generic OIDC provider integration, JIT user provisioning, role mapping, silent session re-auth, client secret encryption, local auth toggle, provider management UI (Sprint 20)
 - Auth hardening: auth-always default, CSRF protection, password policy (NIST 800-63B), session limits, login rate limiting, trusted proxies, security settings UI, API key scope elevation prevention (Sprint 19)
 - AI Planning: LLM-powered conversational planning with SSE streaming, plan generation and apply (Sprints 17-18)
@@ -213,7 +218,7 @@ The storage layer uses build tags to switch between implementations:
   - Migrations apply automatically on startup
   - Forward-only; no rollback support
   - Use `./cloudpam -migrate status` to check schema version
-  - Current migrations: `0001_init.sql` through `0017_oidc_providers.sql`
+  - Current migrations: `0001_init.sql` through `0021_network_objects_relationships.sql` (21 files; new work starts at `0022`)
 
 - **PostgreSQL Support** (`-tags postgres`)
   - Production-grade database with native CIDR operations
@@ -270,6 +275,21 @@ The storage layer uses build tags to switch between implementations:
   - `/api/v1/settings/oidc/providers` - OIDC provider admin CRUD (GET/POST)
   - `/api/v1/settings/oidc/providers/{id}` - OIDC provider admin (GET/PATCH/DELETE)
   - `/api/v1/settings/oidc/providers/{id}/test` - test OIDC provider connection (POST)
+  - `/api/v1/auth/roles` - list/create custom roles (GET/POST)
+  - `/api/v1/auth/roles/{name}` - role get/update/delete (GET/PATCH/DELETE)
+  - `/api/v1/auth/permissions` - permission catalog (GET)
+  - `/api/v1/drift` - list drift items (GET)
+  - `/api/v1/drift/detect` - run drift detection (POST)
+  - `/api/v1/drift/{id}` - drift item detail + resolution (GET/POST)
+  - `/api/v1/network/flat` - flat network view (GET)
+  - `/api/v1/network/hierarchy` - hierarchical network view (GET)
+  - `/api/v1/network/merged` - merged managed + discovered view (GET)
+  - `/api/v1/network/conflicts` - overlapping-CIDR conflicts (GET)
+  - `/api/v1/network/objects` - network object CRUD (GET/POST/PATCH)
+  - `/api/v1/network/relationships` - relationship CRUD (GET/POST)
+  - `/api/v1/updates` - check for a new release (GET)
+  - `/api/v1/updates/upgrade` - trigger self-upgrade (POST)
+  - `/api/v1/updates/status` - upgrade progress (GET), acknowledge (POST `/ack`)
   - `/api/v1/search` - unified search with CIDR containment queries
   - `/api/v1/discovery/resources` - list discovered cloud resources (filterable)
   - `/api/v1/discovery/resources/{id}` - get single discovered resource
@@ -388,11 +408,11 @@ When adding endpoints:
 ### Frontend Development
 
 - Unified React/Vite/TypeScript SPA in `ui/` directory
-- Uses `react-router-dom` for client-side routing with 7 page routes
+- Uses `react-router-dom` for client-side routing (21 page components in `ui/src/pages/`)
 - Tailwind CSS for styling, `lucide-react` for icons
 - Static assets built to `web/dist/` and embedded at build time via `web/embed.go`
 - UI is served at `/` by `handleSPA()` with SPA fallback for client-side routes
-- API hooks in `ui/src/hooks/` (usePools, useAccounts, useBlocks, useAudit, useDiscovery, useAuth, useToast, useRecommendations, useOIDCProviders, useOIDCAdmin, useSessionRefresh)
+- API hooks in `ui/src/hooks/` — 23 hooks: useAIPlanner, useAccounts, useApiKeys, useAudit, useAuth, useBlocks, useDiscovery, useDrift, useLatestRequest, useNetwork, useOIDCAdmin, useOIDCProviders, usePendingAction, usePools, useRecommendations, useRoles, useSearch, useSessionRefresh, useSettings, useTheme, useToast, useUpdates, useUsers
 - Shared types in `ui/src/api/types.ts`, API client in `ui/src/api/client.ts`
 - Schema Planner wizard lives in `ui/src/wizard/` (existing from Sprint 8)
 - Run `cd ui && npm run dev` for hot-reload development (proxied to Go backend)
@@ -638,6 +658,13 @@ cloudpam/
 │   │   ├── recommendation_handlers.go # Recommendation API (generate, apply, dismiss)
 │   │   ├── ai_handlers.go       # AI Planning API (chat, sessions, plan apply)
 │   │   ├── oidc_handlers.go     # OIDC login/callback/refresh + admin CRUD
+│   │   ├── role_handlers.go       # Custom roles + permission catalog
+│   │   ├── drift_handlers.go      # Drift detection (discovered vs managed)
+│   │   ├── network_handlers.go    # Network objects, relationships, conflicts
+│   │   ├── update_handlers.go     # Release check + self-upgrade
+│   │   ├── analysis_handlers.go   # Analysis engine API
+│   │   ├── search_handlers.go     # Unified search
+│   │   └── bootstrap_handlers.go  # First-boot setup
 │   │   ├── middleware.go   # Middleware (logging, auth, rate limit, trusted proxies)
 │   │   ├── context.go      # Request context helpers
 │   │   ├── cidr.go         # IPv4 CIDR validation utilities
@@ -687,13 +714,17 @@ cloudpam/
 │   │   └── llm/            # LLM provider abstraction (OpenAI-compatible)
 │   ├── observability/      # Logging, metrics, tracing
 │   └── docs/               # Internal documentation handlers
-├── migrations/             # SQL migrations (0001-0017)
+├── migrations/             # SQL migrations (0001-0021)
 │   ├── embed.go
 │   ├── 0001_init.sql
 │   ├── 0002_accounts_meta.sql
 │   ├── ...
 │   ├── 0008_discovered_resources.sql  # Discovery tables
 │   ├── 0017_oidc_providers.sql        # OIDC providers + user OIDC columns
+│   ├── 0018_drift_items.sql           # Drift detection items
+│   ├── 0019_account_lockout.sql       # Account lockout state
+│   ├── 0020_rbac_permission_catalog.sql # Custom roles + permission catalog
+│   ├── 0021_network_objects_relationships.sql # Network objects + relationships
 │   └── postgres/           # PostgreSQL migrations
 ├── deploy/                 # Deployment configurations
 │   ├── terraform/aws-org-discovery/  # AWS Organizations discovery IAM
@@ -759,7 +790,7 @@ See `IMPLEMENTATION_ROADMAP.md` for the detailed 20-week plan. Summary:
 **Phase 2 gaps (Cloud Integration):**
 - GCP discovery collector
 - Azure discovery collector
-- Drift detection (discovered vs managed state)
+- ~~Drift detection (discovered vs managed state)~~ ✅ implemented (`internal/api/drift_handlers.go`, migration `0018`, `DriftPage`)
 
 **Phase 5 (Enterprise):**
 - Multi-tenancy enforcement (schema exists, not enforced)
@@ -771,7 +802,7 @@ See `IMPLEMENTATION_ROADMAP.md` for the detailed 20-week plan. Summary:
 
 When implementing new features, follow this order:
 1. Open GitHub issues (check `gh issue list`)
-2. Phase 2 gaps (GCP/Azure discovery, drift detection)
+2. Phase 2 gaps (GCP/Azure discovery)
 3. Phase 5 enterprise features (multi-tenancy, SSO)
 
 ## Additional Documentation

--- a/docs/design/identity-decisions.md
+++ b/docs/design/identity-decisions.md
@@ -1,0 +1,87 @@
+<!--
+Pulled from the "CloudPAM Design System" Claude Design project
+(templates/identity-decisions.md) on 2026-08-04. Source of truth is the design
+project; re-pull rather than editing in place if it changes there.
+-->
+
+# Identity model — decisions
+
+Answers given 3 Aug 2026. These are settled unless noted; everything in
+`settings-shell/` follows them.
+
+| Question | Decision |
+|---|---|
+| SSO | **Already shipped** — SAML 2.0 and OIDC both in production |
+| Provisioning | **SCIM**, owning both user create/deprovision **and** group→role mapping |
+| Local accounts | **Break-glass admin only** — not a general account type |
+| Service accounts | **Separate entity.** No password, no mailbox; holds a role and owns API keys |
+| Pool scoping | **Yes, eventually** — teams own pool subtrees and roles scope to them |
+| Role source | **Settled: conditional on SCIM** (see below) |
+
+## Where a role comes from — settled
+
+**SCIM presence decides it.** There is no user-facing preference:
+
+- **SCIM enabled** → roles come from IdP group→role mapping. The role cell in People is
+  read-only text with the source group beneath it; all changes happen in the mapping
+  table. Break-glass local accounts are the exception and are assigned directly.
+- **SCIM disabled** → each person is assigned a built-in or custom role directly, per
+  user. Group membership is still recorded and mappings are shown but not enforced, so
+  turning provisioning on later is not a data migration.
+
+The `scimEnabled` tweak in the template shows both states.
+
+Two consequences worth naming:
+
+1. **Enabling SCIM silently overrides every per-user role** with whatever the mapping
+   says. That needs a preview-and-confirm step — "12 people will change role, 3 will lose
+   access entirely" — not a toggle that applies instantly.
+2. **Custom roles still need a mapping target.** Deleting a custom role that a mapping
+   points at locks out everyone in that group (see `ROLE_MISSING` in Denied sign-ins).
+   Role deletion must check mappings first — this feeds the role-lifecycle gap.
+
+## Unmapped sign-in — settled
+
+**Denied, never defaulted.** No fallback-to-viewer. Every denial is written to the audit
+log with a machine-readable reason, and the Identity Providers pane surfaces the last 7
+days inline so the failure is visible where it can be fixed:
+
+| Code | Meaning |
+|---|---|
+| `NO_GROUP_MATCH` | authenticated, but no mapping covers any group they hold |
+| `ROLE_MISSING` | matched a mapping whose target role no longer exists |
+| `NOT_A_PERSON` | a service account attempted interactive sign-in |
+
+Each row links to its audit entry. The list is the fastest signal that a mapping is
+wrong — a new hire's first sign-in failing should be visible to an admin without anyone
+filing a ticket.
+
+## What changed in the shell
+
+- **Users → People.** Source column (SAML / OIDC / SCIM / LOCAL) with the IdP group
+  beneath it. Role cell is read-only under SCIM, a select without it.
+- **Deactivate is local-only.** Federated people show "Deprovision in Okta" instead —
+  deactivating them here would just be undone at the next SCIM sync. Unlock stays
+  available for everyone, since lockout is CloudPAM-side.
+- **Break-glass banner** counts local accounts and states the expectation (keep it to
+  one, rotate, expect audit entries). Creating one generates the password rather than
+  asking an admin to invent it, and says it's shown once.
+- **Invite flow removed.** With SCIM, people appear on provisioning or first sign-in.
+  The only account an admin creates by hand is break-glass.
+- **API Keys pane → Service Accounts.** Keys are nested under the account that owns
+  them, since a key alone has no owner to hold accountable. Accounts with no team get an
+  `UNOWNED` badge; an account with no keys says it cannot authenticate yet.
+- **New permissions:** `idp:manage` (providers + mapping) added to the matrix; the group
+  formerly called "Users & Roles" is now "Identity".
+- Role cards show `Scope: all pools` — a placeholder for the tenancy work, so the
+  concept has a home before it has behavior.
+
+## Still open
+
+1. **Which provider wins** when someone exists in both Okta SAML and Google OIDC with
+   the same email? Today the template shows one source per person.
+2. **Can SCIM deprovisioning remove the last admin?** Needs a guard either way.
+3. **Do service accounts get scoped roles** once tenancy lands, or stay global?
+4. **Break-glass password rotation** — enforced, or advisory as the banner implies?
+5. **Enabling SCIM needs a diff step** (see above) — worth designing alongside the
+   first-run states gap.

--- a/docs/design/primitives-contracts.md
+++ b/docs/design/primitives-contracts.md
@@ -1,0 +1,110 @@
+<!--
+Prop contracts extracted from the "CloudPAM Design System" Claude Design project,
+templates/primitives/Primitives.dc.html, on 2026-08-04. The mockups are DC
+templates and need the DC runtime, so they are not copied into the repo — open
+them in the design project to see them render. This file is the actionable part.
+-->
+
+# Config primitives — prop contracts
+
+Source of truth for `docs/design/repo-changes.md` §4. Verbatim from the mockup unless
+marked **[deviation]**.
+
+```ts
+interface ModalProps {
+  open: boolean
+  title: string
+  description?: string
+  size?: 'sm' | 'md' | 'lg'
+  onClose: () => void
+  footer?: React.ReactNode
+  children: React.ReactNode
+}
+
+interface ConfirmDialogProps extends Omit<ModalProps, 'footer'> {
+  confirmLabel: string
+  tone?: 'default' | 'danger'
+  onConfirm: () => void
+}
+
+interface FieldProps {
+  label: string
+  hint?: string
+  error?: string
+  required?: boolean
+  htmlFor?: string
+  children: React.ReactNode
+}
+
+interface Column<T> {
+  key: string
+  label: string
+  width?: string
+  align?: 'left' | 'right'
+  priority?: 1 | 2 | 3
+  sortable?: boolean
+  render?: (row: T) => React.ReactNode
+}
+
+interface DataTableProps<T> {
+  columns: Column<T>[]
+  rows: T[]
+  rowKey: (row: T) => string
+  loading?: boolean
+  error?: string
+  empty?: React.ReactNode
+  toolbar?: React.ReactNode
+}
+
+interface EmptyStateProps {
+  title: string
+  description?: string
+  action?: { label: string; onClick: () => void }
+}
+```
+
+## Gaps in the mockup, and how they're resolved
+
+| Gap | Resolution |
+|---|---|
+| **`Toggle` has no interface.** It is the only one of the six without a `pre` block; the heading gives `<Toggle checked onChange label>`. | **[deviation]** `interface ToggleProps { checked: boolean; onChange: (checked: boolean) => void; label: string; hint?: string; disabled?: boolean }`. The mockup's markup supplies the behavior: `role="switch"`, `aria-checked`, and an accessible name of `` `${label}, ${on ? 'on' : 'off'}` ``. |
+| **`DataTable` cannot express both empty states.** `primitives.md` rule 4 requires *filtered-empty* and *never-configured* to be different designs, but the contract has a single `empty?` slot. | **[deviation]** Split into `empty?: React.ReactNode` (never configured) and `emptyFiltered?: React.ReactNode` (search returned nothing). Without this the caller has to branch, which is exactly what the rule forbids. |
+| **`size` widths undefined.** | **[deviation]** Taken from the mockup's own markup: `sm` = 420px (its ConfirmDialog), `md` = 480px (its Modal), `lg` = 720px. |
+| **`priority` semantics undefined.** The reference implementation never sets it. | **[deviation]** `1` always visible; `2` hidden below `md`; `3` hidden below `lg`. Default `1`. |
+| **`EmptyState` has no icon prop** though §4 says it replaces "centered grey text with an opacity-40 icon". | Left out. The mockup renders a dashed square placeholder, not an icon; add later if a caller needs one. |
+
+## Behavioral contract for `Modal`
+
+From the mockup's own copy — "Escape closes, the backdrop closes, focus is trapped inside,
+and the page behind cannot scroll — none of which the current hand-rolled overlays do
+consistently." All four are required; `SearchModal` implements only Escape.
+
+## Toast: mockup vs spec
+
+The mockup's toast is bottom-centre, dark pill, `role="status"`, 2600 ms, single (a new one
+replaces the old). `repo-changes.md` §5 asks for 2.5 s default / **6 s with Undo**.
+
+**The mockup has no Undo affordance at all**, so §5 is the authority there. CloudPAM's
+current `ToastContainer` differs from both: bottom-**right**, white card with a coloured
+border, **stacking**, 3000 ms, and no `role="status"`.
+
+## Pool-type colour mockup — validation
+
+`templates/pool-type-color/PoolTypeColor.dc.html` proposes the same fix as
+`docs/superpowers/plans/2026-08-04-pool-type-color-and-status-badges.md`, but two of its
+claims do not survive contact with the code:
+
+1. **Its headline example is unreachable.** The mockup's "TODAY" column shows pools typed
+   `root` and `account` falling through to grey, and it lists eight entries including both.
+   But `internal/domain/types.go` defines exactly five pool types and `IsValidPoolType`
+   rejects everything else, so **no pool can have type `root` or `account`**. In the
+   frontend, `root` is a *node id* (`useSchemaGenerator.ts:22`, on a node whose type is
+   `supernet`) and `account` is a *search-result kind* (`SearchModal.tsx:45`). The real
+   bug — `subnet` rendering grey in `TreeNode` but orange via `getPoolTypeColor` — stands.
+2. **It contradicts itself on the de-emphasis default.** The template's `data-props`
+   default is `"ring"`, while `renderVals()` falls back to `'opacity'`, and §6 of
+   `repo-changes.md` states opacity is the recommendation. The plan uses **opacity**.
+
+Its code sample also dims on `isUncommitted`, which has no source in `SchemaNode` — and in
+the wizard every node is uncommitted, so it would dim the whole tree. The plan dims on
+`type === 'subnet'`, which is what §6 actually describes.

--- a/docs/design/primitives.md
+++ b/docs/design/primitives.md
@@ -1,0 +1,61 @@
+<!--
+Pulled from the "CloudPAM Design System" Claude Design project
+(templates/primitives/README.md) on 2026-08-04. Source of truth is the design
+project; re-pull rather than editing in place if it changes there.
+The working implementations live in that project's templates/primitives/Primitives.dc.html.
+-->
+
+# Config primitives — the standard
+
+Every new CloudPAM configuration or administration screen uses these six. Do not
+hand-roll an overlay, a label/input pair, a switch, or a table again.
+
+Open `Primitives.dc.html` for the working implementations and full prop contracts.
+`../settings-shell/` is the standard applied end to end.
+
+## The set
+
+| Primitive | Use it for | Never instead |
+|---|---|---|
+| `Modal` | any overlay | a bespoke fixed-inset div |
+| `ConfirmDialog` | destructive or irreversible actions | firing the action on click |
+| `Field` | every form control | a loose `<label>` + `<input>` |
+| `Toggle` | booleans that apply immediately | a checkbox, or a button that reads as a badge |
+| `DataTable` | any list of records | a bare `<table>` |
+| `EmptyState` | zero results, zero records, filtered-out | centered grey "No results" text |
+
+## Rules
+
+1. **Destructive actions get `ConfirmDialog`, never a bare click.** If the action is
+   reversible, skip the dialog and give the toast an Undo instead — one interruption or
+   the other, not both.
+2. **Validation lives in `Field`'s `error`, not in a toast** and not in a red paragraph
+   at the foot of the form. Mark the field that failed.
+3. **Every mutation confirms itself** via `ToastContext`. Reversible ones carry Undo at
+   6s; plain confirmations get 2.5s. Never toast navigation or anything already visible.
+4. **`DataTable` needs all five states** wired: loading, error, populated,
+   **filtered-empty**, and **never-configured**. The last two are different designs, not
+   one: filtered-empty says "no matches, clear the filter"; never-configured explains what
+   the feature is for and offers the first action. A table with only the populated case is
+   unfinished.
+5. **Columns declare `priority`**, so narrow viewports drop the lowest-value column
+   first instead of hiding three at once.
+6. **`role="switch"` with state in the accessible name** on every `Toggle`, and
+   `aria-invalid` on every errored `Field`.
+7. **Status text goes through `StatusBadge`.** If a label renders grey, the vocabulary
+   is missing an entry — add it to `getStatusBadgeClass` rather than styling a one-off
+   pill.
+
+## Theming
+
+Both templates carry a `theme` tweak. The palette is CSS custom properties set on
+`:root` at mount, with light values as inline `var()` fallbacks — so the design paints
+immediately while streaming and no style attribute contains a template hole. The root
+also gets the `.dark` class, so DS components keep working through their own `dark:`
+variants. Reuse this pattern; it is the only approach that gets dark mode into a
+template without duplicating markup.
+
+## Pending upstream
+
+`Modal`, `ConfirmDialog`, `Field`, `Toggle`, `DataTable`, and `EmptyState` do not exist
+in `cloudpam-ui` yet — see `../repo-changes.md` §4. Until they land, copy from here.

--- a/docs/design/repo-changes.md
+++ b/docs/design/repo-changes.md
@@ -1,0 +1,349 @@
+<!--
+Pulled from the "CloudPAM Design System" Claude Design project
+(templates/repo-changes.md) on 2026-08-04. Source of truth is the design
+project; re-pull rather than editing in place if it changes there.
+-->
+
+# Upstream changes needed in `ui/`
+
+These belong in the CloudPAM repo, not here — this design system is synced read-only.
+Everything below came out of the Administration/Configuration review; the templates in
+this folder are the reference implementations.
+
+Identity decisions that drive §1 and §2 are recorded in `identity-decisions.md`.
+
+---
+
+## 1. Collapse the Administration nav to one Settings destination
+
+`ui/src/components/Sidebar.tsx`
+
+Today the Administration group lists five siblings, three of which are children of
+`/config`:
+
+| Current | Route |
+|---|---|
+| API Keys | `/config/api-keys` |
+| Release Notes | `/changelog` |
+| Identity | `/identity` |
+| Configuration | `/config` |
+| Log Destinations | `/config/log-destinations` |
+
+Panes, after the identity decisions: `/settings/people`, `/settings/identity-providers`,
+`/settings/service-accounts`, `/settings/access`, `/settings/log-destinations`,
+`/settings/system`. Note **API Keys is no longer a pane** — keys live under the service
+account that owns them.
+
+Replace with a single entry:
+
+```tsx
+{(canSettings || canUsers) && (
+  <NavLink to="/settings" className={linkClass}>
+    <Settings className="w-5 h-5 flex-shrink-0" />
+    <span>Settings</span>
+  </NavLink>
+)}
+```
+
+- **Bug fix included:** `NavLink to="/config"` has no `end`, so `/config/api-keys`
+  highlights both "API Keys" and "Configuration" at once. A single route removes it.
+- Gate consistently on `settings:read || users:list` — currently API Keys and Release
+  Notes are ungated while the other three require `settings:read`.
+- **Release Notes is not administration.** Move it into the Settings → System pane as a
+  link, or into the Header's help menu.
+- Redirect the old paths so existing links and bookmarks survive:
+
+```tsx
+<Route path="/identity" element={<Navigate to="/settings/users" replace />} />
+<Route path="/config" element={<Navigate to="/settings" replace />} />
+<Route path="/config/api-keys" element={<Navigate to="/settings/api-keys" replace />} />
+<Route path="/config/log-destinations" element={<Navigate to="/settings/log-destinations" replace />} />
+```
+
+The settings sub-nav should be a nested route so each pane is linkable. `idp:manage` is
+a new permission gating the Identity Providers pane; add it to the built-in admin role.
+
+---
+
+## 1b. Split service accounts out of `users`
+
+From the identity decisions: a service account has no password and no mailbox, holds a
+role, and owns API keys. Today `ops-bot` is a user row with a password column, which is
+why Users and API Keys feel tangled.
+
+- New table + endpoints: `/api/v1/auth/service-accounts`, with keys nested under the
+  account rather than free-floating.
+- Migration: existing machine users become service accounts; their password hashes are
+  dropped, not carried over.
+- An account with no keys cannot authenticate — surface that rather than showing an empty
+  row (`templates/settings-shell/` shows the copy).
+- Keys need an owning team; `UNOWNED` is a real state worth flagging, since nobody is
+  accountable for rotating those.
+
+---
+
+## 1c. Federated people are not deactivatable in CloudPAM
+
+`useUsers().deactivate` currently applies to everyone. For SAML/OIDC/SCIM people this is
+wrong — the next SCIM sync undoes it. Gate the action on `source === 'local'` and show
+"Deprovision in {provider}" otherwise. Unlock stays available for all sources, because
+lockout is CloudPAM-side state.
+
+Also needed: a guard so SCIM deprovisioning cannot remove the last admin.
+
+---
+
+## 1d. Deny unmapped sign-ins, and log why
+
+No fallback role. When a federated principal authenticates but no mapping applies, refuse
+the session and write an audit event carrying a machine-readable reason:
+
+```ts
+type SignInDenialCode = 'NO_GROUP_MATCH' | 'ROLE_MISSING' | 'NOT_A_PERSON';
+// audit event: { action: 'auth.signin.denied', code, subject, provider, groups[] }
+```
+
+- `NO_GROUP_MATCH` — authenticated, holds no mapped group.
+- `ROLE_MISSING` — matched a mapping whose target role was deleted. **Role deletion must
+  check mappings first** to prevent this.
+- `NOT_A_PERSON` — a service account attempted interactive sign-in.
+
+Surface the last 7 days in the Identity Providers pane (implemented in the template), each
+row linking to its audit entry. A denial that only exists in the log will reach an admin
+as a support ticket instead.
+
+Also: **enabling SCIM must not silently rewrite roles.** It needs a preview step listing
+who changes role and who loses access before it applies.
+
+---
+
+## 2. Retire `UsersAdminPanel`
+
+`ui/src/components/UsersAdminPanel.tsx` → delete once the Users pane lands.
+
+The pane in `templates/settings-shell/` supersedes it. What it fixes, for the record —
+these are the defects to make sure the replacement does not inherit:
+
+- Hand-rolled pills for role and Active/Locked/Disabled instead of `StatusBadge`, the
+  DS's one labeling primitive.
+- Role editing hidden behind a badge that looks like a badge, discoverable only via a
+  `title` tooltip. Replaced by an always-visible labeled `<select>`.
+- Deactivate fires with no confirmation and no feedback. Replaced by `ConfirmDialog`
+  plus a toast with Undo.
+- `handleRoleSave` swallows every failure in `catch {}`.
+- The entire header is duplicated for `embedded` vs not, differing only by tag and one
+  sentence. Should be `title` / `description` props.
+- No search, sort, or pagination — unusable past ~50 users.
+- Below `md` it hides Email, Failures, and Last Login simultaneously, leaving mobile
+  with almost nothing.
+- `dark:hover:bg-gray-750` is not a real Tailwind color. Dead class; no hover in dark
+  mode. (Compiled Tailwind silently drops unknown utilities, so this never errored.)
+- Admin sets the new user's password directly, which forces an out-of-band secret
+  handoff. Replaced by an emailed one-time invite link, 72-hour expiry.
+- "Failures" as a column header is jargon. Now a count badge attached to the Locked
+  state, where it means something.
+
+Keep `useUsers` / `useRoles` / `usePendingAction` — the hooks are fine, only the panel
+goes.
+
+---
+
+## 2b. Role lifecycle
+
+`useRoles` already exposes `create` / `update` / `remove`, but no UI reaches them.
+Implemented in `templates/settings-shell/` Access & Roles:
+
+- **Create is always a copy.** A new custom role starts from an existing role's grant set,
+  never an empty grid — the dialog states how many of the N permissions come with the
+  chosen baseline. Built-in roles get a Duplicate action for exactly this reason.
+- **Rename rewrites references.** Group mappings, member assignments, and grant keys all
+  move with the name. The dialog warns when mappings exist, because the role name is part
+  of the public API surface and external scripts calling it by name will break.
+- **Delete is reference-checked, not confirmed.** `DELETE /roles/:name` must refuse while
+  anything points at the role, and return the blockers so the UI can list them:
+
+```ts
+// 409 Conflict
+{ error: 'role_in_use', members: 3, mappings: ['eng-all', 'platform-oncall'] }
+```
+
+  The dialog shows each blocker with a link that navigates to where it gets cleared
+  (People filtered to that role, or the mapping table). Deletion only offers a destructive
+  button once both counts are zero. **This is what prevents the `ROLE_MISSING` denial
+  from §1d** — today nothing stops deleting a mapped role and locking out a whole group.
+- Built-in roles cannot be renamed or deleted; their cards say `fixed` rather than
+  offering a disabled button.
+
+Also needed server-side: block deleting the last role that grants `users:update`, or an
+admin can strip their own ability to fix it.
+
+---
+
+## 2c. First-run states
+
+Flip `deploymentState` to `fresh` in the template to see all of this.
+
+A brand-new install has one local admin from the installer and nothing else. That is the
+first configuration screen every customer sees, and today it renders as a set of empty
+tables.
+
+**A Setup pane leads the sub-nav while incomplete**, showing `n/5`, and disappears on
+completion — no dismissable banner to re-surface later. Steps are ordered, only the next
+one is emphasized, and each states why it matters rather than just what to click:
+
+1. **Connect an identity provider** — until one exists, only the install-time admin can
+   sign in.
+2. **Map a group to a role** — a federated person matching no mapping is denied, so
+   nobody gets in without this.
+3. **Rotate the install-time password** — the bootstrap admin ships with an installer
+   password; rotate it and keep it as break-glass.
+4. **Create a service account** — automation should authenticate as itself, not as a
+   person who might leave.
+5. **Forward audit events** — records stay local until a destination exists.
+
+Step order is load-bearing: 1 before 2 because mappings need a provider, and 2 carries a
+warning to add your own admin group first so you don't lock yourself out of the session
+you're using.
+
+**Each pane also stands alone**, because people arrive by deep link, not always through
+setup:
+
+| Pane | First-run state |
+|---|---|
+| People | "Just you so far" — explains people arrive via SCIM or first sign-in, not invites |
+| Identity Providers | three Connect cards (SAML / OIDC / SCIM) instead of an empty grid |
+| Group mapping | "No mappings yet — nobody can sign in", offers starter mappings |
+| Denied sign-ins | "Nothing has attempted to sign in yet" |
+| Service Accounts | explains why automation needs its own identity |
+| Log Destinations | "Audit events are staying on this box" + the compliance consequence |
+
+Note the distinction the current code misses: **zero-records is not zero-results.** A
+filtered empty table says "no matches, clear the filter"; an unconfigured one explains
+what the feature is for and offers the first action. `EmptyState` needs to express both.
+
+---
+
+## 2d. Responsive behavior
+
+Set `layout: mobile` in the template to review it at 430px without resizing the window.
+
+Breakpoint at **760px**. Two structural changes and one rethink:
+
+- **The nav rail becomes a sticky top bar** with horizontally scrolling pills, keeping the
+  section name visible. It does not become a hamburger — with six destinations, hiding
+  them behind a tap costs more than the vertical space it saves.
+- **Tables become cards, not scrollers.** Each person is one card: identity and status on
+  the first line, source and group on the second, role control and actions below a
+  divider. Every touch target is at least 44px. The same treatment applies to the group
+  mapping table.
+- **The permissions matrix does not scroll horizontally — it transposes.** A role selector
+  runs across the top, and the body becomes a single-column list of permissions with one
+  switch each, for the selected role only. A 37×5 grid cannot be usefully panned on a
+  phone; comparing roles is a desktop task, while *checking or changing one role* is the
+  thing anyone actually does on mobile.
+
+Checkbox squares become proper `role="switch"` toggles at mobile size — 20px squares are
+below the touch minimum, and the single-role view no longer needs the compact grid
+alignment that justified them.
+
+Two implementation notes for the port: the breakpoint is measured in JS here because DC
+templates cannot carry media queries; in the real app this is a Tailwind `md:` variant, and
+`hidden md:block` / `md:hidden` pairs replace the `narrow`/`wide` branches. And the
+current `hidden md:table-cell` approach in `UsersAdminPanel` is the thing to avoid —
+dropping three columns leaves a table that is narrow but useless, rather than a layout
+that fits.
+
+---
+
+## 3. Colorize the missing status labels
+
+`ui/src/utils/badges.ts` (`getStatusBadgeClass`)
+
+`locked`, `disabled`, `revoked`, and `idle` all fall through to the grey default today,
+so a locked account and a planned pool look identical. Add:
+
+```ts
+locked:   "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
+disabled: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+revoked:  "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+idle:     "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
+```
+
+All four color families already ship in the compiled stylesheet at `-100` / `-700`, so
+no Tailwind rebuild is needed beyond the new class strings appearing in source.
+
+Until this lands, the Users pane in the template renders those three states with its own
+literal styles matching these exact values — swap them back to `<StatusBadge>` after the
+sync.
+
+---
+
+## 4. Extract the config primitives
+
+See `templates/primitives/` for working implementations and prop contracts.
+
+| Primitive | Replaces |
+|---|---|
+| `Modal` | separate backdrops in `SearchModal`, `ImportExportModal`, and two dialogs in Settings |
+| `ConfirmDialog` | nothing — destructive actions currently fire immediately |
+| `Field` | ad-hoc label/input/error markup in every form |
+| `Toggle` | nothing — booleans are checkboxes or absent |
+| `DataTable` | bespoke tables in `UsersAdminPanel`, API keys, audit log |
+| `EmptyState` | centered grey text with an opacity-40 icon |
+
+`Modal` is the highest-leverage one: it removes four copies of backdrop + escape
+handling + focus trap, and only one of those copies traps focus today.
+
+---
+
+## 5. Adopt `ToastContext` everywhere
+
+`ToastContext` and `ToastContainer` ship and are almost never called. Suggested rules:
+
+- **Toast every mutation whose result is off-screen or ambiguous** — role changed, user
+  deactivated, key revoked, destination paused, permissions saved.
+- **Do not toast** navigation, form validation (that's `Field`'s `error`), or anything
+  the user can already see change.
+- **Destructive and reversible actions get Undo in the toast**, with a 6-second life
+  instead of the usual 2.5. Deactivate, pause delivery, and role changes are all
+  reversible and should offer it. Revoke is genuinely irreversible — it gets a
+  `ConfirmDialog` instead, never an Undo it cannot honor.
+- One toast at a time; a new one replaces the old rather than stacking.
+- `role="status"` on the container so screen readers announce it, which the current
+  `ToastContainer` does not set.
+
+---
+
+## 6. One pool-type color map
+
+Outside Administration, but a one-function fix with a correctness bug attached. Mockup:
+`templates/pool-type-color/`.
+
+Three sources of truth today:
+
+| | `getPoolTypeColor` | `TreeNode.TYPE_COLORS` | `SchemaPlanner` legend |
+|---|---|---|---|
+| supernet | purple-500 | purple-500 | purple (literal) |
+| root | purple-500 | **missing → grey** | purple (literal) |
+| region | blue-500 | blue-500 | blue (literal) |
+| environment | green-500 | green-500 | green (literal) |
+| vpc | amber-500 | amber-500 | amber (literal) |
+| account | amber-500 | **missing → grey** | — |
+| subnet | orange-500 | **grey-400** | — |
+
+- **Bug:** `root` and `account` hit the unknown fallback in the Schema Planner, so the
+  same pool is purple in `PoolTree` and grey in the wizard. The wizard's own legend
+  contradicts its own tree.
+- **Grey must mean one thing.** Once grey also means "subnet", an unrecognised type is
+  invisible.
+- **The wizard's de-emphasis of subnets is legitimate** — they are leaves not yet
+  committed — but it is implemented by replacing the hue, which destroys the type. Move it
+  to the row as `opacity-50` and keep the hue. (`dimTreatment` in the mockup compares
+  opacity, hollow ring, and none; opacity is the recommendation.)
+- **Render the legend from `POOL_TYPES`** instead of literal swatches, so it cannot drift
+  again.
+- No `dark:` variants needed; the `-500` weights hold on both grounds. `TYPE_COLORS` only
+  needed them for the grey it invented.
+
+Net change: delete `TYPE_COLORS`, one call site edited, legend mapped over the shared
+constant.

--- a/docs/superpowers/plans/2026-08-04-config-primitives.md
+++ b/docs/superpowers/plans/2026-08-04-config-primitives.md
@@ -1,0 +1,1336 @@
+# Config Primitives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the six config primitives (`EmptyState`, `Field`, `Toggle`, `Modal`, `ConfirmDialog`, `DataTable`), extend `ToastContext` to support Undo, and migrate the two existing modals onto `Modal` — removing four hand-rolled overlays.
+
+**Architecture:** A new `ui/src/components/primitives/` directory with one component per file and a barrel export. Built leaf-first so each task compiles against what came before: `EmptyState` → `Field`/`Toggle` → `Modal` → `ConfirmDialog` → `DataTable`. The toast change lands separately because it alters an existing shared context. The final task migrates `SearchModal` and `ImportExportModal`, which is what proves `Modal` is actually sufficient rather than merely written.
+
+**Tech Stack:** React 18, TypeScript 5.7, Vite 8, Vitest 4 (jsdom), `@testing-library/react`, Tailwind CSS v4, `lucide-react`.
+
+## Global Constraints
+
+- Frontend only. No Go, no SQL, no API changes.
+- All commands run in the Nix dev shell: `nix develop --command bash -c 'cd ui && npx vitest run'`.
+- **There is no `setupFiles` in `vite.config.ts`**, so `@testing-library/jest-dom` matchers are NOT available. Use plain assertions — `expect(x).toBeTruthy()`, `expect(x).toBeNull()`, `expect(el.getAttribute('aria-checked')).toBe('true')`. Never `toBeInTheDocument()`.
+- Tests follow the existing convention in `ui/src/__tests__/`: `import { describe, expect, it, vi } from 'vitest'`, `vi.hoisted` for mocks.
+- These components live in `ui/src`, so **any Tailwind class you write here will be compiled**. That constraint only bites authored design-system previews, not app source.
+- Every component is presentational and controlled — no data fetching, no context reads except `Toast*` in Task 7.
+- Commit after each task with the message given in its final step.
+
+## Prop contracts
+
+Taken from `docs/design/primitives-contracts.md`, which extracted them from the design
+project's `Primitives.dc.html`. Deviations from the mockup are marked there with the reason;
+the three that matter here:
+
+- `ToggleProps` is defined by this plan — the mockup has no interface for it.
+- `DataTableProps` gains `emptyFiltered` alongside `empty`, because `primitives.md` rule 4
+  requires filtered-empty and never-configured to be *different designs*, and one slot
+  cannot express both.
+- `size` widths and `priority` breakpoints are specified here; the mockup left both undefined.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `ui/src/components/primitives/EmptyState.tsx` | Zero-state block: title, description, one optional action. |
+| `ui/src/components/primitives/Field.tsx` | Label + control + hint + error, with `aria-invalid` wiring. |
+| `ui/src/components/primitives/Toggle.tsx` | `role="switch"` with state in the accessible name. |
+| `ui/src/components/primitives/Modal.tsx` | The single overlay: backdrop, Escape, focus trap, scroll lock. |
+| `ui/src/components/primitives/ConfirmDialog.tsx` | `Modal` + a confirm/cancel footer and a danger tone. |
+| `ui/src/components/primitives/DataTable.tsx` | Generic table with five states and responsive column priority. |
+| `ui/src/components/primitives/index.ts` | Barrel export. |
+| `ui/src/hooks/useToast.ts` | **Modify.** Action, duration, replace-not-stack. |
+| `ui/src/components/ToastContainer.tsx` | **Modify.** `role="status"`, render the Undo action. |
+| `ui/src/components/SearchModal.tsx` | **Modify.** Migrate onto `Modal`. |
+| `ui/src/components/ImportExportModal.tsx` | **Modify.** Migrate onto `Modal`. |
+
+---
+
+### Task 1: EmptyState
+
+**Files:**
+- Create: `ui/src/components/primitives/EmptyState.tsx`
+- Test: `ui/src/__tests__/primitives/EmptyState.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `interface EmptyStateProps { title: string; description?: string; action?: { label: string; onClick: () => void } }` and `export default function EmptyState(props: EmptyStateProps)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import EmptyState from '../../components/primitives/EmptyState'
+
+describe('EmptyState', () => {
+  it('renders the title', () => {
+    render(<EmptyState title="No pools yet" />)
+    expect(screen.getByText('No pools yet')).toBeTruthy()
+  })
+
+  it('renders an optional description', () => {
+    render(<EmptyState title="No pools yet" description="Create one to get started." />)
+    expect(screen.getByText('Create one to get started.')).toBeTruthy()
+  })
+
+  it('renders no button when no action is given', () => {
+    render(<EmptyState title="No pools yet" />)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('invokes the action', () => {
+    const onClick = vi.fn()
+    render(<EmptyState title="No pools yet" action={{ label: 'Create pool', onClick }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Create pool' }))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/EmptyState.test.tsx'`
+Expected: FAIL — cannot resolve `../../components/primitives/EmptyState`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+export interface EmptyStateProps {
+  title: string
+  description?: string
+  action?: { label: string; onClick: () => void }
+}
+
+export default function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <div className="px-5 py-12 text-center">
+      <div className="mx-auto mb-4 h-10 w-10 rounded-lg border border-dashed border-gray-300 dark:border-gray-600" />
+      <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{title}</p>
+      {description && (
+        <p className="mt-1.5 text-sm text-gray-500 dark:text-gray-400">{description}</p>
+      )}
+      {action && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="mt-4 rounded-lg border border-gray-300 px-3.5 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/EmptyState.test.tsx'`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/components/primitives/EmptyState.tsx ui/src/__tests__/primitives/EmptyState.test.tsx
+git commit -m "feat(ui): add EmptyState primitive"
+```
+
+---
+
+### Task 2: Field
+
+**Files:**
+- Create: `ui/src/components/primitives/Field.tsx`
+- Test: `ui/src/__tests__/primitives/Field.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `interface FieldProps { label: string; hint?: string; error?: string; required?: boolean; htmlFor?: string; children: React.ReactNode }`.
+
+Rule 2 of `primitives.md`: validation lives here, on the field that failed — not in a toast, not in a red paragraph at the foot of the form. When `error` is set the hint is replaced, not stacked.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Field from '../../components/primitives/Field'
+
+describe('Field', () => {
+  it('renders label and hint', () => {
+    render(
+      <Field label="Pool name" hint="Lowercase, hyphens allowed.">
+        <input />
+      </Field>,
+    )
+    expect(screen.getByText('Pool name')).toBeTruthy()
+    expect(screen.getByText('Lowercase, hyphens allowed.')).toBeTruthy()
+  })
+
+  it('replaces the hint with the error rather than stacking them', () => {
+    render(
+      <Field label="CIDR" hint="Lowercase, hyphens allowed." error="Prefix must be 0-32.">
+        <input />
+      </Field>,
+    )
+    expect(screen.getByText('Prefix must be 0-32.')).toBeTruthy()
+    expect(screen.queryByText('Lowercase, hyphens allowed.')).toBeNull()
+  })
+
+  it('marks the control aria-invalid when errored', () => {
+    const { container } = render(
+      <Field label="CIDR" error="Prefix must be 0-32.">
+        <input />
+      </Field>,
+    )
+    expect(container.querySelector('[aria-invalid="true"]')).toBeTruthy()
+  })
+
+  it('does not mark the control aria-invalid when valid', () => {
+    const { container } = render(
+      <Field label="CIDR">
+        <input />
+      </Field>,
+    )
+    expect(container.querySelector('[aria-invalid="true"]')).toBeNull()
+  })
+
+  it('associates the label with the control via htmlFor', () => {
+    const { container } = render(
+      <Field label="Pool name" htmlFor="pool-name">
+        <input id="pool-name" />
+      </Field>,
+    )
+    expect(container.querySelector('label[for="pool-name"]')).toBeTruthy()
+  })
+
+  it('marks required fields', () => {
+    render(
+      <Field label="Pool name" required>
+        <input />
+      </Field>,
+    )
+    expect(screen.getByText('*')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/Field.test.tsx'`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`aria-invalid` is applied by cloning the child, so callers do not have to remember it.
+
+```tsx
+import { Children, cloneElement, isValidElement } from 'react'
+
+export interface FieldProps {
+  label: string
+  hint?: string
+  error?: string
+  required?: boolean
+  htmlFor?: string
+  children: React.ReactNode
+}
+
+export default function Field({ label, hint, error, required, htmlFor, children }: FieldProps) {
+  // Wire aria-invalid onto the control itself; a caller should never have to
+  // repeat the error state on the input.
+  const control = Children.map(children, (child) =>
+    error && isValidElement(child)
+      ? cloneElement(child as React.ReactElement<{ 'aria-invalid'?: boolean }>, { 'aria-invalid': true })
+      : child,
+  )
+
+  return (
+    <div>
+      <label
+        htmlFor={htmlFor}
+        className="mb-1 block text-xs font-semibold text-gray-700 dark:text-gray-300"
+      >
+        {label}
+        {required && <span className="ml-0.5 text-red-600 dark:text-red-400">*</span>}
+      </label>
+      {control}
+      {error ? (
+        <p className="mt-1.5 text-xs font-medium text-red-700 dark:text-red-400">{error}</p>
+      ) : (
+        hint && <p className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">{hint}</p>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/Field.test.tsx'`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/components/primitives/Field.tsx ui/src/__tests__/primitives/Field.test.tsx
+git commit -m "feat(ui): add Field primitive with aria-invalid wiring"
+```
+
+---
+
+### Task 3: Toggle
+
+**Files:**
+- Create: `ui/src/components/primitives/Toggle.tsx`
+- Test: `ui/src/__tests__/primitives/Toggle.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `interface ToggleProps { checked: boolean; onChange: (checked: boolean) => void; label: string; hint?: string; disabled?: boolean }`.
+
+The mockup gives no interface for this one; the shape above comes from its heading
+(`<Toggle checked onChange label>`) and its markup. Rule 6 of `primitives.md` requires
+`role="switch"` **with the state in the accessible name**, which is why `aria-label` is
+`` `${label}, on|off` `` rather than just `label`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import Toggle from '../../components/primitives/Toggle'
+
+describe('Toggle', () => {
+  it('exposes role=switch with aria-checked', () => {
+    render(<Toggle checked={true} onChange={() => {}} label="Require MFA" />)
+    const sw = screen.getByRole('switch')
+    expect(sw.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('puts the state in the accessible name', () => {
+    render(<Toggle checked={false} onChange={() => {}} label="Require MFA" />)
+    expect(screen.getByRole('switch').getAttribute('aria-label')).toBe('Require MFA, off')
+  })
+
+  it('reports the NEXT value on change, not the current one', () => {
+    const onChange = vi.fn()
+    render(<Toggle checked={false} onChange={onChange} label="Require MFA" />)
+    fireEvent.click(screen.getByRole('switch'))
+    expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  it('renders the hint', () => {
+    render(<Toggle checked={true} onChange={() => {}} label="Require MFA" hint="Applies at next sign-in." />)
+    expect(screen.getByText('Applies at next sign-in.')).toBeTruthy()
+  })
+
+  it('does not fire when disabled', () => {
+    const onChange = vi.fn()
+    render(<Toggle checked={false} onChange={onChange} label="Require MFA" disabled />)
+    fireEvent.click(screen.getByRole('switch'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/Toggle.test.tsx'`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+export interface ToggleProps {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  label: string
+  hint?: string
+  disabled?: boolean
+}
+
+export default function Toggle({ checked, onChange, label, hint, disabled }: ToggleProps) {
+  return (
+    <div className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-gray-100 py-3 dark:border-gray-700">
+      <div>
+        <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{label}</div>
+        {hint && <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{hint}</div>}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={`${label}, ${checked ? 'on' : 'off'}`}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={`flex h-6 w-11 items-center rounded-full px-0.5 transition-colors ${
+          checked ? 'justify-end bg-blue-600' : 'justify-start bg-gray-300 dark:bg-gray-600'
+        } ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
+      >
+        <span className="block h-5 w-5 rounded-full bg-white" />
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/Toggle.test.tsx'`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/components/primitives/Toggle.tsx ui/src/__tests__/primitives/Toggle.test.tsx
+git commit -m "feat(ui): add Toggle primitive with role=switch"
+```
+
+---
+
+### Task 4: Modal
+
+**Files:**
+- Create: `ui/src/components/primitives/Modal.tsx`
+- Test: `ui/src/__tests__/primitives/Modal.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `interface ModalProps { open: boolean; title: string; description?: string; size?: 'sm' | 'md' | 'lg'; onClose: () => void; footer?: React.ReactNode; children: React.ReactNode }`.
+
+Four behaviors are the whole point, per the mockup: Escape closes, backdrop closes, focus is
+trapped, and the page behind cannot scroll. `SearchModal` implements only the first.
+Widths: `sm` 420px, `md` 480px (default), `lg` 720px.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import Modal from '../../components/primitives/Modal'
+
+const open = (over: Partial<React.ComponentProps<typeof Modal>> = {}) =>
+  render(
+    <Modal open title="Import / Export" onClose={over.onClose ?? (() => {})} {...over}>
+      <button>inside</button>
+    </Modal>,
+  )
+
+describe('Modal', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <Modal open={false} title="Import / Export" onClose={() => {}}>
+        <p>body</p>
+      </Modal>,
+    )
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('renders a modal dialog with its title', () => {
+    open()
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    expect(screen.getByText('Import / Export')).toBeTruthy()
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    open({ onClose })
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes on backdrop click but not on panel click', () => {
+    const onClose = vi.fn()
+    const { container } = open({ onClose })
+    fireEvent.click(container.querySelector('[data-testid="modal-backdrop"]')!)
+    expect(onClose).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('dialog'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('locks page scroll while open and restores it on close', () => {
+    const { unmount } = open()
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('moves focus into the dialog', () => {
+    open()
+    expect(screen.getByRole('dialog').contains(document.activeElement)).toBe(true)
+  })
+
+  it('renders a footer when given', () => {
+    open({ footer: <button>Save</button> })
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/Modal.test.tsx'`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+import { useEffect, useRef } from 'react'
+import { X } from 'lucide-react'
+
+export interface ModalProps {
+  open: boolean
+  title: string
+  description?: string
+  size?: 'sm' | 'md' | 'lg'
+  onClose: () => void
+  footer?: React.ReactNode
+  children: React.ReactNode
+}
+
+const WIDTHS: Record<NonNullable<ModalProps['size']>, string> = {
+  sm: 'max-w-[420px]',
+  md: 'max-w-[480px]',
+  lg: 'max-w-[720px]',
+}
+
+export default function Modal({
+  open, title, description, size = 'md', onClose, footer, children,
+}: ModalProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab' || !panelRef.current) return
+      // Focus trap: cycle within the panel.
+      const focusables = panelRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )
+      if (focusables.length === 0) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    panelRef.current?.focus()
+
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      data-testid="modal-backdrop"
+      onClick={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-6"
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+        className={`w-full ${WIDTHS[size]} rounded-xl bg-white shadow-xl outline-none dark:bg-gray-800`}
+      >
+        <div className="flex items-start justify-between gap-4 px-6 pt-5">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
+            {description && (
+              <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">{description}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded p-1 hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="px-6 py-4">{children}</div>
+        {footer && (
+          <div className="flex justify-end gap-2.5 border-t border-gray-100 px-6 py-4 dark:border-gray-700">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/Modal.test.tsx'`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/components/primitives/Modal.tsx ui/src/__tests__/primitives/Modal.test.tsx
+git commit -m "feat(ui): add Modal primitive with focus trap and scroll lock"
+```
+
+---
+
+### Task 5: ConfirmDialog
+
+**Files:**
+- Create: `ui/src/components/primitives/ConfirmDialog.tsx`
+- Test: `ui/src/__tests__/primitives/ConfirmDialog.test.tsx`
+
+**Interfaces:**
+- Consumes: `Modal`, `ModalProps` from Task 4.
+- Produces: `interface ConfirmDialogProps extends Omit<ModalProps, 'footer'> { confirmLabel: string; tone?: 'default' | 'danger'; onConfirm: () => void }`.
+
+Rule 1 of `primitives.md`: destructive actions get this, never a bare click. Reversible ones
+get a toast with Undo instead — one interruption or the other, never both.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import ConfirmDialog from '../../components/primitives/ConfirmDialog'
+
+describe('ConfirmDialog', () => {
+  it('renders the confirm label and fires onConfirm', () => {
+    const onConfirm = vi.fn()
+    render(
+      <ConfirmDialog
+        open
+        title="Revoke terraform-ci?"
+        confirmLabel="Revoke key"
+        onConfirm={onConfirm}
+        onClose={() => {}}
+      >
+        <p>Any pipeline using this key starts failing immediately.</p>
+      </ConfirmDialog>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke key' }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels without confirming', () => {
+    const onConfirm = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <ConfirmDialog open title="Revoke?" confirmLabel="Revoke" onConfirm={onConfirm} onClose={onClose}>
+        <p>body</p>
+      </ConfirmDialog>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('styles the danger tone differently from the default', () => {
+    const { unmount } = render(
+      <ConfirmDialog open title="t" confirmLabel="Go" tone="danger" onConfirm={() => {}} onClose={() => {}}>
+        <p>body</p>
+      </ConfirmDialog>,
+    )
+    const danger = screen.getByRole('button', { name: 'Go' }).className
+    unmount()
+
+    render(
+      <ConfirmDialog open title="t" confirmLabel="Go" onConfirm={() => {}} onClose={() => {}}>
+        <p>body</p>
+      </ConfirmDialog>,
+    )
+    expect(screen.getByRole('button', { name: 'Go' }).className).not.toBe(danger)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/ConfirmDialog.test.tsx'`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+import Modal, { type ModalProps } from './Modal'
+
+export interface ConfirmDialogProps extends Omit<ModalProps, 'footer'> {
+  confirmLabel: string
+  tone?: 'default' | 'danger'
+  onConfirm: () => void
+}
+
+export default function ConfirmDialog({
+  confirmLabel, tone = 'default', onConfirm, onClose, size = 'sm', ...rest
+}: ConfirmDialogProps) {
+  const confirmClass =
+    tone === 'danger'
+      ? 'bg-red-700 text-white hover:bg-red-800'
+      : 'bg-blue-600 text-white hover:bg-blue-700'
+
+  return (
+    <Modal
+      {...rest}
+      size={size}
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`rounded-lg px-4 py-2 text-sm font-semibold ${confirmClass}`}
+          >
+            {confirmLabel}
+          </button>
+        </>
+      }
+    />
+  )
+}
+```
+
+Note `Modal` must export its props type for the `Omit` to work — add `export type { ModalProps }` if Task 4 declared it without `export`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/ConfirmDialog.test.tsx'`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/components/primitives/ConfirmDialog.tsx ui/src/__tests__/primitives/ConfirmDialog.test.tsx
+git commit -m "feat(ui): add ConfirmDialog primitive"
+```
+
+---
+
+### Task 6: DataTable
+
+**Files:**
+- Create: `ui/src/components/primitives/DataTable.tsx`
+- Test: `ui/src/__tests__/primitives/DataTable.test.tsx`
+
+**Interfaces:**
+- Consumes: `EmptyState` from Task 1.
+- Produces:
+  - `interface Column<T> { key: string; label: string; width?: string; align?: 'left' | 'right'; priority?: 1 | 2 | 3; sortable?: boolean; render?: (row: T) => React.ReactNode }`
+  - `interface DataTableProps<T> { columns: Column<T>[]; rows: T[]; rowKey: (row: T) => string; loading?: boolean; error?: string; empty?: React.ReactNode; emptyFiltered?: React.ReactNode; filtered?: boolean; toolbar?: React.ReactNode }`
+
+All five states from rule 4 must be wired. `empty` and `emptyFiltered` are separate slots —
+one cannot express both designs — and `filtered` selects between them.
+`priority`: `1` always visible, `2` hidden below `md`, `3` hidden below `lg`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import DataTable, { type Column } from '../../components/primitives/DataTable'
+
+type Pool = { id: string; name: string; cidr: string }
+
+const columns: Column<Pool>[] = [
+  { key: 'name', label: 'Pool' },
+  { key: 'cidr', label: 'CIDR', priority: 2 },
+]
+const rows: Pool[] = [
+  { id: '1', name: 'production-us-east', cidr: '10.42.0.0/16' },
+  { id: '2', name: 'staging-us-east', cidr: '10.48.0.0/16' },
+]
+const base = { columns, rows, rowKey: (r: Pool) => r.id }
+
+describe('DataTable', () => {
+  it('renders headers and rows', () => {
+    render(<DataTable {...base} />)
+    expect(screen.getByText('Pool')).toBeTruthy()
+    expect(screen.getByText('production-us-east')).toBeTruthy()
+    expect(screen.getByText('10.48.0.0/16')).toBeTruthy()
+  })
+
+  it('shows the loading state instead of rows', () => {
+    render(<DataTable {...base} loading />)
+    expect(screen.getByRole('status')).toBeTruthy()
+    expect(screen.queryByText('production-us-east')).toBeNull()
+  })
+
+  it('shows the error state instead of rows', () => {
+    render(<DataTable {...base} error="Could not load pools (503)." />)
+    expect(screen.getByText('Could not load pools (503).')).toBeTruthy()
+    expect(screen.queryByText('production-us-east')).toBeNull()
+  })
+
+  it('shows the never-configured empty state', () => {
+    render(<DataTable {...base} rows={[]} empty={<p>No pools yet</p>} emptyFiltered={<p>No matches</p>} />)
+    expect(screen.getByText('No pools yet')).toBeTruthy()
+    expect(screen.queryByText('No matches')).toBeNull()
+  })
+
+  it('shows the filtered-empty state, which is a different design', () => {
+    render(
+      <DataTable {...base} rows={[]} filtered empty={<p>No pools yet</p>} emptyFiltered={<p>No matches</p>} />,
+    )
+    expect(screen.getByText('No matches')).toBeTruthy()
+    expect(screen.queryByText('No pools yet')).toBeNull()
+  })
+
+  it('uses a column render function when given', () => {
+    render(
+      <DataTable
+        {...base}
+        columns={[{ key: 'name', label: 'Pool', render: (r) => <em>{r.name.toUpperCase()}</em> }]}
+      />,
+    )
+    expect(screen.getByText('PRODUCTION-US-EAST')).toBeTruthy()
+  })
+
+  it('drops low-priority columns at narrow widths via responsive classes', () => {
+    const { container } = render(<DataTable {...base} />)
+    // priority 2 => hidden below md
+    expect(container.querySelector('.hidden.md\\:block')).toBeTruthy()
+  })
+
+  it('renders a toolbar when given', () => {
+    render(<DataTable {...base} toolbar={<input aria-label="Filter pools" />} />)
+    expect(screen.getByLabelText('Filter pools')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/DataTable.test.tsx'`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+export interface Column<T> {
+  key: string
+  label: string
+  width?: string
+  align?: 'left' | 'right'
+  priority?: 1 | 2 | 3
+  sortable?: boolean
+  render?: (row: T) => React.ReactNode
+}
+
+export interface DataTableProps<T> {
+  columns: Column<T>[]
+  rows: T[]
+  rowKey: (row: T) => string
+  loading?: boolean
+  error?: string
+  /** Shown when the collection has never had records. */
+  empty?: React.ReactNode
+  /** Shown when a filter excluded everything. A different design from `empty`. */
+  emptyFiltered?: React.ReactNode
+  filtered?: boolean
+  toolbar?: React.ReactNode
+}
+
+// priority 1 always shows; 2 drops below md; 3 drops below lg.
+const PRIORITY_CLASS: Record<1 | 2 | 3, string> = {
+  1: '',
+  2: 'hidden md:block',
+  3: 'hidden lg:block',
+}
+
+export default function DataTable<T>({
+  columns, rows, rowKey, loading, error, empty, emptyFiltered, filtered, toolbar,
+}: DataTableProps<T>) {
+  const grid = { gridTemplateColumns: columns.map((c) => c.width ?? '1fr').join(' ') }
+
+  const body = () => {
+    if (loading) {
+      return (
+        <div role="status" className="px-5 py-12 text-center text-sm text-gray-500 dark:text-gray-400">
+          Loading…
+        </div>
+      )
+    }
+    if (error) {
+      return (
+        <div role="alert" className="px-5 py-12 text-center text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )
+    }
+    if (rows.length === 0) {
+      return <div>{filtered ? emptyFiltered : empty}</div>
+    }
+    return rows.map((row) => (
+      <div
+        key={rowKey(row)}
+        style={grid}
+        className="grid items-center border-b border-gray-100 py-3 text-sm last:border-0 dark:border-gray-700"
+      >
+        {columns.map((c) => (
+          <div
+            key={c.key}
+            className={`px-3.5 ${c.align === 'right' ? 'text-right' : ''} ${PRIORITY_CLASS[c.priority ?? 1]}`}
+          >
+            {c.render ? c.render(row) : String((row as Record<string, unknown>)[c.key] ?? '')}
+          </div>
+        ))}
+      </div>
+    ))
+  }
+
+  return (
+    <div>
+      {toolbar && <div className="mb-3.5 flex items-center gap-3">{toolbar}</div>}
+      <div className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
+        <div
+          style={grid}
+          className="grid border-b border-gray-200 bg-gray-50 py-2.5 text-xs font-semibold text-gray-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400"
+        >
+          {columns.map((c) => (
+            <div
+              key={c.key}
+              className={`px-3.5 ${c.align === 'right' ? 'text-right' : ''} ${PRIORITY_CLASS[c.priority ?? 1]}`}
+            >
+              {c.label}
+            </div>
+          ))}
+        </div>
+        {body()}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/DataTable.test.tsx'`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/components/primitives/DataTable.tsx ui/src/__tests__/primitives/DataTable.test.tsx
+git commit -m "feat(ui): add DataTable primitive with all five states"
+```
+
+---
+
+### Task 7: Extend ToastContext for Undo
+
+**Files:**
+- Modify: `ui/src/hooks/useToast.ts`
+- Modify: `ui/src/components/ToastContainer.tsx`
+- Test: `ui/src/__tests__/primitives/Toast.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface ToastAction { label: string; onClick: () => void }`
+  - `interface Toast { id: string; message: string; type: 'info' | 'error' | 'success'; action?: ToastAction }`
+  - `showToast(message: string, type?: 'info' | 'error' | 'success', action?: ToastAction): void`
+
+Three behavior changes from §5, all breaking the current implementation:
+**one toast at a time** (a new one replaces the old, rather than stacking), **6000 ms when
+an action is present** and 2500 ms otherwise (currently a flat 3000 ms), and
+**`role="status"`** on the container so screen readers announce it.
+
+`showToast`'s existing two-argument signature is preserved, so no current caller breaks.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { ToastContext, useToastState } from '../../hooks/useToast'
+import ToastContainer from '../../components/ToastContainer'
+
+function Harness() {
+  const state = useToastState()
+  return (
+    <ToastContext.Provider value={state}>
+      <button onClick={() => state.showToast('Saved', 'success')}>plain</button>
+      <button onClick={() => state.showToast('Deactivated', 'success', { label: 'Undo', onClick: undo })}>
+        withUndo
+      </button>
+      <ToastContainer />
+    </ToastContext.Provider>
+  )
+}
+const undo = vi.fn()
+
+beforeEach(() => { vi.useFakeTimers(); undo.mockClear() })
+afterEach(() => { vi.useRealTimers() })
+
+describe('toast', () => {
+  it('announces via role=status', () => {
+    render(<Harness />)
+    act(() => { fireEvent.click(screen.getByText('plain')) })
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('shows one toast at a time - a new one replaces the old', () => {
+    render(<Harness />)
+    act(() => { fireEvent.click(screen.getByText('plain')) })
+    act(() => { fireEvent.click(screen.getByText('withUndo')) })
+    expect(screen.queryByText('Saved')).toBeNull()
+    expect(screen.getByText('Deactivated')).toBeTruthy()
+  })
+
+  it('expires a plain toast at 2500ms', () => {
+    render(<Harness />)
+    act(() => { fireEvent.click(screen.getByText('plain')) })
+    act(() => { vi.advanceTimersByTime(2499) })
+    expect(screen.queryByText('Saved')).toBeTruthy()
+    act(() => { vi.advanceTimersByTime(2) })
+    expect(screen.queryByText('Saved')).toBeNull()
+  })
+
+  it('gives an Undo toast the longer 6000ms life', () => {
+    render(<Harness />)
+    act(() => { fireEvent.click(screen.getByText('withUndo')) })
+    act(() => { vi.advanceTimersByTime(2600) })
+    expect(screen.queryByText('Deactivated')).toBeTruthy()
+    act(() => { vi.advanceTimersByTime(3500) })
+    expect(screen.queryByText('Deactivated')).toBeNull()
+  })
+
+  it('invokes the action and dismisses', () => {
+    render(<Harness />)
+    act(() => { fireEvent.click(screen.getByText('withUndo')) })
+    act(() => { fireEvent.click(screen.getByRole('button', { name: 'Undo' })) })
+    expect(undo).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('Deactivated')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/Toast.test.tsx'`
+Expected: FAIL — toasts stack, there is no `role="status"`, and `showToast` takes no action.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the body of `ui/src/hooks/useToast.ts`, keeping the existing exports:
+
+```ts
+import { createContext, useCallback, useContext, useRef, useState } from 'react'
+
+export interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
+export interface Toast {
+  id: string
+  message: string
+  type: 'info' | 'error' | 'success'
+  action?: ToastAction
+}
+
+export interface ToastContextValue {
+  toasts: Toast[]
+  showToast: (message: string, type?: Toast['type'], action?: ToastAction) => void
+  dismissToast: (id: string) => void
+}
+
+export const ToastContext = createContext<ToastContextValue>({
+  toasts: [],
+  showToast: () => {},
+  dismissToast: () => {},
+})
+
+// Reversible actions carry Undo and need longer to read and act on; plain
+// confirmations do not. See docs/design/repo-changes.md §5.
+const PLAIN_MS = 2500
+const ACTION_MS = 6000
+
+export function useToastState(): ToastContextValue {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  const showToast = useCallback(
+    (message: string, type: Toast['type'] = 'info', action?: ToastAction) => {
+      const id = Math.random().toString(36).slice(2)
+      // One at a time: a new toast replaces the old rather than stacking.
+      if (timerRef.current) clearTimeout(timerRef.current)
+      setToasts([{ id, message, type, action }])
+      timerRef.current = setTimeout(
+        () => setToasts((prev) => prev.filter((t) => t.id !== id)),
+        action ? ACTION_MS : PLAIN_MS,
+      )
+    },
+    [],
+  )
+
+  return { toasts, showToast, dismissToast }
+}
+
+export function useToast(): ToastContextValue {
+  return useContext(ToastContext)
+}
+```
+
+Then `ui/src/components/ToastContainer.tsx`:
+
+```tsx
+import { useToast } from '../hooks/useToast'
+
+export default function ToastContainer() {
+  const { toasts, dismissToast } = useToast()
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div role="status" className="fixed right-4 bottom-4 z-50 flex flex-col gap-2">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className={`min-w-60 rounded-lg border bg-white px-4 py-3 shadow-lg dark:bg-gray-800 ${
+            t.type === 'error'
+              ? 'border-red-200 dark:border-red-800'
+              : t.type === 'success'
+                ? 'border-green-200 dark:border-green-800'
+                : 'border-blue-200 dark:border-blue-800'
+          }`}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="text-sm font-medium">
+                {t.type === 'error' ? 'Error' : t.type === 'success' ? 'Success' : 'Info'}
+              </div>
+              <div className="text-sm text-gray-600 dark:text-gray-300">{t.message}</div>
+            </div>
+            {t.action && (
+              <button
+                type="button"
+                onClick={() => {
+                  t.action?.onClick()
+                  dismissToast(t.id)
+                }}
+                className="shrink-0 text-sm font-semibold text-blue-600 hover:text-blue-700 dark:text-blue-400"
+              >
+                {t.action.label}
+              </button>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/primitives/Toast.test.tsx'`
+Expected: PASS, 5 tests.
+
+Then confirm no existing caller broke — `showToast(msg, type)` still works:
+
+Run: `nix develop --command bash -c 'cd ui && npx tsc --noEmit && npx vitest run'`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/hooks/useToast.ts ui/src/components/ToastContainer.tsx ui/src/__tests__/primitives/Toast.test.tsx
+git commit -m "feat(ui): support Undo actions and single-toast semantics
+
+Adds an optional action with a 6s life (2.5s without), replaces stacking
+with one-at-a-time, and puts role=status on the container so screen readers
+announce it. showToast's two-argument form is unchanged."
+```
+
+---
+
+### Task 8: Migrate SearchModal and ImportExportModal onto Modal
+
+**Files:**
+- Modify: `ui/src/components/ImportExportModal.tsx`
+- Modify: `ui/src/components/SearchModal.tsx`
+- Create: `ui/src/components/primitives/index.ts`
+- Test: existing `ui/src/__tests__/ImportExportModal.test.tsx` and `SearchModal.test.tsx` must keep passing.
+
+**Interfaces:**
+- Consumes: `Modal` from Task 4.
+- Produces: `ui/src/components/primitives/index.ts` re-exporting all six primitives and their prop types.
+
+This is the task that proves `Modal` is sufficient. `ImportExportModal` currently builds its
+own backdrop at line 91 (`fixed inset-0 … bg-black/40`) with a click-to-close and no Escape
+handler and no focus trap; `SearchModal` has Escape but no focus trap. Both keep their own
+`open`/`onClose` props — only the overlay chrome moves.
+
+**`SearchModal` is a command palette, not a dialog box.** It is top-aligned with no title
+chrome, so migrating it wholesale would change its appearance. Migrate `ImportExportModal`
+fully; for `SearchModal`, adopt `Modal` only if it can be done without visual change — if
+not, leave it and record why in the commit message. Do not force it.
+
+- [ ] **Step 1: Confirm the existing tests pass before touching anything**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/ImportExportModal.test.tsx src/__tests__/SearchModal.test.tsx'`
+Expected: PASS. This is the baseline the migration must preserve.
+
+- [ ] **Step 2: Write the barrel**
+
+Create `ui/src/components/primitives/index.ts`:
+
+```ts
+export { default as EmptyState, type EmptyStateProps } from './EmptyState'
+export { default as Field, type FieldProps } from './Field'
+export { default as Toggle, type ToggleProps } from './Toggle'
+export { default as Modal, type ModalProps } from './Modal'
+export { default as ConfirmDialog, type ConfirmDialogProps } from './ConfirmDialog'
+export { default as DataTable, type Column, type DataTableProps } from './DataTable'
+```
+
+- [ ] **Step 3: Migrate ImportExportModal**
+
+Replace its outer backdrop and panel markup with `Modal`, keeping the two-pane body exactly
+as it is:
+
+```tsx
+import { Modal } from './primitives'
+
+// …inside the component, replacing the outer <div className="fixed inset-0 …"> wrapper:
+return (
+  <Modal open={open} onClose={onClose} title="Import / Export" size="lg">
+    {/* the existing Export Data / Import Data two-pane body, unchanged */}
+  </Modal>
+)
+```
+
+Delete the now-dead close button and backdrop `onClick` — `Modal` owns both.
+
+- [ ] **Step 4: Run the full suite and type check**
+
+Run: `nix develop --command bash -c 'cd ui && npx tsc --noEmit && npx vitest run'`
+Expected: PASS, with the pre-existing ImportExportModal tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/components/primitives/index.ts ui/src/components/ImportExportModal.tsx ui/src/components/SearchModal.tsx
+git commit -m "refactor(ui): migrate ImportExportModal onto the Modal primitive
+
+Removes a hand-rolled backdrop that had click-to-close but no Escape
+handler and no focus trap."
+```
+
+---
+
+### Task 9: Re-sync the design system
+
+`ImportExportModal` and `ToastContainer` are both synced components, and both changed. Their
+preview cards will move.
+
+- [ ] **Step 1: Rebuild the frontend**
+
+Run: `nix develop --command bash -c 'cd ui && npm run build'`
+Expected: exit 0.
+
+- [ ] **Step 2: Update the ToastContainer preview**
+
+`.design-sync/previews/ToastContainer.tsx` has a `Stacked` cell showing three toasts at
+once. **That state no longer exists** — §5 made toasts one-at-a-time. Replace it with a
+`WithUndo` cell exercising the new action, and drop `Stacked`.
+
+- [ ] **Step 3: Re-sync**
+
+Follow `.design-sync/NOTES.md`. From the repo root:
+
+```bash
+nix develop --command bash -c 'cd ui && npx tsc -p tsconfig.dts.json'
+nix develop --command node .ds-sync/resync.mjs --config .design-sync/config.json \
+  --node-modules ui/node_modules --out ./ds-bundle \
+  --remote .design-sync/.cache/remote-sync.json
+```
+
+Expected: `verification.changed` lists `ImportExportModal` and `ToastContainer`;
+`upload.any: true`.
+
+- [ ] **Step 4: Re-grade and upload**
+
+Read the two review sheets, confirm the cards render, write grades, and upload per the
+design-sync skill's atomic path.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .design-sync
+git commit -m "chore(design-sync): re-sync after primitives and toast changes"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Covers §4 in full — all six primitives with the mockup's contracts —
+and §5's toast rules (Undo at 6s, plain at 2.5s, one at a time, `role="status"`). §5's
+*usage* guidance ("toast every mutation whose result is off-screen") is a rule for callers,
+not a component change; it applies when Plan C wires the Settings panes. Out of scope: §1,
+§2, §2b, §2c, §2d (Plan C), §3 and §6 (Plan A), §1b/§1c/§1d (Plan D).
+
+**2. Placeholder scan.** No TBDs. Every code step carries the literal implementation. Task 8
+deliberately leaves `SearchModal` conditional — it is a command palette rather than a dialog,
+and forcing it through `Modal` would change its appearance; the plan says to judge and record
+rather than pretend the answer is known.
+
+**3. Type consistency.** `ModalProps` is defined in Task 4 and consumed by Task 5's `Omit`.
+`Column<T>` and `DataTableProps<T>` are defined in Task 6 and re-exported in Task 8's barrel.
+`ToastAction` is defined in Task 7 and used by both `useToast.ts` and `ToastContainer.tsx`.
+`EmptyState` (Task 1) is available to `DataTable` (Task 6) — note `DataTable` takes empty
+states as `ReactNode` slots rather than importing `EmptyState` directly, so callers can pass
+anything.
+
+**Deviations from the mockup, all recorded in `docs/design/primitives-contracts.md`:**
+`ToggleProps` invented (no interface in the mockup); `DataTable` gains `emptyFiltered` +
+`filtered` because one slot cannot satisfy rule 4; `size` widths and `priority` breakpoints
+specified because the mockup left both undefined.
+
+---
+
+## Plan C readiness
+
+Plan C (Settings shell) consumes every primitive here. Before writing it, pull the two
+remaining mockups — `templates/settings-shell/SettingsShell.dc.html` and
+`templates/first-run/FirstRun.dc.html` — which hold the People table, the permissions
+matrix, the role dialogs, and the five first-run steps. Plan C also needs Plan D's
+`409 role_in_use` response shape for the role-delete dialog.

--- a/docs/superpowers/plans/2026-08-04-pool-type-color-and-status-badges.md
+++ b/docs/superpowers/plans/2026-08-04-pool-type-color-and-status-badges.md
@@ -1,0 +1,649 @@
+# Pool-Type Color Unification & Status Badge Vocabulary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make pool-type color a single source of truth so the same pool never renders a different color in two places, and give `locked` / `disabled` / `revoked` / `idle` their own badge colors instead of falling through to grey.
+
+**Architecture:** Introduce one `POOL_TYPES` constant that owns the id → label → dot-class mapping. `getPoolTypeColor` reads from it, the Schema Planner legend renders from it, and `TreeNode`'s private `TYPE_COLORS` map is deleted. Subnet de-emphasis in the wizard moves from "replace the hue with grey" to "keep the hue, dim the row", so grey once again means only "unrecognised type". Separately, four missing entries are added to `getStatusBadgeClass`.
+
+**Tech Stack:** React 18, TypeScript 5.7, Vite 8, Vitest 4, Tailwind CSS v4.
+
+## Global Constraints
+
+- Frontend only. No Go, no SQL, no API changes. Nothing in this plan touches `internal/` or `migrations/`.
+- All commands run inside the Nix dev shell: prefix with `nix develop --command`, e.g. `nix develop --command bash -c 'cd ui && npx vitest run'`. Node is not on the default PATH.
+- Tailwind v4 compiles only classes it finds as **literal strings** in `ui/src`. Never build a class name by concatenation — write the full literal (`'bg-purple-500'`, not `` `bg-${hue}-500` ``), or it will silently not exist at runtime.
+- `getStatusBadgeClass` lives in `ui/src/utils/format.ts`. There is **no** `ui/src/utils/badges.ts` — the spec's §3 path is wrong; use `format.ts`.
+- Existing behavior that must not regress: `getPoolTypeColor('unknown')` returns `'bg-gray-400'`, and `getPoolTypeColor('supernet')` returns `'bg-purple-500'`. Both are asserted in `ui/src/__tests__/format.test.ts`.
+- Commit after each task with the message given in the task's final step.
+
+---
+
+## Decisions — resolved
+
+1. **Which types belong in the legend? — RESOLVED: exactly five.** `internal/domain/types.go:9-13` is authoritative: `supernet`, `region`, `environment`, `vpc`, `subnet`. `IsValidPoolType` rejects anything else, so no other value can reach the frontend from the API.
+
+   `getPoolTypeColor`'s `root` and `account` keys are **dead** and are deleted by this plan:
+   - `root` is a *node id*, not a type — `ui/src/wizard/hooks/useSchemaGenerator.ts:22` sets `id: 'root'` on a node whose `type` is `'supernet'` (line 24).
+   - `account` is a *search-result kind* — the only occurrence is `ui/src/components/SearchModal.tsx:45` (`i.type === 'account'`, separating pool hits from account hits). It never passes through `getPoolTypeColor`, and there is no `PoolTypeAccount` in Go.
+
+   The current legend (`ui/src/wizard/steps/PreviewStep.tsx:82-85`) therefore labels two things the system cannot produce (*Root*, *Account*) while omitting two it can (*Supernet*, *Subnet*). All five real types go in the legend, so no `inLegend` flag is needed.
+
+2. **Should `getPoolTypeColor` keep accepting `string`? — Yes, deliberately.** It is typed `(type: string)` today, which is what lets unknown values reach the grey fallback. Do not "tighten" it to `PoolType`: the fallback is load-bearing, and after this change grey means exactly one thing.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `ui/src/utils/poolTypes.ts` | **New.** `POOL_TYPES` — the single source of truth for pool-type id, human label, and dot class. Plus `UNKNOWN_POOL_TYPE_DOT`. |
+| `ui/src/utils/format.ts` | **Modify.** `getPoolTypeColor` delegates to `POOL_TYPES`; `getStatusBadgeClass` gains four entries. |
+| `ui/src/wizard/components/TreeNode.tsx` | **Modify.** Delete the private `TYPE_COLORS`; use the shared color; dim subnet rows via opacity. |
+| `ui/src/wizard/steps/PreviewStep.tsx` | **Modify.** Legend renders from `POOL_TYPES` instead of four literal swatches. |
+| `ui/src/__tests__/poolTypes.test.ts` | **New.** Guards the constant's shape and the no-duplicate-grey invariant. |
+| `ui/src/__tests__/format.test.ts` | **Modify.** Extend for the new status colors and the shared color source. |
+| `ui/src/__tests__/PoolTree.test.tsx` | **Modify.** Add the subnet-hue regression test. |
+
+---
+
+### Task 1: Create the `POOL_TYPES` single source of truth
+
+**Files:**
+- Create: `ui/src/utils/poolTypes.ts`
+- Test: `ui/src/__tests__/poolTypes.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface PoolTypeMeta { id: PoolType; label: string; dot: string }`
+  - `const POOL_TYPES: readonly PoolTypeMeta[]`
+  - `const UNKNOWN_POOL_TYPE_DOT = 'bg-gray-400'`
+  - `function poolTypeDot(type: string): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ui/src/__tests__/poolTypes.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { POOL_TYPES, UNKNOWN_POOL_TYPE_DOT, poolTypeDot } from '../utils/poolTypes'
+
+describe('POOL_TYPES', () => {
+  it('matches the five pool types the Go domain accepts', () => {
+    // internal/domain/types.go ValidPoolTypes is authoritative.
+    const ids = POOL_TYPES.map((t) => t.id)
+    expect(ids).toEqual(['supernet', 'region', 'environment', 'vpc', 'subnet'])
+  })
+
+  it('does not resurrect the dead root/account keys', () => {
+    // 'root' is a node id (useSchemaGenerator) and 'account' is a search-result
+    // kind (SearchModal) — neither is a pool type.
+    expect(poolTypeDot('root')).toBe(UNKNOWN_POOL_TYPE_DOT)
+    expect(poolTypeDot('account')).toBe(UNKNOWN_POOL_TYPE_DOT)
+  })
+
+  it('never assigns the unknown-type grey to a known type', () => {
+    // Grey must mean exactly one thing: "type not recognised". If a known
+    // type also renders grey, an unrecognised type becomes invisible.
+    const greys = POOL_TYPES.filter((t) => t.dot === UNKNOWN_POOL_TYPE_DOT)
+    expect(greys).toEqual([])
+  })
+
+  it('gives every type a non-empty label', () => {
+    for (const t of POOL_TYPES) {
+      expect(t.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('resolves a known type to its dot class', () => {
+    expect(poolTypeDot('subnet')).toBe('bg-orange-500')
+    expect(poolTypeDot('supernet')).toBe('bg-purple-500')
+  })
+
+  it('falls back to grey for an unrecognised type', () => {
+    expect(poolTypeDot('nonsense')).toBe(UNKNOWN_POOL_TYPE_DOT)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/poolTypes.test.ts'`
+Expected: FAIL — `Failed to resolve import "../utils/poolTypes"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `ui/src/utils/poolTypes.ts`:
+
+```ts
+// Single source of truth for pool-type presentation.
+//
+// Grey is reserved: it means "type not recognised". Nothing in POOL_TYPES may
+// use UNKNOWN_POOL_TYPE_DOT, or an unknown type becomes indistinguishable from
+// a known one. Dot classes are written as full literal strings because
+// Tailwind v4 only compiles classes it can find literally in ui/src.
+// The five ids mirror internal/domain/types.go ValidPoolTypes, which the API
+// enforces via IsValidPoolType. Do not add 'root' or 'account': the former is a
+// node id in the schema generator, the latter a search-result kind.
+import type { PoolType } from '../api/types'
+
+export interface PoolTypeMeta {
+  id: PoolType
+  label: string
+  dot: string
+}
+
+export const UNKNOWN_POOL_TYPE_DOT = 'bg-gray-400'
+
+export const POOL_TYPES: readonly PoolTypeMeta[] = [
+  { id: 'supernet', label: 'Supernet', dot: 'bg-purple-500' },
+  { id: 'region', label: 'Region', dot: 'bg-blue-500' },
+  { id: 'environment', label: 'Environment', dot: 'bg-green-500' },
+  { id: 'vpc', label: 'VPC', dot: 'bg-amber-500' },
+  { id: 'subnet', label: 'Subnet', dot: 'bg-orange-500' },
+]
+
+const BY_ID = new Map(POOL_TYPES.map((t) => [t.id, t]))
+
+export function poolTypeDot(type: string): string {
+  return BY_ID.get(type)?.dot ?? UNKNOWN_POOL_TYPE_DOT
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/poolTypes.test.ts'`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/utils/poolTypes.ts ui/src/__tests__/poolTypes.test.ts
+git commit -m "feat(ui): add POOL_TYPES as the single source of pool-type color"
+```
+
+---
+
+### Task 2: Point `getPoolTypeColor` at `POOL_TYPES`
+
+**Files:**
+- Modify: `ui/src/utils/format.ts:31-42`
+- Test: `ui/src/__tests__/format.test.ts`
+
+**Interfaces:**
+- Consumes: `poolTypeDot`, `UNKNOWN_POOL_TYPE_DOT` from Task 1.
+- Produces: `getPoolTypeColor(type: string): string` — unchanged signature, now backed by `POOL_TYPES`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ui/src/__tests__/format.test.ts` (inside the existing top-level `describe`, next to the current `getPoolTypeColor` test):
+
+```ts
+  it('getPoolTypeColor agrees with POOL_TYPES for every known type', () => {
+    for (const t of POOL_TYPES) {
+      expect(getPoolTypeColor(t.id)).toBe(t.dot)
+    }
+  })
+
+  it('getPoolTypeColor gives subnet its own hue, not grey', () => {
+    // Regression: the wizard used to grey out subnets, which collided with
+    // the unknown-type fallback.
+    expect(getPoolTypeColor('subnet')).toBe('bg-orange-500')
+    expect(getPoolTypeColor('subnet')).not.toBe(UNKNOWN_POOL_TYPE_DOT)
+  })
+```
+
+Add to that file's imports:
+
+```ts
+import { POOL_TYPES, UNKNOWN_POOL_TYPE_DOT } from '../utils/poolTypes'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/format.test.ts'`
+Expected: The two new tests FAIL — `getPoolTypeColor('root')` currently returns `'bg-purple-500'` but is a separate literal map, and `account` is absent from the new constant's ordering check. If both happen to pass, the map still needs replacing for Task 4 to have a single source; continue.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ui/src/utils/format.ts`, add the import at the top of the file:
+
+```ts
+import { poolTypeDot } from './poolTypes'
+```
+
+Replace the whole existing `getPoolTypeColor` function (lines 31-42) with:
+
+```ts
+export function getPoolTypeColor(type: string): string {
+  return poolTypeDot(type)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/format.test.ts'`
+Expected: PASS, including the pre-existing `getPoolTypeColor('unknown') === 'bg-gray-400'` assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/utils/format.ts ui/src/__tests__/format.test.ts
+git commit -m "refactor(ui): back getPoolTypeColor with POOL_TYPES"
+```
+
+---
+
+### Task 3: Delete `TYPE_COLORS` and dim subnets without destroying the hue
+
+**Files:**
+- Modify: `ui/src/wizard/components/TreeNode.tsx:6-12` (delete `TYPE_COLORS`), `:26-45` (row + dot)
+- Test: `ui/src/__tests__/PoolTree.test.tsx`
+
+**Interfaces:**
+- Consumes: `getPoolTypeColor` from Task 2.
+- Produces: no new exports. `TreeNode`'s rendered dot class now comes from the shared source.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ui/src/__tests__/PoolTree.test.tsx`:
+
+```tsx
+import TreeNode from '../wizard/components/TreeNode'
+import type { SchemaNode } from '../wizard/utils/cidr'
+
+describe('TreeNode pool-type color', () => {
+  const node = (type: SchemaNode['type']): SchemaNode => ({
+    id: 'n1',
+    name: 'node',
+    type,
+    cidr: '10.0.0.0/24',
+    children: [],
+  })
+
+  it('gives a subnet its own hue instead of grey', () => {
+    const { container } = render(<TreeNode node={node('subnet')} />)
+    expect(container.querySelector('.bg-orange-500')).toBeTruthy()
+    expect(container.querySelector('.bg-gray-400')).toBeNull()
+  })
+
+  it('dims the subnet row rather than recoloring the dot', () => {
+    const { container } = render(<TreeNode node={node('subnet')} />)
+    expect(container.querySelector('.opacity-50')).toBeTruthy()
+  })
+
+  it('does not dim a non-subnet row', () => {
+    const { container } = render(<TreeNode node={node('region')} />)
+    expect(container.querySelector('.opacity-50')).toBeNull()
+    expect(container.querySelector('.bg-blue-500')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/PoolTree.test.tsx'`
+Expected: FAIL — the subnet dot renders `bg-gray-400 dark:bg-gray-500`, so `.bg-orange-500` is null and `.bg-gray-400` is found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ui/src/wizard/components/TreeNode.tsx`:
+
+Delete the entire `TYPE_COLORS` constant (lines 6-12):
+
+```ts
+const TYPE_COLORS: Record<string, string> = {
+  supernet: 'bg-purple-500',
+  region: 'bg-blue-500',
+  environment: 'bg-green-500',
+  vpc: 'bg-amber-500',
+  subnet: 'bg-gray-400 dark:bg-gray-500',
+}
+```
+
+Add to the imports at the top of the file:
+
+```ts
+import { getPoolTypeColor } from '../../utils/format'
+```
+
+Replace the dot element:
+
+```tsx
+<div className={`w-2 h-2 rounded-full ${TYPE_COLORS[node.type] ?? 'bg-gray-400 dark:bg-gray-500'}`} />
+```
+
+with:
+
+```tsx
+<div className={`w-2 h-2 rounded-full ${getPoolTypeColor(node.type)}`} />
+```
+
+Then dim the row instead. Find the row `<div>` whose `className` starts with `flex items-center gap-2 py-1.5 px-2 rounded` and add the opacity to its template literal, immediately after the `node.conflict` ternary:
+
+```tsx
+className={`flex items-center gap-2 py-1.5 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ${
+  node.conflict ? 'bg-red-50 dark:bg-red-900/30 hover:bg-red-100 dark:hover:bg-red-900/50' : ''
+} ${node.type === 'subnet' ? 'opacity-50' : ''}`}
+```
+
+`opacity-50` is a literal string here so Tailwind will compile it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/PoolTree.test.tsx'`
+Expected: PASS.
+
+Then confirm nothing else referenced the deleted map:
+
+Run: `grep -rn "TYPE_COLORS" ui/src`
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/wizard/components/TreeNode.tsx ui/src/__tests__/PoolTree.test.tsx
+git commit -m "fix(ui): keep subnet hue in the wizard tree, dim the row instead
+
+TYPE_COLORS greyed out subnets and omitted root/account entirely, so the
+same pool rendered purple in PoolTree and grey in the Schema Planner, and
+grey meant both 'subnet' and 'unknown type'."
+```
+
+---
+
+### Task 4: Render the Schema Planner legend from `POOL_TYPES`
+
+Decision 1 is resolved: all five real pool types appear in the legend. This task is unblocked.
+
+**Files:**
+- Modify: `ui/src/wizard/steps/PreviewStep.tsx:80-87`
+
+**Interfaces:**
+- Consumes: `POOL_TYPES` from Task 1.
+- Produces: no new exports.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ui/src/__tests__/DimensionsStep.test.tsx` — or create `ui/src/__tests__/PreviewStepLegend.test.tsx` if you prefer isolation; this plan assumes the new file:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import PreviewStep from '../wizard/steps/PreviewStep'
+import type { SchemaNode } from '../wizard/utils/cidr'
+import { POOL_TYPES } from '../utils/poolTypes'
+
+const schema: SchemaNode = {
+  id: 'root',
+  name: 'Corporate Supernet',
+  type: 'supernet',
+  cidr: '10.0.0.0/8',
+  children: [],
+}
+
+describe('PreviewStep legend', () => {
+  it('lists every legend-visible pool type', () => {
+    render(
+      <PreviewStep
+        schema={schema}
+        conflicts={[]}
+        conflictsLoading={false}
+        conflictsError={null}
+        onExport={() => {}}
+      />,
+    )
+    for (const t of POOL_TYPES) {
+      expect(screen.getByText(t.label)).toBeTruthy()
+    }
+  })
+
+  it('includes Subnet, which the old literal legend omitted', () => {
+    render(
+      <PreviewStep
+        schema={schema}
+        conflicts={[]}
+        conflictsLoading={false}
+        conflictsError={null}
+        onExport={() => {}}
+      />,
+    )
+    expect(screen.getByText('Subnet')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/PreviewStepLegend.test.tsx'`
+Expected: FAIL — the legend has four hard-coded labels (Root, Region, Environment, Account) and no "Subnet" or "Supernet".
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ui/src/wizard/steps/PreviewStep.tsx`, add to the imports:
+
+```ts
+import { POOL_TYPES } from '../../utils/poolTypes'
+```
+
+Replace the four literal `<span>` swatches at lines 82-85 with:
+
+```tsx
+{POOL_TYPES.map((t) => (
+  <span key={t.id} className="flex items-center gap-1">
+    <div className={`w-2 h-2 rounded-full ${t.dot}`} /> {t.label}
+  </span>
+))}
+```
+
+All five types are legend-visible, so there is no filter. If a sixth pool type is ever added to `internal/domain/types.go`, adding it to `POOL_TYPES` is the only frontend change needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/PreviewStepLegend.test.tsx'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/wizard/steps/PreviewStep.tsx ui/src/__tests__/PreviewStepLegend.test.tsx
+git commit -m "fix(ui): render Schema Planner legend from POOL_TYPES
+
+The legend was four literal swatches naming Root and Account, neither of
+which the wizard emits, while omitting Supernet and Subnet, which it does."
+```
+
+---
+
+### Task 5: Give `locked` / `disabled` / `revoked` / `idle` their own colors
+
+**Files:**
+- Modify: `ui/src/utils/format.ts:69-82` (`getStatusBadgeClass`)
+- Test: `ui/src/__tests__/format.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `getStatusBadgeClass` — unchanged signature, four new recognised statuses.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing top-level `describe` in `ui/src/__tests__/format.test.ts`:
+
+```ts
+  it('getStatusBadgeClass colors account lifecycle states distinctly', () => {
+    expect(getStatusBadgeClass('locked')).toContain('amber')
+    expect(getStatusBadgeClass('disabled')).toContain('red')
+    expect(getStatusBadgeClass('revoked')).toContain('red')
+    expect(getStatusBadgeClass('idle')).toContain('amber')
+  })
+
+  it('getStatusBadgeClass no longer greys out known account states', () => {
+    // Regression: a locked account and a planned pool rendered identically.
+    const grey = getStatusBadgeClass('some-unknown-status')
+    for (const s of ['locked', 'disabled', 'revoked', 'idle']) {
+      expect(getStatusBadgeClass(s)).not.toBe(grey)
+    }
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/format.test.ts'`
+Expected: FAIL — all four currently return the grey default, so `.toContain('amber')` fails.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ui/src/utils/format.ts`, add these four entries to the `classes` record inside `getStatusBadgeClass`, alongside the existing `active` / `planned` / `deprecated` keys:
+
+```ts
+    locked: 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300',
+    disabled: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+    revoked: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+    idle: 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300',
+```
+
+All eight classes already ship in the compiled stylesheet at `-100` / `-700` / `dark:-900` / `dark:-300`, so no new Tailwind surface is introduced.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nix develop --command bash -c 'cd ui && npx vitest run src/__tests__/format.test.ts'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/utils/format.ts ui/src/__tests__/format.test.ts
+git commit -m "fix(ui): color locked/disabled/revoked/idle status badges
+
+All four fell through to the grey default, making a locked account and a
+planned pool visually identical."
+```
+
+---
+
+### Task 6: Remove the dead `dark:hover:bg-gray-750` class
+
+**Files:**
+- Modify: `ui/src/components/UsersAdminPanel.tsx:259`
+- Modify: `ui/src/pages/ApiKeysPage.tsx:276`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+`gray-750` is not a Tailwind color. It compiles to nothing, so these two tables have no dark-mode row hover at all. The spec flagged only `UsersAdminPanel`; `ApiKeysPage` has the identical bug.
+
+- [ ] **Step 1: Confirm the class is genuinely dead**
+
+Run:
+```bash
+nix develop --command node -e 'console.log(require("fs").readFileSync("ui/.ds-css/compiled.css","utf8").includes("gray-750"))'
+```
+Expected: `false` — the class does not exist in the compiled stylesheet.
+
+Run: `grep -rn "gray-750" ui/src`
+Expected: exactly two hits, the two lines above.
+
+- [ ] **Step 2: Replace both occurrences**
+
+In both files, change:
+
+```
+dark:hover:bg-gray-750
+```
+
+to:
+
+```
+dark:hover:bg-gray-700
+```
+
+`dark:hover:bg-gray-700` is already present in the compiled stylesheet.
+
+- [ ] **Step 3: Verify no occurrences remain**
+
+Run: `grep -rn "gray-750" ui/src`
+Expected: no output.
+
+- [ ] **Step 4: Run the full suite and type check**
+
+Run: `nix develop --command bash -c 'cd ui && npx tsc --noEmit && npx vitest run'`
+Expected: type check clean, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/components/UsersAdminPanel.tsx ui/src/pages/ApiKeysPage.tsx
+git commit -m "fix(ui): use a real Tailwind color for dark-mode row hover
+
+gray-750 does not exist, so dark:hover:bg-gray-750 compiled to nothing and
+neither table had a dark-mode hover state."
+```
+
+---
+
+### Task 7: Rebuild and re-sync the design system
+
+The design system ships CloudPAM's **compiled** Tailwind CSS, so the color changes above do not reach claude.ai/design until the bundle is rebuilt. `TreeNode` and `PoolTree` previews will both change appearance.
+
+**Files:**
+- Modify: none by hand. `ui/.ds-css/compiled.css` and `ui/types/` are regenerated.
+
+- [ ] **Step 1: Run the full frontend build**
+
+Run: `nix develop --command bash -c 'cd ui && npm run build'`
+Expected: exit 0.
+
+- [ ] **Step 2: Re-sync**
+
+Follow `.design-sync/NOTES.md`. In short, from the repo root:
+
+```bash
+ln -sfn .. ui/node_modules/cloudpam-ui   # only if npm ci has run since the last sync
+nix develop --command bash -c 'cd ui && npx tsc -p tsconfig.dts.json'
+nix develop --command node .ds-sync/resync.mjs --config .design-sync/config.json \
+  --node-modules ui/node_modules --out ./ds-bundle \
+  --remote .design-sync/.cache/remote-sync.json
+```
+
+Expected: the verdict JSON lists `TreeNode` and `PoolTree` under `verification.changed` (their render hashes moved), with `upload.any: true`.
+
+- [ ] **Step 3: Re-grade the changed previews**
+
+Read `ds-bundle/_screenshots/review/schema-wizard__TreeNode.png` and `.../data-display__PoolTree.png`. Confirm subnet dots are orange and subnet rows in the wizard are dimmed. Write verdicts to `.design-sync/.cache/review/<Name>.grade.json` per the design-sync skill.
+
+- [ ] **Step 4: Upload**
+
+Per the design-sync skill's §5 atomic path — the project is pinned and non-empty, so it updates in one pass.
+
+- [ ] **Step 5: Commit any sync-input changes**
+
+```bash
+git add .design-sync
+git commit -m "chore(design-sync): re-sync after pool-type color unification"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** This plan covers §6 (Tasks 1–4), §3 (Task 5), and the `dark:hover:bg-gray-750` defect noted in §2 (Task 6). Deliberately **out of scope**, each deferred to its own plan: §1/§1b/§1c/§1d (Settings nav, service accounts, federated deactivation, denial codes), §2/§2b/§2c/§2d (retiring `UsersAdminPanel`, role lifecycle, first-run, responsive), §4 (six primitives), §5 (toast adoption).
+
+**2. Placeholder scan.** No TBDs. Every code step carries the literal code, and there are no remaining conditionals — Decision 1 is resolved to five pool types.
+
+**3. Type consistency.** `PoolTypeMeta` / `POOL_TYPES` / `UNKNOWN_POOL_TYPE_DOT` / `poolTypeDot` are defined in Task 1 and used with those exact names in Tasks 2 and 4. `getPoolTypeColor(type: string): string` keeps its existing signature throughout. `SchemaNode` is imported from `../wizard/utils/cidr`, matching the existing source.
+
+**Correction to the spec:** §3 gives the path `ui/src/utils/badges.ts`. That file does not exist; `getStatusBadgeClass` is in `ui/src/utils/format.ts`. Task 5 uses the real path.
+
+---
+
+## Remaining Plans (not yet written)
+
+| Plan | Covers | Blocked by |
+|---|---|---|
+| **B — Config primitives** | §4: `Modal`, `ConfirmDialog`, `Field`, `Toggle`, `DataTable`, `EmptyState`; §5 toast rules | Nothing. Should be written next — C depends on it. |
+| **C — Settings shell** | §1 nav collapse + redirects, §2 retire `UsersAdminPanel`, §2b role lifecycle UI, §2c first-run, §2d responsive | Plan B; and §2b's UI needs Plan D's 409 response. |
+| **D — Identity backend** | §1b service accounts (new table, endpoints, migration `0022`, three storage backends), §1c local-only deactivation, §1d denial codes + audit, §2b reference-checked role deletion, `idp:manage` permission | All five open questions in `docs/design/identity-decisions.md`. |
+
+Plan D is the largest and the only one touching Go, SQL, and `internal/auth`. Migrations are currently at `0021_network_objects_relationships.sql`, so it starts at `0022`. Note `CLAUDE.md` still says migrations end at `0017` — it is out of date and should be corrected as part of Plan D.

--- a/ui/tsconfig.dts.json
+++ b/ui/tsconfig.dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Imports the 19 reusable components from `ui/src/components` and `ui/src/wizard` into a Claude Design project, so the design agent builds with CloudPAM's real components instead of generic ones.

**Nothing in `ui/src` changes.** This adds sync inputs only — config, authored preview cards, a converter fork, and notes. The one production-adjacent file is `ui/tsconfig.dts.json`, a separate tsconfig that is not part of `npm run build`.

## Why each piece exists

`ui/` is an application, not a component library (`private: true`, no exports entry, no `dist/`). Most of this follows from that:

- **`ui/tsconfig.dts.json`** emits declarations to `ui/types/` (gitignored). Without it every generated `<Name>Props` is an empty `[key: string]: unknown` — the design agent gets no API contract at all. `findTypesRoot` auto-detects the directory, so **`ui/package.json` is untouched**.
- **`.design-sync/overrides/source-kit.mjs`** forks the converter's package adapter for two reasons: the stock synth entry emits only `export * from`, which does not re-export defaults — and every component here is `export default function <Name>`, so `window.CloudPAM.<Name>` would be `undefined`. It also scopes discovery to `components/` + `wizard/`, otherwise the entry pulls in `main.tsx` → `index.css` → `@import "tailwindcss"` and esbuild cannot resolve it.
- **`.design-sync/preview-provider.tsx`** supplies a `MemoryRouter` and a signed-in admin. The app's three contexts all have defaults, but those defaults are a *signed-out* user (`hasPermission: () => false`), which renders `Sidebar`'s nav empty and `Header` signed-out.
- **`.design-sync/previews/*.tsx`** are the authored preview cards — real props and children for the real components, no reimplementation.

## Verification

All 19 components have authored previews; every cell was captured and graded against the absolute rubric. Final `package-validate.mjs` run: **19/19 previews render, 0 bad, 0 thin, 0 identical-variant, 0 floor cards, no warnings.**

## Gotcha worth knowing

The shipped stylesheet is the app's **compiled** Tailwind output, so only classes CloudPAM already uses exist — `h-40`/`h-56`/`max-w-xl` and friends silently resolve to nothing. Preview layout therefore uses inline styles, and `.design-sync/conventions.md` documents the same constraint for the design agent (it's prepended to the generated README the agent reads).

## Re-syncing

See `.design-sync/NOTES.md`. Two things are ephemeral and must be recreated after `npm ci`:

```sh
ln -sfn .. ui/node_modules/cloudpam-ui   # converter resolves <node_modules>/<pkg>
# then cfg.buildCmd, which regenerates ui/types/ and ui/.ds-css/compiled.css
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)