### PR TITLE
fix(ui): unify pool-type color, extend status badge vocabulary (Plan A)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -135,6 +135,11 @@ checked properly, so don't "fix" the conventions file for them:
 - **The self-link and `ui/types/` are both gitignored/ephemeral.** A fresh clone
   needs `npm ci`, then the `ln -sfn`, then `cfg.buildCmd`. Forgetting either is
   the most likely first failure.
+- **`.design-sync/node_modules` is also a gitignored symlink** (`-> ../.ds-sync/node_modules`,
+  per `.gitignore:77`) and just as easy to forget on a fresh clone. Without it the
+  converter can't resolve its own dependencies and fails with a misleading `ts-morph`
+  resolution error that looks like a config problem, not a missing link. Recreate it
+  the same way as the `cloudpam-ui` self-link, before running `cfg.buildCmd`.
 - **`cssEntry` is a copy, not a live file.** If someone runs the converter
   without `buildCmd`, `ui/.ds-css/compiled.css` is stale (or absent) and the
   cards render against old CSS. When in doubt, re-run `buildCmd`.

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -89,12 +89,13 @@ There are no brand webfonts — type is the system stack (`--font-sans`), with
 
 ## Product idiom
 
-- CIDRs render monospace next to a colored type dot. `getPoolTypeColor` drives
-  it: supernet/root=`bg-purple-500`, region=`bg-blue-500`,
-  environment=`bg-green-500`, vpc/account=`bg-amber-500`,
-  subnet=`bg-orange-500`, unknown=`bg-gray-400`. (The Schema Wizard's `TreeNode`
-  keeps its own near-identical map that greys out subnets — match whichever
-  surface you're building alongside.)
+- CIDRs render monospace next to a colored type dot. `POOL_TYPES` in
+  `src/utils/poolTypes.ts` is the single source: supernet=`bg-purple-500`,
+  region=`bg-blue-500`, environment=`bg-green-500`, vpc=`bg-amber-500`,
+  subnet=`bg-orange-500`. Grey (`bg-gray-400`) is reserved for an unrecognised
+  type and must never be used for a known one. `getPoolTypeColor` and the Schema
+  Wizard's `TreeNode` both read that map, so every surface agrees; `TreeNode`
+  dims a subnet row with `opacity-50` rather than changing its hue.
 - Utilization is a bar plus a percentage; it turns red as a pool fills.
 - `StatusBadge` is the one labeling primitive — `variant` picks the vocabulary
   (`status` / `provider` / `tier` / `action` / `type`), so use it instead of

--- a/docs/design/repo-changes.md
+++ b/docs/design/repo-changes.md
@@ -276,6 +276,21 @@ Until this lands, the Users pane in the template renders those three states with
 literal styles matching these exact values — swap them back to `<StatusBadge>` after the
 sync.
 
+**Correction to the spec:** the claim above that these four fall through to grey "in the
+live UI" is false — verified during the final review of Plan A. `getStatusBadgeClass` has
+exactly one call site, `StatusBadge.tsx:32` (the `variant === 'status'` default case), and
+nothing in the app currently passes it `locked`/`disabled`/`revoked`/`idle`. The surfaces
+that actually render these statuses today hand-roll their own pills instead of going
+through `StatusBadge`: `UsersAdminPanel.tsx:309-321` (Locked/Active/Disabled) and
+`ApiKeysPage.tsx:91-106` (Revoked/Expired/Expiring/No expiry/Active). So there is no live
+defect to fix — the four entries are still correct to add (Plan C routes these surfaces
+through `StatusBadge`), just pre-wiring rather than a fix. One follow-on detail for that
+port: the hand-rolled pills use `dark:bg-amber-900/30`, while `getStatusBadgeClass` (in
+`ui/src/utils/format.ts` — the `badges.ts` path above is stale; see the correction note in
+`docs/superpowers/plans/2026-08-04-pool-type-color-and-status-badges.md`) uses
+`dark:bg-amber-900` with no opacity suffix, so swapping them in is a visible color delta,
+not a no-op.
+
 ---
 
 ## 4. Extract the config primitives

--- a/ui/src/__tests__/PoolTree.test.tsx
+++ b/ui/src/__tests__/PoolTree.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import PoolTree from '../components/PoolTree'
 import type { PoolWithStats } from '../api/types'
+import TreeNode from '../wizard/components/TreeNode'
+import type { SchemaNode } from '../wizard/utils/cidr'
 
 function pool(id: number, name: string, cidr: string, children: PoolWithStats[] = []): PoolWithStats {
   return {
@@ -94,5 +96,32 @@ describe('PoolTree global expand controls', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Expand All' }))
     expect(screen.getByText('Region')).toBeTruthy()
     expect(screen.getByText('Environment')).toBeTruthy()
+  })
+})
+
+describe('TreeNode pool-type color', () => {
+  const node = (type: SchemaNode['type']): SchemaNode => ({
+    id: 'n1',
+    name: 'node',
+    type,
+    cidr: '10.0.0.0/24',
+    children: [],
+  })
+
+  it('gives a subnet its own hue instead of grey', () => {
+    const { container } = render(<TreeNode node={node('subnet')} />)
+    expect(container.querySelector('.bg-orange-500')).toBeTruthy()
+    expect(container.querySelector('.bg-gray-400')).toBeNull()
+  })
+
+  it('dims the subnet row rather than recoloring the dot', () => {
+    const { container } = render(<TreeNode node={node('subnet')} />)
+    expect(container.querySelector('.opacity-50')).toBeTruthy()
+  })
+
+  it('does not dim a non-subnet row', () => {
+    const { container } = render(<TreeNode node={node('region')} />)
+    expect(container.querySelector('.opacity-50')).toBeNull()
+    expect(container.querySelector('.bg-blue-500')).toBeTruthy()
   })
 })

--- a/ui/src/__tests__/PreviewStepLegend.test.tsx
+++ b/ui/src/__tests__/PreviewStepLegend.test.tsx
@@ -13,8 +13,8 @@ const schema: SchemaNode = {
 }
 
 describe('PreviewStep legend', () => {
-  it('lists every legend-visible pool type', () => {
-    render(
+  it('lists every legend-visible pool type with its assigned color', () => {
+    const { container } = render(
       <PreviewStep
         schema={schema}
         conflicts={[]}
@@ -25,6 +25,7 @@ describe('PreviewStep legend', () => {
     )
     for (const t of POOL_TYPES) {
       expect(screen.getByText(t.label)).toBeTruthy()
+      expect(container.querySelector('.' + t.dot)).toBeTruthy()
     }
   })
 

--- a/ui/src/__tests__/PreviewStepLegend.test.tsx
+++ b/ui/src/__tests__/PreviewStepLegend.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import PreviewStep from '../wizard/steps/PreviewStep'
+import type { SchemaNode } from '../wizard/utils/cidr'
+import { POOL_TYPES } from '../utils/poolTypes'
+
+const schema: SchemaNode = {
+  id: 'root',
+  name: 'Corporate Supernet',
+  type: 'supernet',
+  cidr: '10.0.0.0/8',
+  children: [],
+}
+
+describe('PreviewStep legend', () => {
+  it('lists every legend-visible pool type', () => {
+    render(
+      <PreviewStep
+        schema={schema}
+        conflicts={[]}
+        conflictsLoading={false}
+        conflictsError={null}
+        onExport={() => {}}
+      />,
+    )
+    for (const t of POOL_TYPES) {
+      expect(screen.getByText(t.label)).toBeTruthy()
+    }
+  })
+
+  it('includes Subnet, which the old literal legend omitted', () => {
+    render(
+      <PreviewStep
+        schema={schema}
+        conflicts={[]}
+        conflictsLoading={false}
+        conflictsError={null}
+        onExport={() => {}}
+      />,
+    )
+    expect(screen.getByText('Subnet')).toBeTruthy()
+  })
+})

--- a/ui/src/__tests__/format.test.ts
+++ b/ui/src/__tests__/format.test.ts
@@ -10,6 +10,7 @@ import {
   getStatusBadgeClass,
   getActionBadgeClass,
 } from '../utils/format'
+import { POOL_TYPES, UNKNOWN_POOL_TYPE_DOT } from '../utils/poolTypes'
 
 describe('formatHostCount', () => {
   it('returns raw number for small counts', () => {
@@ -85,6 +86,19 @@ describe('color helpers', () => {
     expect(getPoolTypeColor('supernet')).toBe('bg-purple-500')
     expect(getPoolTypeColor('vpc')).toBe('bg-amber-500')
     expect(getPoolTypeColor('unknown')).toBe('bg-gray-400')
+  })
+
+  it('getPoolTypeColor agrees with POOL_TYPES for every known type', () => {
+    for (const t of POOL_TYPES) {
+      expect(getPoolTypeColor(t.id)).toBe(t.dot)
+    }
+  })
+
+  it('getPoolTypeColor gives subnet its own hue, not grey', () => {
+    // Regression: the wizard used to grey out subnets, which collided with
+    // the unknown-type fallback.
+    expect(getPoolTypeColor('subnet')).toBe('bg-orange-500')
+    expect(getPoolTypeColor('subnet')).not.toBe(UNKNOWN_POOL_TYPE_DOT)
   })
 
   it('getUtilizationColor returns red for high utilization', () => {

--- a/ui/src/__tests__/format.test.ts
+++ b/ui/src/__tests__/format.test.ts
@@ -128,4 +128,19 @@ describe('color helpers', () => {
     expect(getActionBadgeClass('update')).toContain('blue')
     expect(getActionBadgeClass('delete')).toContain('red')
   })
+
+  it('getStatusBadgeClass colors account lifecycle states distinctly', () => {
+    expect(getStatusBadgeClass('locked')).toContain('amber')
+    expect(getStatusBadgeClass('disabled')).toContain('red')
+    expect(getStatusBadgeClass('revoked')).toContain('red')
+    expect(getStatusBadgeClass('idle')).toContain('amber')
+  })
+
+  it('getStatusBadgeClass no longer greys out known account states', () => {
+    // Regression: a locked account and a planned pool rendered identically.
+    const grey = getStatusBadgeClass('some-unknown-status')
+    for (const s of ['locked', 'disabled', 'revoked', 'idle']) {
+      expect(getStatusBadgeClass(s)).not.toBe(grey)
+    }
+  })
 })

--- a/ui/src/__tests__/poolTypes.test.ts
+++ b/ui/src/__tests__/poolTypes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { POOL_TYPES, UNKNOWN_POOL_TYPE_DOT, poolTypeDot } from '../utils/poolTypes'
+
+describe('POOL_TYPES', () => {
+  it('matches the five pool types the Go domain accepts', () => {
+    // internal/domain/types.go ValidPoolTypes is authoritative.
+    const ids = POOL_TYPES.map((t) => t.id)
+    expect(ids).toEqual(['supernet', 'region', 'environment', 'vpc', 'subnet'])
+  })
+
+  it('does not resurrect the dead root/account keys', () => {
+    // 'root' is a node id (useSchemaGenerator) and 'account' is a search-result
+    // kind (SearchModal) — neither is a pool type.
+    expect(poolTypeDot('root')).toBe(UNKNOWN_POOL_TYPE_DOT)
+    expect(poolTypeDot('account')).toBe(UNKNOWN_POOL_TYPE_DOT)
+  })
+
+  it('never assigns the unknown-type grey to a known type', () => {
+    // Grey must mean exactly one thing: "type not recognised". If a known
+    // type also renders grey, an unrecognised type becomes invisible.
+    const greys = POOL_TYPES.filter((t) => t.dot === UNKNOWN_POOL_TYPE_DOT)
+    expect(greys).toEqual([])
+  })
+
+  it('gives every type a non-empty label', () => {
+    for (const t of POOL_TYPES) {
+      expect(t.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('resolves a known type to its dot class', () => {
+    expect(poolTypeDot('subnet')).toBe('bg-orange-500')
+    expect(poolTypeDot('supernet')).toBe('bg-purple-500')
+  })
+
+  it('falls back to grey for an unrecognised type', () => {
+    expect(poolTypeDot('nonsense')).toBe(UNKNOWN_POOL_TYPE_DOT)
+  })
+})

--- a/ui/src/components/UsersAdminPanel.tsx
+++ b/ui/src/components/UsersAdminPanel.tsx
@@ -256,7 +256,7 @@ export default function UsersAdminPanel({ embedded = false }: UsersAdminPanelPro
               </tr>
             ) : (
               users.map(u => (
-                <tr key={u.id} className="border-b dark:border-gray-700 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-750">
+                <tr key={u.id} className="border-b dark:border-gray-700 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-700">
                   <td className="px-4 py-3">
                     <div>
                       <span className="font-medium text-gray-900 dark:text-white">{u.username}</span>

--- a/ui/src/pages/ApiKeysPage.tsx
+++ b/ui/src/pages/ApiKeysPage.tsx
@@ -273,7 +273,7 @@ export default function ApiKeysPage() {
               </tr>
             ) : (
               keys.map(k => (
-                <tr key={k.id} className="border-b dark:border-gray-700 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-750">
+                <tr key={k.id} className="border-b dark:border-gray-700 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-700">
                   <td className="px-4 py-3 font-medium text-gray-900 dark:text-white">{k.name}</td>
                   <td className="px-4 py-3 font-mono text-gray-600 dark:text-gray-400">{k.prefix}...</td>
                   <td className="hidden md:table-cell px-4 py-3">

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -70,6 +70,10 @@ export function getStatusBadgeClass(status: string): string {
     running: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
     pending: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
     failed: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+    locked: 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300',
+    disabled: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+    revoked: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+    idle: 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300',
   }
   return classes[status] || 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
 }

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -1,3 +1,5 @@
+import { poolTypeDot } from './poolTypes'
+
 export function formatHostCount(count: number): string {
   if (count >= 1000000) return (count / 1000000).toFixed(1) + 'M'
   if (count >= 1000) return (count / 1000).toFixed(1) + 'K'
@@ -29,16 +31,7 @@ export function formatTimeAgo(timestamp: string): string {
 }
 
 export function getPoolTypeColor(type: string): string {
-  const colors: Record<string, string> = {
-    supernet: 'bg-purple-500',
-    root: 'bg-purple-500',
-    region: 'bg-blue-500',
-    environment: 'bg-green-500',
-    vpc: 'bg-amber-500',
-    subnet: 'bg-orange-500',
-    account: 'bg-amber-500',
-  }
-  return colors[type] || 'bg-gray-400'
+  return poolTypeDot(type)
 }
 
 export function getUtilizationColor(util: number): string {

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -70,6 +70,9 @@ export function getStatusBadgeClass(status: string): string {
     running: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
     pending: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
     failed: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+    // locked/disabled/revoked/idle: account & key lifecycle vocabulary. 'idle' here
+    // is NOT the self-upgrade "idle" (UpdatesPage) — that's the normal at-rest
+    // state, where this amber would misread as attention-needed.
     locked: 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300',
     disabled: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
     revoked: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',

--- a/ui/src/utils/poolTypes.ts
+++ b/ui/src/utils/poolTypes.ts
@@ -25,8 +25,8 @@ export const POOL_TYPES: readonly PoolTypeMeta[] = [
   { id: 'subnet', label: 'Subnet', dot: 'bg-orange-500' },
 ]
 
-const BY_ID = new Map(POOL_TYPES.map((t) => [t.id, t]))
+const BY_ID = new Map<string, PoolTypeMeta>(POOL_TYPES.map((t) => [t.id, t]))
 
 export function poolTypeDot(type: string): string {
-  return BY_ID.get(type as PoolType)?.dot ?? UNKNOWN_POOL_TYPE_DOT
+  return BY_ID.get(type)?.dot ?? UNKNOWN_POOL_TYPE_DOT
 }

--- a/ui/src/utils/poolTypes.ts
+++ b/ui/src/utils/poolTypes.ts
@@ -1,0 +1,32 @@
+// Single source of truth for pool-type presentation.
+//
+// Grey is reserved: it means "type not recognised". Nothing in POOL_TYPES may
+// use UNKNOWN_POOL_TYPE_DOT, or an unknown type becomes indistinguishable from
+// a known one. Dot classes are written as full literal strings because
+// Tailwind v4 only compiles classes it can find literally in ui/src.
+// The five ids mirror internal/domain/types.go ValidPoolTypes, which the API
+// enforces via IsValidPoolType. Do not add 'root' or 'account': the former is a
+// node id in the schema generator, the latter a search-result kind.
+import type { PoolType } from '../api/types'
+
+export interface PoolTypeMeta {
+  id: PoolType
+  label: string
+  dot: string
+}
+
+export const UNKNOWN_POOL_TYPE_DOT = 'bg-gray-400'
+
+export const POOL_TYPES: readonly PoolTypeMeta[] = [
+  { id: 'supernet', label: 'Supernet', dot: 'bg-purple-500' },
+  { id: 'region', label: 'Region', dot: 'bg-blue-500' },
+  { id: 'environment', label: 'Environment', dot: 'bg-green-500' },
+  { id: 'vpc', label: 'VPC', dot: 'bg-amber-500' },
+  { id: 'subnet', label: 'Subnet', dot: 'bg-orange-500' },
+]
+
+const BY_ID = new Map(POOL_TYPES.map((t) => [t.id, t]))
+
+export function poolTypeDot(type: string): string {
+  return BY_ID.get(type as PoolType)?.dot ?? UNKNOWN_POOL_TYPE_DOT
+}

--- a/ui/src/wizard/components/TreeNode.tsx
+++ b/ui/src/wizard/components/TreeNode.tsx
@@ -2,14 +2,7 @@ import { useState } from 'react'
 import { ChevronRight, ChevronDown, AlertTriangle } from 'lucide-react'
 import type { SchemaNode } from '../utils/cidr'
 import { usableHosts, formatHostCount } from '../utils/cidr'
-
-const TYPE_COLORS: Record<string, string> = {
-  supernet: 'bg-purple-500',
-  region: 'bg-blue-500',
-  environment: 'bg-green-500',
-  vpc: 'bg-amber-500',
-  subnet: 'bg-gray-400 dark:bg-gray-500',
-}
+import { getPoolTypeColor } from '../../utils/format'
 
 interface Props {
   node: SchemaNode
@@ -27,7 +20,7 @@ export default function TreeNode({ node, depth = 0, defaultExpanded }: Props) {
       <div
         className={`flex items-center gap-2 py-1.5 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer ${
           node.conflict ? 'bg-red-50 dark:bg-red-900/30 hover:bg-red-100 dark:hover:bg-red-900/50' : ''
-        }`}
+        } ${node.type === 'subnet' ? 'opacity-50' : ''}`}
         style={{ paddingLeft: `${depth * 20 + 8}px` }}
         onClick={() => hasChildren && setExpanded(!expanded)}
       >
@@ -41,7 +34,7 @@ export default function TreeNode({ node, depth = 0, defaultExpanded }: Props) {
           <div className="w-4" />
         )}
 
-        <div className={`w-2 h-2 rounded-full ${TYPE_COLORS[node.type] ?? 'bg-gray-400 dark:bg-gray-500'}`} />
+        <div className={`w-2 h-2 rounded-full ${getPoolTypeColor(node.type)}`} />
 
         <span className="font-medium text-gray-900 dark:text-gray-100">{node.name}</span>
         <code className="text-xs bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded font-mono text-gray-600 dark:text-gray-300">

--- a/ui/src/wizard/steps/PreviewStep.tsx
+++ b/ui/src/wizard/steps/PreviewStep.tsx
@@ -79,7 +79,7 @@ export default function PreviewStep({ schema, conflicts, conflictsLoading, confl
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
         <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 border-b dark:border-gray-700 flex items-center justify-between">
           <h3 className="font-medium text-gray-900 dark:text-gray-100">Address Space Hierarchy</h3>
-          <div className="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
+          <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
             {POOL_TYPES.map((t) => (
               <span key={t.id} className="flex items-center gap-1">
                 <div className={`w-2 h-2 rounded-full ${t.dot}`} /> {t.label}

--- a/ui/src/wizard/steps/PreviewStep.tsx
+++ b/ui/src/wizard/steps/PreviewStep.tsx
@@ -3,6 +3,7 @@ import type { SchemaNode } from '../utils/cidr'
 import { hostCount, formatHostCount, countLeafNodes } from '../utils/cidr'
 import type { SchemaConflict } from '../../api/types'
 import TreeNode from '../components/TreeNode'
+import { POOL_TYPES } from '../../utils/poolTypes'
 
 interface Props {
   schema: SchemaNode
@@ -79,10 +80,11 @@ export default function PreviewStep({ schema, conflicts, conflictsLoading, confl
         <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 border-b dark:border-gray-700 flex items-center justify-between">
           <h3 className="font-medium text-gray-900 dark:text-gray-100">Address Space Hierarchy</h3>
           <div className="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
-            <span className="flex items-center gap-1"><div className="w-2 h-2 rounded-full bg-purple-500" /> Root</span>
-            <span className="flex items-center gap-1"><div className="w-2 h-2 rounded-full bg-blue-500" /> Region</span>
-            <span className="flex items-center gap-1"><div className="w-2 h-2 rounded-full bg-green-500" /> Environment</span>
-            <span className="flex items-center gap-1"><div className="w-2 h-2 rounded-full bg-amber-500" /> Account</span>
+            {POOL_TYPES.map((t) => (
+              <span key={t.id} className="flex items-center gap-1">
+                <div className={`w-2 h-2 rounded-full ${t.dot}`} /> {t.label}
+              </span>
+            ))}
           </div>
         </div>
         <div className="p-4 max-h-96 overflow-auto font-mono text-sm">


### PR DESCRIPTION
Implements **Plan A** of the four plans the Administration/Configuration design spec decomposes into: `docs/superpowers/plans/2026-08-04-pool-type-color-and-status-badges.md`.

This was built on `design-sync/cloudpam-design-system` because the design-system re-sync needs the `.design-sync/` scaffolding that branch adds. #250 squash-merged into `master` while this was in flight, so the branch has been rebased onto `master` and targets it directly. The rebase was clean — every file this branch shares with #250 was byte-identical.

## What this fixes

**Pool-type color had two sources that disagreed.** `getPoolTypeColor` in `utils/format.ts` and a private `TYPE_COLORS` map in `wizard/components/TreeNode.tsx` each owned their own literal mapping. The same pool rendered purple in `PoolTree` and grey in the Schema Planner.

A new `ui/src/utils/poolTypes.ts` owns `POOL_TYPES` — the single id → label → dot mapping — and everything now reads from it. `TYPE_COLORS` is deleted; `grep -rn "TYPE_COLORS" ui/src` returns nothing.

**Grey meant two things.** The wizard de-emphasised subnets by swapping their hue for grey, colliding with the unrecognised-type fallback. Subnet rows now keep their orange hue and get `opacity-50` instead, so grey means exactly one thing.

**The legend named types the system cannot produce.** It listed Root and Account — `root` is a node id in the schema generator, `account` is a search-result kind — while omitting Supernet and Subnet, which the wizard does emit. The legend now renders from `POOL_TYPES`, so adding a sixth type to `internal/domain/types.go` needs one frontend change, not two.

**`dark:hover:bg-gray-750` compiled to nothing.** `gray-750` is not a Tailwind color, so `UsersAdminPanel` and `ApiKeysPage` had no dark-mode row hover at all. Both now use `dark:hover:bg-gray-700`.

## One correction to the spec

The spec (`docs/design/repo-changes.md`) claimed `locked`/`disabled`/`revoked`/`idle` fall through to grey so "a locked account and a planned pool render identically". **That never happened.** `getStatusBadgeClass` has exactly one consumer — `StatusBadge` with `variant="status"` — and no caller passes any of those four. The surfaces that render them hand-roll their own pills (`UsersAdminPanel.tsx:309-321`, `ApiKeysPage.tsx:91-106`).

The four entries are still correct to add — Plan C routes those surfaces through `StatusBadge` — but they are **pre-wiring, not a fix to a live defect**. The correction is recorded in `repo-changes.md` so Plan C does not inherit the false premise, along with the detail that the hand-rolled pills use `dark:bg-amber-900/30` where `format.ts` uses `dark:bg-amber-900` — swapping them in is a visible delta, not a no-op.

## Design system

`ui/` was rebuilt and re-synced to the pinned claude.ai/design project. The re-sync verdict is green across build/diff/validate with zero warns; the compiled bundle carries `bg-orange-500`, `opacity-50`, `flex-wrap` and zero `gray-750`.

Note for future re-syncs: `verification.changed` stays empty for app-source-only changes, because render hashes cover per-component preview artifacts, not the shared bundle — the bundle/style hash moves instead. The plan's Task 7 predicted otherwise; that prediction was mechanically impossible.

`.design-sync/NOTES.md` gains the `.design-sync/node_modules -> ../.ds-sync/node_modules` symlink, which the runbook omitted and whose absence fails a fresh re-sync with a misleading `ts-morph` error.

## Testing

- 288 frontend tests across 47 files, `tsc --noEmit` clean
- `go test ./...` — 18 packages ok, exit 0
- Zero Go, SQL, `internal/` or `migrations/` files touched

Each behavioural claim is pinned by a test that fails if regressed: no `POOL_TYPES` entry may equal the unknown-type grey; a subnet dot renders `bg-orange-500` and no `bg-gray-400`; the legend loop asserts both the label and the dot class, so re-hard-coding hues while keeping `POOL_TYPES` for labels only would fail.

## Deliberately out of scope

`ui/src/pages/` still duplicates pool-type labels in five `<option>` lists — the obvious next consumer of `POOL_TYPES`, but this was a colour plan. Plans B (config primitives), C (Settings shell) and D (identity backend) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
